### PR TITLE
bst-1: Use collections.abc instead collections

### DIFF
--- a/buildstream/_artifactcache/artifactcache.py
+++ b/buildstream/_artifactcache/artifactcache.py
@@ -21,7 +21,8 @@ import multiprocessing
 import os
 import signal
 import string
-from collections import Mapping, namedtuple
+from collections import namedtuple
+from collections.abc import Mapping
 
 from ..types import _KeyStrength
 from .._exceptions import ArtifactError, CASError, LoadError, LoadErrorReason

--- a/buildstream/_context.py
+++ b/buildstream/_context.py
@@ -19,7 +19,8 @@
 
 import os
 import datetime
-from collections import deque, Mapping
+from collections import deque
+from collections.abc import Mapping
 from contextlib import contextmanager
 from . import utils
 from . import _cachekey

--- a/buildstream/_includes.py
+++ b/buildstream/_includes.py
@@ -1,5 +1,5 @@
 import os
-from collections import Mapping
+from collections.abc import Mapping
 from . import _yaml
 from ._exceptions import LoadError, LoadErrorReason
 

--- a/buildstream/_loader/loader.py
+++ b/buildstream/_loader/loader.py
@@ -19,7 +19,8 @@
 
 import os
 from functools import cmp_to_key
-from collections import Mapping, namedtuple
+from collections import namedtuple
+from collections.abc import Mapping
 import tempfile
 import shutil
 

--- a/buildstream/_options/optionpool.py
+++ b/buildstream/_options/optionpool.py
@@ -18,7 +18,7 @@
 #        Tristan Van Berkom <tristan.vanberkom@codethink.co.uk>
 #
 
-from collections import Mapping
+from collections.abc import Mapping
 import jinja2
 
 from .. import _yaml

--- a/buildstream/_project.py
+++ b/buildstream/_project.py
@@ -19,7 +19,8 @@
 #        Tiago Gomes <tiago.gomes@codethink.co.uk>
 
 import os
-from collections import Mapping, OrderedDict
+from collections import OrderedDict
+from collections.abc import Mapping
 from pluginbase import PluginBase
 from . import utils
 from . import _cachekey

--- a/buildstream/element.py
+++ b/buildstream/element.py
@@ -76,7 +76,8 @@ import os
 import re
 import stat
 import copy
-from collections import Mapping, OrderedDict
+from collections import OrderedDict
+from collections.abc import Mapping
 from contextlib import contextmanager
 from enum import Enum
 import tempfile

--- a/buildstream/plugins/elements/junction.py
+++ b/buildstream/plugins/elements/junction.py
@@ -126,7 +126,7 @@ the user to resolve possibly conflicting nested junctions by creating a junction
 with the same name in the top-level project, which then takes precedence.
 """
 
-from collections import Mapping
+from collections.abc import Mapping
 from buildstream import Element
 from buildstream._pipeline import PipelineError
 

--- a/buildstream/plugins/sources/git.py
+++ b/buildstream/plugins/sources/git.py
@@ -104,7 +104,7 @@ This plugin also utilises the following configurable :class:`core warnings <buil
 import os
 import errno
 import re
-from collections import Mapping
+from collections.abc import Mapping
 from io import StringIO
 
 from configparser import RawConfigParser

--- a/buildstream/source.py
+++ b/buildstream/source.py
@@ -147,7 +147,7 @@ Class Reference
 """
 
 import os
-from collections import Mapping
+from collections.abc import Mapping
 from contextlib import contextmanager
 
 from . import Plugin

--- a/tests/yaml/yaml.py
+++ b/tests/yaml/yaml.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from collections import Mapping
+from collections.abc import Mapping
 
 from buildstream import _yaml
 from buildstream._exceptions import LoadError, LoadErrorReason


### PR DESCRIPTION
Collections Abstract Base Classes has been moved to the collections.abc module. They were deprecated since version 3.3, will be removed from the old location in version 3.10

See https://docs.python.org/3/library/collections.html#module-collections

Fixes #1483 