### PR TITLE
.github/compose/ci.remote-execution.yml: Fix tests

### DIFF
--- a/.github/compose/ci.remote-execution.yml
+++ b/.github/compose/ci.remote-execution.yml
@@ -29,7 +29,7 @@ services:
     image: registry.gitlab.com/buildgrid/buildgrid.hub.docker.com/buildgrid:nightly
     command: [
       "bgd", "server", "start", "-v",
-      "/etc/buildgrid/default.conf"]
+      "/etc/buildgrid/default.yml"]
     ports:
       - 50051:50051
     networks:
@@ -53,7 +53,7 @@ services:
     image: registry.gitlab.com/buildgrid/buildgrid.hub.docker.com/buildgrid:nightly
     command: [
       "bgd", "server", "start", "-v",
-      "/etc/buildgrid/artifacts.conf"]
+      "/etc/buildgrid/artifacts.yml"]
     ports:
       - 50052:50052
     networks:


### PR DESCRIPTION
It appears that BuildGrid has introduced a semi breaking change, which is
that it has renamed the config files it installs from ".conf" to ".yml".

This means we needed to update our `bgd` invocations to specify the
new config file names.

This change fixes the remote execution tests.