### PR TITLE
_sandboxbuildboxrun.py: Drop --use-localcas

### DIFF
--- a/.github/compose/ci.buildgrid.yml
+++ b/.github/compose/ci.buildgrid.yml
@@ -38,7 +38,7 @@ services:
   bot:
     image: registry.gitlab.com/buildgrid/buildgrid.hub.docker.com/buildbox:nightly
     command: [
-      "sh", "-c", "sleep 15 && ( buildbox-casd --cas-remote=http://controller:50051 /var/lib/buildgrid/cache & buildbox-worker --request-timeout=30 --bots-remote=http://controller:50051 --cas-remote=unix:/var/lib/buildgrid/cache/casd.sock --buildbox-run=buildbox-run-bubblewrap --runner-arg=--use-localcas --platform OSFamily=linux --platform ISA=x86-64 --verbose )"]
+      "sh", "-c", "sleep 15 && ( buildbox-casd --cas-remote=http://controller:50051 /var/lib/buildgrid/cache & buildbox-worker --request-timeout=30 --bots-remote=http://controller:50051 --cas-remote=unix:/var/lib/buildgrid/cache/casd.sock --buildbox-run=buildbox-run-bubblewrap --platform OSFamily=linux --platform ISA=x86-64 --verbose )"]
     privileged: true
     volumes:
       - type: volume

--- a/src/buildstream/sandbox/_sandboxbuildboxrun.py
+++ b/src/buildstream/sandbox/_sandboxbuildboxrun.py
@@ -94,7 +94,6 @@ class SandboxBuildBoxRun(SandboxREAPI):
 
             buildbox_command = [
                 utils.get_host_tool("buildbox-run"),
-                "--use-localcas",
                 "--remote={}".format(casd_process_manager._connection_string),
                 "--action={}".format(action_file.name),
                 "--action-result={}".format(result_file.name),


### PR DESCRIPTION
This option is not needed and has been deprecated in BuildBox upstream for a year and will be removed.

See https://gitlab.com/BuildGrid/buildbox/buildbox-common/-/merge_requests/394