### PR TITLE
Query sources of cached elements in build pipeline with source push enabled

### DIFF
--- a/src/buildstream/_scheduler/queues/pullqueue.py
+++ b/src/buildstream/_scheduler/queues/pullqueue.py
@@ -21,6 +21,7 @@
 # Local imports
 from . import Queue, QueueStatus
 from ..resources import ResourceType
+from ..jobs import JobStatus
 from ..._exceptions import SkipJob
 
 
@@ -42,6 +43,10 @@ class PullQueue(Queue):
             return QueueStatus.SKIP
 
     def done(self, _, element, result, status):
+
+        if status is JobStatus.FAIL:
+            return
+
         element._load_artifact_done()
 
     @staticmethod

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -195,9 +195,9 @@ class Stream:
     #
     # Args:
     #    elements (list of Element): The elements to check
-    #    sources (bool): True to only query the source cache
+    #    only_sources (bool): True to only query the source cache
     #
-    def query_cache(self, elements, *, sources=False):
+    def query_cache(self, elements, *, only_sources=False):
         with self._context.messenger.timed_activity("Query cache", silent_nested=True):
             # Enqueue complete build plan as this is required to determine `buildable` status.
             plan = list(_pipeline.dependencies(elements, _Scope.ALL))
@@ -208,7 +208,7 @@ class Stream:
                     # This is the case for artifact elements, which load the
                     # artifact early on.
                     pass
-                elif not sources and element._get_cache_key(strength=_KeyStrength.WEAK):
+                elif not only_sources and element._get_cache_key(strength=_KeyStrength.WEAK):
                     element._load_artifact(pull=False)
                     if not element._can_query_cache() or not element._cached_success():
                         element._query_source_cache()
@@ -322,7 +322,7 @@ class Stream:
 
         # Ensure we have our sources if we are launching a build shell
         if scope == _Scope.BUILD and not usebuildtree:
-            self.query_cache([element], sources=True)
+            self.query_cache([element], only_sources=True)
             self._fetch([element])
             _pipeline.assert_sources_cached(self._context, [element])
 
@@ -438,7 +438,7 @@ class Stream:
             ignore_project_source_remotes=ignore_project_source_remotes,
         )
 
-        self.query_cache(elements, sources=True)
+        self.query_cache(elements, only_sources=True)
 
         # Delegated to a shared fetch method
         self._fetch(elements, announce_session=True)
@@ -512,7 +512,7 @@ class Stream:
             ignore_project_source_remotes=ignore_project_source_remotes,
         )
 
-        self.query_cache(elements, sources=True)
+        self.query_cache(elements, only_sources=True)
 
         if not self._sourcecache.has_push_remotes():
             raise StreamError("No source caches available for pushing sources")
@@ -897,7 +897,7 @@ class Stream:
         )
 
         # Assert all sources are cached in the source dir
-        self.query_cache(elements, sources=True)
+        self.query_cache(elements, only_sources=True)
         self._fetch(elements)
         _pipeline.assert_sources_cached(self._context, elements)
 
@@ -948,7 +948,7 @@ class Stream:
         # If we're going to checkout, we need at least a fetch,
         #
         if not no_checkout:
-            self.query_cache(elements, sources=True)
+            self.query_cache(elements, only_sources=True)
             self._fetch(elements, fetch_original=True)
 
         expanded_directories = []

--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -1596,9 +1596,7 @@ class Element(Plugin):
     def __should_schedule(self):
         # We're processing if we're already scheduled, we've
         # finished assembling or if we're waiting to pull.
-        processing = (
-            self.__assemble_scheduled or self.__assemble_done or (self._can_query_cache() and self._pull_pending())
-        )
+        processing = self.__assemble_scheduled or self.__assemble_done or self._pull_pending()
 
         # We should schedule a build when
         return (


### PR DESCRIPTION
The source cache status of all elements is required if source push is enabled, independent of whether the artifact is already available.

Fixes #1456.

Fixes: 2003805e ("Move artifact and source cache query trigger to...")