### PR TITLE
_context.py: Ensure paths in user configuration are absolute

### DIFF
--- a/buildstream/_context.py
+++ b/buildstream/_context.py
@@ -181,6 +181,12 @@ class Context():
             path = os.path.normpath(path)
             setattr(self, directory, path)
 
+            # Relative paths don't make sense in user configuration. The exception is
+            # workspacedir where `.` is useful as it will be combined with the name
+            # specified on the command line.
+            if not os.path.isabs(path) and not (directory == 'workspacedir' and path == '.'):
+                raise LoadError("{} must be an absolute path".format(directory), LoadErrorReason.INVALID_DATA)
+
         # Load quota configuration
         # We need to find the first existing directory in the path of
         # our artifactdir - the artifactdir may not have been created


### PR DESCRIPTION
Relative paths don't make sense in user configuration. The exception is
workspacedir where `.` is useful as it will be combined with the name
specified on the command line.

Backport of f2c3f8eb0db188caac6991632c4453c39b42e84c (part of [!1566](https://gitlab.com/BuildStream/buildstream/-/merge_requests/1566))