### PR TITLE
CI improvements

### DIFF
--- a/.github/compose/ci.bst-artifact-server.yml
+++ b/.github/compose/ci.bst-artifact-server.yml
@@ -11,8 +11,8 @@
 #      push: true
 #
 # Basic usage:
-#  - docker-compose -f ci.buildstream-remote-cache.yml up
-#  - docker-compose -f ci.buildstream-remote-cache.yml down
+#  - docker-compose -f ci.bst-artifact-server.yml up
+#  - docker-compose -f ci.bst-artifact-server.yml down
 #
 version: "3.2"
 

--- a/.github/compose/ci.buildbarn.yml
+++ b/.github/compose/ci.buildbarn.yml
@@ -16,8 +16,8 @@
 #     push: true
 #
 # Basic usage:
-#  - docker-compose -f ci.buildbarn-remote-cache.yml up
-#  - docker-compose -f ci.buildbarn-remote-cache.yml down
+#  - docker-compose -f ci.buildbarn.yml up
+#  - docker-compose -f ci.buildbarn.yml down
 
 version: '3.4'
 

--- a/.github/compose/ci.buildgrid.yml
+++ b/.github/compose/ci.buildgrid.yml
@@ -19,8 +19,8 @@
 #        url: http://localhost:50051
 #
 # Basic usage:
-#  - docker-compose -f ci.remote-execution.yml up
-#  - docker-compose -f ci.remote-execution.yml down
+#  - docker-compose -f ci.buildgrid.yml up
+#  - docker-compose -f ci.buildgrid.yml down
 #
 version: "3.2"
 

--- a/.github/compose/ci.buildstream-remote-cache.yml
+++ b/.github/compose/ci.buildstream-remote-cache.yml
@@ -19,8 +19,9 @@ version: "3.2"
 services:
   controller:
     image: buildstream/buildstream:dev
-    command: ["bst-artifact-server","--port",
-      "50052",
+    command: ["bst-artifact-server",
+      "--log-level", "warning",
+      "--port", "50052",
       "--enable-push",
       "/artifacts"
     ]

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -58,7 +58,7 @@ services:
     environment:
       BST_PLUGINS_EXPERIMENTAL_VERSION: master
 
-  remote-execution:
+  buildgrid:
     <<: *tests-template
     command: tox -vvvvv -- --color=yes --remote-execution
     environment:
@@ -72,7 +72,7 @@ services:
     #
     network_mode: host
 
-  buildstream-remote-cache:
+  bst-artifact-server:
     <<: *tests-template
     command: tox -vvvvv -- --color=yes --remote-cache
     environment:
@@ -84,7 +84,7 @@ services:
     #
     network_mode: host
 
-  buildbarn-remote-cache:
+  buildbarn:
     <<: *tests-template
     command: tox -vvvvv -- --color=yes --remote-cache
     environment:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,9 @@ jobs:
         # and they also map to corresponding filenames of services which are expected
         # to be run in the background
         test-name:
-          - remote-execution
-          - buildstream-remote-cache
-          - buildbarn-remote-cache
+          - bst-artifact-server
+          - buildbarn
+          - buildgrid
 
     steps:
       - name: Check out repository

--- a/src/buildstream/_artifactelement.py
+++ b/src/buildstream/_artifactelement.py
@@ -24,7 +24,6 @@ from contextlib import suppress
 
 from . import Element
 from . import _cachekey
-from ._artifact import Artifact
 from ._artifactproject import ArtifactProject
 from ._exceptions import ArtifactElementError
 from ._loader import LoadElement

--- a/src/buildstream/_assetcache.py
+++ b/src/buildstream/_assetcache.py
@@ -22,7 +22,6 @@ from typing import List, Dict, Tuple, Iterable, Optional
 import grpc
 
 from . import utils
-from .node import MappingNode
 from ._cas import CASRemote, CASCache
 from ._exceptions import AssetCacheError, RemoteError
 from ._remotespec import RemoteSpec, RemoteType

--- a/src/buildstream/_cas/casserver.py
+++ b/src/buildstream/_cas/casserver.py
@@ -75,6 +75,9 @@ class LogLevel(click.Choice):
         super().__init__([m.lower() for m in LogLevel.Levels._member_names_])  # pylint: disable=no-member
 
     def convert(self, value, param, ctx) -> "LogLevel.Levels":
+        if isinstance(value, LogLevel.Levels):
+            value = value.value
+
         return LogLevel.Levels(super().convert(value, param, ctx))
 
     @classmethod


### PR DESCRIPTION
- Fix bst-artifact-server incompatibility with Click 8.0

    The buildstream Docker images now include Click 8.0, which breaks the `--log-level` default value of bst-artifact-server. This branch fixes the incompatibility and adds a temporary workaround to get CI to pass until the Docker image is rebuilt with the fix.

- .github: Rename remote service tests in CI

    There is one CI job for each remote service, which should run all applicable tests against that particular service. Consistently use the name of the remote service as CI job name to clarify this and prepare for additional tests.
