### PR TITLE
.github: Add fedora 33 to CI suite

### DIFF
--- a/.github/common.env
+++ b/.github/common.env
@@ -1,6 +1,6 @@
 # Shared common variables
 
 CI_IMAGE_VERSION=master-241289109
-CI_TOXENV_MAIN=py36,py37,py38-nocover
-CI_TOXENV_PLUGINS=py36-plugins,py37-plugins,py38-plugins-nocover
+CI_TOXENV_MAIN=py36,py37,py38-nocover,py39-nocover
+CI_TOXENV_PLUGINS=py36-plugins,py37-plugins,py38-plugins-nocover,py39-plugins-nocover
 CI_TOXENV_ALL="${CI_TOXENV_MAIN},${CI_TOXENV_PLUGINS}"

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -29,6 +29,10 @@ services:
   fedora-32:
     <<: *tests-template
 
+  fedora-33:
+    <<: *tests-template
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:33-${CI_IMAGE_VERSION:-latest}
+
   debian-10:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-debian:10-${CI_IMAGE_VERSION:-latest}

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -22,10 +22,6 @@ x-tests-template: &tests-template
 
 services:
 
-  fedora-31:
-    <<: *tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:31-${CI_IMAGE_VERSION:-latest}
-
   fedora-32:
     <<: *tests-template
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
         # "../compose/ci.docker-compose.yml"
         test-name:
           - debian-10
-          - fedora-31
           - fedora-32
           - fedora-33
           - ubuntu-18.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
           - debian-10
           - fedora-31
           - fedora-32
+          - fedora-33
           - ubuntu-18.04
           - centos-7.7.1908
           - fedora-missing-deps


### PR DESCRIPTION
Fedora 33 is the current latest stable release.

---

The CI failure on the centos branch seems unrelaed to the change.