### PR TITLE
element: batch integration command when running a shell

### DIFF
--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -1454,7 +1454,7 @@ class Element(Plugin):
                 # Run any integration commands provided by the dependencies
                 # once they are all staged and ready
                 if integrate:
-                    with self.timed_activity("Integrating sandbox"):
+                    with self.timed_activity("Integrating sandbox"), sandbox.batch(SandboxFlags.NONE):
                         for dep in self._dependencies(scope):
                             dep.integrate(sandbox)
 


### PR DESCRIPTION
There is currently a huge overhead for for starting a buildbox-run
sandbox, we don't have to incur that overhead multiple times.