### PR TITLE
Revive remote execution testing

### DIFF
--- a/.github/common.env
+++ b/.github/common.env
@@ -1,3 +1,6 @@
 # Shared common variables
 
 CI_IMAGE_VERSION=master-241289109
+CI_TOXENV_MAIN=py36,py37,py38-nocover
+CI_TOXENV_PLUGINS=py36-plugins,py37-plugins,py38-plugins-nocover
+CI_TOXENV_ALL="${CI_TOXENV_MAIN},${CI_TOXENV_PLUGINS}"

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -1,14 +1,20 @@
 version: '3.4'
 
 x-tests-template: &tests-template
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:32-${CI_IMAGE_VERSION:-latest}
     command: tox -vvvvv -- --color=yes --integration -n 4
+    environment:
+      TOXENV: ${CI_TOXENV_ALL}
+
+    # Enable privileges to run the sandbox
+    #
+    privileged: true
     devices:
       - /dev/fuse:/dev/fuse
-    environment:
-      BST_PLUGINS_EXPERIMENTAL_VERSION: 1.93.4
-      TOXENV: py36,py37,py38-nocover,py36-plugins,py37-plugins,py38-plugins-nocover
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:32-${CI_IMAGE_VERSION:-latest}
-    privileged: true
+
+    # Mount the local directory and set the working directory
+    # to run the tests from.
+    #
     volumes:
       - ../..:/home/testuser/buildstream
     working_dir: /home/testuser/buildstream

--- a/.github/compose/ci.remote-execution-cluster.yml
+++ b/.github/compose/ci.remote-execution-cluster.yml
@@ -1,0 +1,67 @@
+##
+# BuildGrid Compose manifest for BuildStream.
+#
+# Spins-up a unnamed and unauthenticated grid:
+#  - Controller + CAS + AC at http://localhost:50051
+#  - Ref. + CAS at: http://localhost:50052
+#
+# BuildStream configuration snippet:
+#
+#    artifacts:
+#      url: http://localhost:50052
+#      push: true
+#    remote-execution:
+#      execution-service:
+#        url: http://localhost:50051
+#      action-cache-service:
+#        url: http://localhost:50051
+#      storage-service:
+#        url: http://localhost:50051
+#
+# Basic usage:
+#  - docker-compose -f buildgrid-compose.yml up
+#  - docker-compose -f buildgrid-compose.yml down
+#
+version: "3.2"
+
+services:
+  controller:
+    image: registry.gitlab.com/buildgrid/buildgrid.hub.docker.com/buildgrid:nightly
+    command: [
+      "bgd", "server", "start", "-v",
+      "/etc/buildgrid/default.conf"]
+    ports:
+      - 50051:50051
+    networks:
+      - grid
+
+  bot:
+    image: registry.gitlab.com/buildgrid/buildgrid.hub.docker.com/buildbox:nightly
+    command: [
+      "sh", "-c", "sleep 15 && ( buildbox-casd --cas-remote=http://controller:50051 /var/lib/buildgrid/cache & buildbox-worker --request-timeout=30 --bots-remote=http://controller:50051 --cas-remote=unix:/var/lib/buildgrid/cache/casd.sock --buildbox-run=buildbox-run-bubblewrap --runner-arg=--use-localcas --platform OSFamily=linux --platform ISA=x86-64 --verbose )"]
+    privileged: true
+    volumes:
+      - type: volume
+        source: cache
+        target: /var/lib/buildgrid/cache
+    depends_on:
+      - controller
+    networks:
+      - grid
+
+  storage:
+    image: registry.gitlab.com/buildgrid/buildgrid.hub.docker.com/buildgrid:nightly
+    command: [
+      "bgd", "server", "start", "-v",
+      "/etc/buildgrid/artifacts.conf"]
+    ports:
+      - 50052:50052
+    networks:
+      - grid
+
+networks:
+  grid:
+    driver: bridge
+
+volumes:
+  cache:

--- a/.github/compose/ci.remote-execution-test.yml
+++ b/.github/compose/ci.remote-execution-test.yml
@@ -1,0 +1,36 @@
+version: '3.4'
+
+services:
+
+  test:
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:32-${CI_IMAGE_VERSION:-latest}
+    command: tox -vvvvv -- --color=yes --remote-execution
+    environment:
+      TOXENV: ${CI_TOXENV_MAIN}
+      ARTIFACT_CACHE_SERVICE: http://localhost:50052
+      REMOTE_EXECUTION_SERVICE: http://localhost:50051
+      SOURCE_CACHE_SERVICE: http://localhost:50052
+
+    # Some of the remote execution tests still require running a local sandbox
+    # to run `bst shell` on some build results even though they were built
+    # remotely, so we need to enable priviledged mode for this container as well.
+    #
+    privileged: true
+    devices:
+      - /dev/fuse:/dev/fuse
+
+    # Mount the local directory and set the working directory
+    # to run the tests from.
+    #
+    volumes:
+      - ../..:/home/testuser/buildstream
+    working_dir: /home/testuser/buildstream
+
+    # The ci.remote-execution-cluster.yml takes care of bringing up
+    # a remote execution cluster, exposing the ports 50052 and 50051
+    # on the localhost network.
+    #
+    # We need to use host networking mode in order to be able to
+    # properly resolve these services.
+    #
+    network_mode: host

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,43 @@ jobs:
             run \
             ${{ matrix.test-name }}
 
+  remote-execution:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        # BuildStream requires tags to be able to find its version.
+        with:
+          fetch-depth: 0
+
+      - name: Give `testuser` ownership of the source directory
+        run: sudo chown -R 1000:1000 ${GITHUB_WORKSPACE}
+
+      - name: Bring up the RE cluster
+        run: |
+          docker-compose \
+            --env-file ${GITHUB_WORKSPACE}/.github/common.env \
+            --file ${GITHUB_WORKSPACE}/.github/compose/ci.remote-execution-cluster.yml \
+            up --detach --renew-anon-volumes --remove-orphans
+
+      - name: Run the remote execution tests
+        run: |
+          docker-compose \
+            --env-file ${GITHUB_WORKSPACE}/.github/common.env \
+            --file ${GITHUB_WORKSPACE}/.github/compose/ci.remote-execution-test.yml run test
+
+      - name: Bring down the RE cluster
+        run: |
+          docker-compose \
+            --env-file ${GITHUB_WORKSPACE}/.github/common.env \
+            --file ${GITHUB_WORKSPACE}/.github/compose/ci.remote-execution-cluster.yml stop
+          docker-compose \
+            --env-file ${GITHUB_WORKSPACE}/.github/common.env \
+            --file ${GITHUB_WORKSPACE}/.github/compose/ci.remote-execution-cluster.yml logs
+          docker-compose \
+            --env-file ${GITHUB_WORKSPACE}/.github/common.env \
+            --file ${GITHUB_WORKSPACE}/.github/compose/ci.remote-execution-cluster.yml down
+
   docs:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
This does the following:

* .github/compose/ci.remote-execution-cluster.yml

  Added this remote execution cluster definition based on the
  one we were using in gitlab.

  This will bring up an action cache, execution service and storage
  service which can be accessed from outside of the docker on ports
  50051 and 50052.

* .github/compose/ci.remote-execution-test.yml

  Added this composition which will use host networking more to run the
  remote execution tests adjacent to the cluster, without requiring
  docker-in-docker.

* .github/workflows/ci.yml

  Added the `remote-execution` job to the main CI, this will
  bring up the cluster, run the tests, and then fetch logs from
  the cluster and bring down the cluster.
