### PR TITLE
Remove requirement of running private global fixtures

### DIFF
--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -51,7 +51,8 @@ from ._remotespec import RemoteSpec
 from ._state import State
 from .types import _KeyStrength, _PipelineSelection, _Scope, _HostMount
 from .plugin import Plugin
-from . import utils, _yaml, _site, _pipeline
+from . import utils, node, _yaml, _site, _pipeline
+from .downloadablefilesource import DownloadableFileSource
 
 
 # Stream()
@@ -114,6 +115,16 @@ class Stream:
     def cleanup(self):
         # Reset the element loader state
         Element._reset_load_state()
+
+        # Reset global state in node.pyx, this is for the sake of
+        # test isolation.
+        node._reset_global_state()
+
+        # Ensure that any global state loaded by the downloadablefilesource
+        # is discarded in between sessions (different invocations of the CLI
+        # may come with different local state such as .netrc files, so we need
+        # a reset here).
+        DownloadableFileSource._reset_url_opener()
 
     # set_project()
     #

--- a/src/buildstream/testing/_fixtures.py
+++ b/src/buildstream/testing/_fixtures.py
@@ -21,8 +21,6 @@ import time
 import psutil
 import pytest
 
-from buildstream import node, DownloadableFileSource
-
 
 # Number of seconds to wait for background threads to exit.
 _AWAIT_THREADS_TIMEOUT_SECONDS = 5
@@ -54,10 +52,3 @@ def thread_check(default_thread_number):
     assert has_no_unexpected_background_threads(default_thread_number)
     yield
     assert has_no_unexpected_background_threads(default_thread_number)
-
-
-# Reset global state in node.pyx to improve test isolation
-@pytest.fixture(autouse=True)
-def reset_global_node_state():
-    node._reset_global_state()
-    DownloadableFileSource._reset_url_opener()

--- a/src/buildstream/testing/_sourcetests/conftest.py
+++ b/src/buildstream/testing/_sourcetests/conftest.py
@@ -14,4 +14,4 @@
 #  You should have received a copy of the GNU Lesser General Public
 #  License along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-from .._fixtures import reset_global_node_state, default_thread_number, thread_check  # pylint: disable=unused-import
+from .._fixtures import default_thread_number, thread_check  # pylint: disable=unused-import

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,6 @@ import pytest
 from buildstream.testing import register_repo_kind, sourcetests_collection_hook
 from buildstream.testing._fixtures import (  # pylint: disable=unused-import
     default_thread_number,
-    reset_global_node_state,
     thread_check,
 )
 from buildstream.testing.integration import integration_cache  # pylint: disable=unused-import

--- a/tests/sourcecache/fetch.py
+++ b/tests/sourcecache/fetch.py
@@ -151,6 +151,9 @@ def test_fetch_fallback(cli, tmpdir, datafiles):
             assert ("SUCCESS Fetching from {}".format(repo.source_config(ref=ref)["url"])) in res.stderr
 
             # Check that the source in both in the source dir and the local CAS
+            project = Project(project_dir, context)
+            project.ensure_fully_loaded()
+
             element = project.load_elements([element_name])[0]
             element._query_source_cache()
             assert element._cached_sources()


### PR DESCRIPTION
Some of the special global fixtures in the private
`buildstream.testing._fixtures` module are required to run even
in tests declared in external plugin repositories, this is especially
true ever since the scheduler was made to be threaded, and the loaded
netrc data is no longer local to the process which uses it.

Since then, we've added 0360bc1feca1d5429cdb7fbc083727d242499733
which explicitly resets more state in the DownloadableFileSource, tests
in external plugin repos which derive this source will fail without having
this state reset between BuildStream invocations.

This patch changes things such that the internal node state and internal
DownloadableFileSource state is reset unconditionally between BuildStream
invocations, so that it is not necessary for external repos to concern
themselves with cherry picking these functions in any conftest.py they
might use.

The test `tests/sourcecache/fetch.py::test_fetch_fallback` needed to be fixed
in this case, as it is using under the hood nonsense to test, which relies on
state being persisted where this cannot and should not be guaranteed.