### PR TITLE
_context.py: make directories in the configuration absolute

### DIFF
--- a/src/buildstream/_context.py
+++ b/src/buildstream/_context.py
@@ -282,6 +282,7 @@ class Context:
             path = os.path.expanduser(path)
             path = os.path.expandvars(path)
             path = os.path.normpath(path)
+            path = os.path.abspath(path)
             setattr(self, directory, path)
 
             # Relative paths don't make sense in user configuration. The exception is


### PR DESCRIPTION
bst doesn't check that the paths set are absolute and sometimes breaks if
they aren't