### PR TITLE
_context.py: make directories in the configuration absolute

### DIFF
--- a/buildstream/_context.py
+++ b/buildstream/_context.py
@@ -179,6 +179,7 @@ class Context():
             path = os.path.expanduser(path)
             path = os.path.expandvars(path)
             path = os.path.normpath(path)
+            path = os.path.abspath(path)
             setattr(self, directory, path)
 
         # Load quota configuration


### PR DESCRIPTION
bst doesn't check that the paths set are absolute and sometimes breaks if
they aren't

bst 1 backport of #1440