### PR TITLE
Stop requiring project.conf for all commands

### DIFF
--- a/src/buildstream/_frontend/app.py
+++ b/src/buildstream/_frontend/app.py
@@ -284,22 +284,23 @@ class App:
                     cli_options=self._main_options["option"],
                     default_mirror=self._main_options.get("default_mirror"),
                 )
-
-                self.stream.set_project(self.project)
             except LoadError as e:
 
-                # Help users that are new to BuildStream by suggesting 'init'.
-                # We don't want to slow down users that just made a mistake, so
-                # don't stop them with an offer to create a project for them.
-                if e.reason == LoadErrorReason.MISSING_PROJECT_CONF:
-                    click.echo("No project found. You can create a new project like so:", err=True)
-                    click.echo("", err=True)
-                    click.echo("    bst init", err=True)
-
-                self._error_exit(e, "Error loading project")
+                # If there was no project.conf at all then there was just no project found.
+                #
+                # Don't error out in this case, as Stream() supports some operations which
+                # do not require a project. If Stream() requires a project and it is missing,
+                # then it will raise an error.
+                #
+                if e.reason != LoadErrorReason.MISSING_PROJECT_CONF:
+                    self._error_exit(e, "Error loading project")
 
             except BstError as e:
                 self._error_exit(e, "Error loading project")
+
+            # Set the project on the Stream, this can be None if there is no project.
+            #
+            self.stream.set_project(self.project)
 
             # Run the body of the session here, once everything is loaded
             try:

--- a/src/buildstream/_frontend/widget.py
+++ b/src/buildstream/_frontend/widget.py
@@ -444,7 +444,7 @@ class LogLine(Widget):
     # and so on.
     #
     # Args:
-    #    toplevel_project (Project): The toplevel project we were invoked from
+    #    toplevel_project (Project): The toplevel project we were invoked from, or None
     #    stream (Stream): The stream
     #    log_file (file): An optional file handle for additional logging
     #
@@ -460,7 +460,8 @@ class LogLine(Widget):
         text += self.content_profile.fmt("BuildStream Version {}\n".format(bst_version), bold=True)
         values = OrderedDict()
         values["Session Start"] = starttime.strftime("%A, %d-%m-%Y at %H:%M:%S")
-        values["Project"] = "{} ({})".format(toplevel_project.name, toplevel_project.directory)
+        if toplevel_project:
+            values["Project"] = "{} ({})".format(toplevel_project.name, toplevel_project.directory)
         values["Targets"] = ", ".join([t.name for t in stream.targets])
         text += self._format_values(values)
 
@@ -483,7 +484,12 @@ class LogLine(Widget):
 
         # Print information about each loaded project
         #
-        for project_info in toplevel_project.loaded_projects():
+        if toplevel_project:
+            loaded_projects = toplevel_project.loaded_projects()
+        else:
+            loaded_projects = []
+
+        for project_info in loaded_projects:
             project = project_info.project
 
             # Project title line

--- a/src/buildstream/_workspaces.py
+++ b/src/buildstream/_workspaces.py
@@ -313,9 +313,15 @@ class Workspace:
 class Workspaces:
     def __init__(self, toplevel_project, workspace_project_cache):
         self._toplevel_project = toplevel_project
-        self._bst_directory = os.path.join(toplevel_project.directory, ".bst")
-        self._workspaces = self._load_config()
         self._workspace_project_cache = workspace_project_cache
+
+        # A project without a directory can happen
+        if toplevel_project.directory:
+            self._bst_directory = os.path.join(toplevel_project.directory, ".bst")
+            self._workspaces = self._load_config()
+        else:
+            self._bst_directory = None
+            self._workspaces = {}
 
     # list()
     #

--- a/tests/format/project.py
+++ b/tests/format/project.py
@@ -15,10 +15,11 @@ DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project")
 
 
 @pytest.mark.datafiles(os.path.join(DATA_DIR))
-def test_missing_project_conf(cli, datafiles):
+@pytest.mark.parametrize("args", [["workspace", "list"], ["show", "pony.bst"]], ids=["list-workspace", "show-element"])
+def test_missing_project_conf(cli, datafiles, args):
     project = str(datafiles)
-    result = cli.run(project=project, args=["workspace", "list"])
-    result.assert_main_error(ErrorDomain.LOAD, LoadErrorReason.MISSING_PROJECT_CONF)
+    result = cli.run(project=project, args=args)
+    result.assert_main_error(ErrorDomain.STREAM, "project-not-loaded")
 
 
 @pytest.mark.datafiles(os.path.join(DATA_DIR))

--- a/tests/frontend/artifact_checkout.py
+++ b/tests/frontend/artifact_checkout.py
@@ -32,7 +32,8 @@ DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project")
     ],
     ids=["none", "build", "run", "all"],
 )
-def test_checkout(cli, tmpdir, datafiles, deps, expect_exist, expect_noexist):
+@pytest.mark.parametrize("with_project", [True, False], ids=["with-project", "without-project"])
+def test_checkout(cli, tmpdir, datafiles, deps, expect_exist, expect_noexist, with_project):
     project = str(datafiles)
     checkout = os.path.join(cli.directory, "checkout")
 
@@ -55,6 +56,10 @@ def test_checkout(cli, tmpdir, datafiles, deps, expect_exist, expect_noexist):
         shutil.rmtree(str(os.path.join(str(tmpdir), "cache", "cas")))
         shutil.rmtree(str(os.path.join(str(tmpdir), "cache", "artifacts")))
         assert cli.get_element_state(project, "target-import.bst") != "cached"
+
+        # Delete the project.conf if we're going to try this without a project
+        if not with_project:
+            os.remove(os.path.join(project, "project.conf"))
 
         # Now checkout the artifact
         result = cli.run(

--- a/tests/frontend/artifact_delete.py
+++ b/tests/frontend/artifact_delete.py
@@ -50,7 +50,8 @@ def test_artifact_delete_element(cli, tmpdir, datafiles):
 
 # Test that we can delete an artifact by specifying its ref.
 @pytest.mark.datafiles(DATA_DIR)
-def test_artifact_delete_artifact(cli, tmpdir, datafiles):
+@pytest.mark.parametrize("with_project", [True, False], ids=["with-project", "without-project"])
+def test_artifact_delete_artifact(cli, tmpdir, datafiles, with_project):
     project = str(datafiles)
     element = "target.bst"
 
@@ -68,6 +69,10 @@ def test_artifact_delete_artifact(cli, tmpdir, datafiles):
 
     # Explicitly check that the ARTIFACT exists in the cache
     assert os.path.exists(os.path.join(local_cache, "artifacts", "refs", artifact))
+
+    # Delete the project.conf if we're going to try this without a project
+    if not with_project:
+        os.remove(os.path.join(project, "project.conf"))
 
     # Delete the artifact
     result = cli.run(project=project, args=["artifact", "delete", artifact])

--- a/tests/frontend/artifact_list_contents.py
+++ b/tests/frontend/artifact_list_contents.py
@@ -29,22 +29,8 @@ DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
 
 
 @pytest.mark.datafiles(DATA_DIR)
-def test_artifact_list_exact_contents_element(cli, datafiles):
-    project = str(datafiles)
-
-    # Ensure we have an artifact to read
-    result = cli.run(project=project, args=["build", "import-bin.bst"])
-    assert result.exit_code == 0
-
-    # List the contents via the element name
-    result = cli.run(project=project, args=["artifact", "list-contents", "import-bin.bst"])
-    assert result.exit_code == 0
-    expected_output = "import-bin.bst:\n\tusr\n\tusr/bin\n\tusr/bin/hello\n\n"
-    assert expected_output in result.output
-
-
-@pytest.mark.datafiles(DATA_DIR)
-def test_artifact_list_exact_contents_ref(cli, datafiles):
+@pytest.mark.parametrize("target", ["element-name", "artifact-name"])
+def test_artifact_list_exact_contents(cli, datafiles, target):
     project = str(datafiles)
 
     # Get the cache key of our test element
@@ -54,11 +40,48 @@ def test_artifact_list_exact_contents_ref(cli, datafiles):
     result = cli.run(project=project, args=["build", "import-bin.bst"])
     assert result.exit_code == 0
 
+    if target == "element-name":
+        arg = "import-bin.bst"
+    elif target == "artifact-name":
+        key = cli.get_element_key(project, "import-bin.bst")
+        arg = "test/import-bin/" + key
+
     # List the contents via the key
-    result = cli.run(project=project, args=["artifact", "list-contents", "test/import-bin/" + key])
+    result = cli.run(project=project, args=["artifact", "list-contents", arg])
     assert result.exit_code == 0
 
-    expected_output = "test/import-bin/" + key + ":\n" "\tusr\n" "\tusr/bin\n" "\tusr/bin/hello\n\n"
+    expected_output_template = "{target}:\n\tusr\n\tusr/bin\n\tusr/bin/hello\n\n"
+    expected_output = expected_output_template.format(target=arg)
+
+    assert expected_output in result.output
+
+
+@pytest.mark.datafiles(DATA_DIR)
+@pytest.mark.parametrize("target", ["element-name", "artifact-name"])
+def test_artifact_list_exact_contents_long(cli, datafiles, target):
+    project = str(datafiles)
+
+    # Ensure we have an artifact to read
+    result = cli.run(project=project, args=["build", "import-bin.bst"])
+    assert result.exit_code == 0
+
+    if target == "element-name":
+        arg = "import-bin.bst"
+    elif target == "artifact-name":
+        key = cli.get_element_key(project, "import-bin.bst")
+        arg = "test/import-bin/" + key
+
+    # List the contents via the element name
+    result = cli.run(project=project, args=["artifact", "list-contents", "--long", arg])
+    assert result.exit_code == 0
+    expected_output_template = (
+        "{target}:\n"
+        "\tdrwxr-xr-x  dir    1           usr\n"
+        "\tdrwxr-xr-x  dir    1           usr/bin\n"
+        "\t-rw-r--r--  reg    107         usr/bin/hello\n\n"
+    )
+    expected_output = expected_output_template.format(target=arg)
+
     assert expected_output in result.output
 
 
@@ -89,49 +112,3 @@ def test_artifact_list_exact_contents_glob(cli, datafiles):
 
     for artifact in expected_artifacts:
         assert artifact in result.output
-
-
-@pytest.mark.datafiles(DATA_DIR)
-def test_artifact_list_exact_contents_element_long(cli, datafiles):
-    project = str(datafiles)
-
-    # Ensure we have an artifact to read
-    result = cli.run(project=project, args=["build", "import-bin.bst"])
-    assert result.exit_code == 0
-
-    # List the contents via the element name
-    result = cli.run(project=project, args=["artifact", "list-contents", "--long", "import-bin.bst"])
-    assert result.exit_code == 0
-    expected_output = (
-        "import-bin.bst:\n"
-        "\tdrwxr-xr-x  dir    1           usr\n"
-        "\tdrwxr-xr-x  dir    1           usr/bin\n"
-        "\t-rw-r--r--  reg    107         usr/bin/hello\n\n"
-    )
-
-    assert expected_output in result.output
-
-
-@pytest.mark.datafiles(DATA_DIR)
-def test_artifact_list_exact_contents_ref_long(cli, datafiles):
-    project = str(datafiles)
-
-    # Get the cache key of our test element
-    key = cli.get_element_key(project, "import-bin.bst")
-
-    # Ensure we have an artifact to read
-    result = cli.run(project=project, args=["build", "import-bin.bst"])
-    assert result.exit_code == 0
-
-    # List the contents via the key
-    result = cli.run(project=project, args=["artifact", "list-contents", "-l", "test/import-bin/" + key])
-    assert result.exit_code == 0
-
-    expected_output = (
-        "  test/import-bin/" + key + ":\n"
-        "\tdrwxr-xr-x  dir    1           usr\n"
-        "\tdrwxr-xr-x  dir    1           usr/bin\n"
-        "\t-rw-r--r--  reg    107         usr/bin/hello\n\n"
-    )
-
-    assert expected_output in result.output

--- a/tests/frontend/artifact_show.py
+++ b/tests/frontend/artifact_show.py
@@ -88,7 +88,8 @@ def test_artifact_show_element_missing_deps(cli, tmpdir, datafiles):
 
 # Test artifact show with artifact ref
 @pytest.mark.datafiles(DATA_DIR)
-def test_artifact_show_artifact_ref(cli, tmpdir, datafiles):
+@pytest.mark.parametrize("with_project", [True, False], ids=["with-project", "without-project"])
+def test_artifact_show_artifact_name(cli, tmpdir, datafiles, with_project):
     project = str(datafiles)
     element = "target.bst"
 
@@ -97,6 +98,10 @@ def test_artifact_show_artifact_ref(cli, tmpdir, datafiles):
 
     cache_key = cli.get_element_key(project, element)
     artifact_ref = "test/target/" + cache_key
+
+    # Delete the project.conf if we're going to try this without a project
+    if not with_project:
+        os.remove(os.path.join(project, "project.conf"))
 
     result = cli.run(project=project, args=["artifact", "show", artifact_ref])
     result.assert_success()


### PR DESCRIPTION
This merge requests removes the requirement that BuildStream should be launched within a project directory, or that `-C/--directory` should be specified to indicate a project directory.

When `Stream` finds itself trying to load an `Element`, then an Error is raised if a `Project` was not loaded, but not if only `ArtifactElement`s are loaded.

Tests for the various commands which support operation on artifact names have been enhanced to also test the cases where a project is not loaded.
