### PR TITLE
Add `--except` option to `bst source push`

### DIFF
--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -828,6 +828,13 @@ def source_fetch(app, elements, deps, except_, source_remotes, ignore_project_so
 ##################################################################
 @source.command(name="push", short_help="Push sources in a pipeline")
 @click.option(
+    "--except",
+    "except_",
+    multiple=True,
+    type=click.Path(readable=False),
+    help="Except certain dependencies from pushing",
+)
+@click.option(
     "--deps",
     "-d",
     default=_PipelineSelection.NONE,
@@ -856,7 +863,7 @@ def source_fetch(app, elements, deps, except_, source_remotes, ignore_project_so
 )
 @click.argument("elements", nargs=-1, type=click.Path(readable=False))
 @click.pass_obj
-def source_push(app, elements, deps, source_remotes, ignore_project_source_remotes):
+def source_push(app, elements, deps, except_, source_remotes, ignore_project_source_remotes):
     """Push sources required to build the pipeline
 
     Specifying no elements will result in pushing the sources of the default
@@ -882,6 +889,7 @@ def source_push(app, elements, deps, source_remotes, ignore_project_source_remot
         app.stream.source_push(
             elements,
             selection=deps,
+            except_targets=except_,
             source_remotes=source_remotes,
             ignore_project_source_remotes=ignore_project_source_remotes,
         )

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -434,6 +434,7 @@ class Stream:
     # Args:
     #    targets (list of str): Targets to push
     #    selection (_PipelineSelection): The selection mode for the specified targets
+    #    except_targets: Specified targets to except from pushing
     #    source_remotes: Source cache remotes specified on the commmand line
     #    ignore_project_source_remotes: Whether to ignore source remotes specified by projects
     #
@@ -449,6 +450,7 @@ class Stream:
         targets,
         *,
         selection=_PipelineSelection.NONE,
+        except_targets: Iterable[str] = (),
         source_remotes: Iterable[RemoteSpec] = (),
         ignore_project_source_remotes: bool = False,
     ):
@@ -456,6 +458,7 @@ class Stream:
         elements = self._load(
             targets,
             selection=selection,
+            except_targets=except_targets,
             load_artifacts=True,
             connect_source_cache=True,
             source_remotes=source_remotes,


### PR DESCRIPTION
This is for consistency of `--except` options as outlined in issue #1349
