### PR TITLE
Create a dummy sandbox when the sandbox config can't be satisfied

### DIFF
--- a/src/buildstream/_platform/platform.py
+++ b/src/buildstream/_platform/platform.py
@@ -161,42 +161,27 @@ class Platform:
     def create_sandbox(self, *args, **kwargs):  # pylint: disable=method-hidden
         raise ImplError("Platform {platform} does not implement create_sandbox()".format(platform=type(self).__name__))
 
-    def check_sandbox_config(self, config):  # pylint: disable=method-hidden
-        raise ImplError(
-            "Platform {platform} does not implement check_sandbox_config()".format(platform=type(self).__name__)
-        )
-
     # Buildbox run sandbox methods
-    def _check_sandbox_config_buildboxrun(self, config):
-        from ..sandbox._sandboxbuildboxrun import SandboxBuildBoxRun  # pylint: disable=cyclic-import
-
-        SandboxBuildBoxRun.check_sandbox_config(self, config)
-
     @staticmethod
     def _create_buildboxrun_sandbox(*args, **kwargs):
         from ..sandbox._sandboxbuildboxrun import SandboxBuildBoxRun  # pylint: disable=cyclic-import
 
+        SandboxBuildBoxRun.check_sandbox_config(kwargs['config'])
         return SandboxBuildBoxRun(*args, **kwargs)
 
     def _setup_buildboxrun_sandbox(self):
         from ..sandbox._sandboxbuildboxrun import SandboxBuildBoxRun  # pylint: disable=cyclic-import
 
         self._check_sandbox(SandboxBuildBoxRun)
-        self.check_sandbox_config = self._check_sandbox_config_buildboxrun
         self.create_sandbox = self._create_buildboxrun_sandbox
         return True
 
     # Dummy sandbox methods
-    @staticmethod
-    def _check_dummy_sandbox_config(config):
-        pass
-
     def _create_dummy_sandbox(self, *args, **kwargs):
         dummy_reasons = " and ".join(self.dummy_reasons)
         kwargs["dummy_reason"] = dummy_reasons
         return SandboxDummy(*args, **kwargs)
 
     def _setup_dummy_sandbox(self):
-        self.check_sandbox_config = Platform._check_dummy_sandbox_config
         self.create_sandbox = self._create_dummy_sandbox
         return True

--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -2707,7 +2707,6 @@ class Element(Plugin):
 
         elif directory is not None and os.path.exists(directory):
             platform = context.platform
-            platform.check_sandbox_config(config)
 
             sandbox = platform.create_sandbox(
                 context,

--- a/src/buildstream/sandbox/_sandboxbuildboxrun.py
+++ b/src/buildstream/sandbox/_sandboxbuildboxrun.py
@@ -69,7 +69,7 @@ class SandboxBuildBoxRun(SandboxREAPI):
             cls._isas.add(Platform.get_host_arch())
 
     @classmethod
-    def check_sandbox_config(cls, platform, config):
+    def check_sandbox_config(cls, config):
         if config.build_os not in cls._osfamilies:
             raise SandboxError("OS '{}' is not supported by buildbox-run.".format(config.build_os))
         if config.build_arch not in cls._isas:


### PR DESCRIPTION
Instead of an error, a dummy sandbox can be used for checking out an
artifact for a different OS/arch if integration commands don't need to
be run.

Should fix #1352 (not tested yet)