### PR TITLE
WIP: Use collections.abc instead collections

### DIFF
--- a/contrib/update_committers.py
+++ b/contrib/update_committers.py
@@ -9,7 +9,7 @@ import json
 import urllib.request
 import urllib.parse
 from jinja2 import Environment, FileSystemLoader
-from collections import OrderedDict
+from collections.abc import OrderedDict
 
 GIT_ERROR = 1
 MERGE_REQUEST = 'https://gitlab.com/api/v4/projects/1975139/merge_requests'

--- a/src/buildstream/_frontend/status.py
+++ b/src/buildstream/_frontend/status.py
@@ -19,7 +19,7 @@
 import os
 import sys
 import curses
-from collections import OrderedDict
+from collections.abc import OrderedDict
 import click
 
 # Import a widget internal for formatting time codes

--- a/src/buildstream/_frontend/widget.py
+++ b/src/buildstream/_frontend/widget.py
@@ -18,7 +18,7 @@
 #        Tristan Van Berkom <tristan.vanberkom@codethink.co.uk>
 import datetime
 import os
-from collections import defaultdict, OrderedDict
+from collections.abc import defaultdict, OrderedDict
 from contextlib import ExitStack
 from mmap import mmap
 import re

--- a/src/buildstream/_pipeline.py
+++ b/src/buildstream/_pipeline.py
@@ -21,7 +21,7 @@
 
 import itertools
 
-from collections import OrderedDict
+from collections.abc import OrderedDict
 from operator import itemgetter
 from typing import List, Iterator
 from pyroaring import BitMap  # pylint: disable=no-name-in-module

--- a/src/buildstream/_project.py
+++ b/src/buildstream/_project.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Optional, Dict, Union, List
 
 import os
 import sys
-from collections import OrderedDict
+from collections.abc import OrderedDict
 from pathlib import Path
 from pluginbase import PluginBase
 from . import utils

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -28,7 +28,7 @@ import shutil
 import tarfile
 import tempfile
 from contextlib import contextmanager, suppress
-from collections import deque
+from collections.abc import deque
 from typing import List, Tuple, Optional, Iterable, Callable
 
 from ._artifactelement import verify_artifact_ref, ArtifactElement

--- a/src/buildstream/_yaml.pyx
+++ b/src/buildstream/_yaml.pyx
@@ -24,7 +24,7 @@
 import datetime
 import sys
 from contextlib import ExitStack
-from collections import OrderedDict
+from collections.abc import OrderedDict
 from collections.abc import Mapping
 
 from ruamel import yaml

--- a/src/buildstream/scriptelement.py
+++ b/src/buildstream/scriptelement.py
@@ -33,7 +33,7 @@ implementations.
 """
 
 import os
-from collections import OrderedDict
+from collections.abc import OrderedDict
 from typing import List, Optional, TYPE_CHECKING
 
 from .element import Element

--- a/src/buildstream/testing/__init__.py
+++ b/src/buildstream/testing/__init__.py
@@ -20,7 +20,7 @@ This package contains various utilities which make it easier to test plugins.
 """
 
 import os
-from collections import OrderedDict
+from collections.abc import OrderedDict
 from buildstream.exceptions import ErrorDomain, LoadErrorReason
 from ._yaml import generate_project, generate_element, load_yaml
 from .repo import Repo

--- a/src/buildstream/testing/_cachekeys.py
+++ b/src/buildstream/testing/_cachekeys.py
@@ -16,7 +16,7 @@
 #
 
 import os
-from collections import OrderedDict
+from collections.abc import OrderedDict
 
 from .runcli import Cli
 

--- a/tests/cachekey/cachekey.py
+++ b/tests/cachekey/cachekey.py
@@ -39,7 +39,7 @@
 # Pylint doesn't play well with fixtures and dependency injection from pytest
 # pylint: disable=redefined-outer-name
 
-from collections import OrderedDict
+from collections.abc import OrderedDict
 import os
 
 import pytest

--- a/tests/testutils/artifactshare.py
+++ b/tests/testutils/artifactshare.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import signal
 import sys
-from collections import namedtuple
+from collections.abc import namedtuple
 from contextlib import ExitStack, contextmanager
 from concurrent import futures
 from multiprocessing import Process, Queue

--- a/tests/testutils/platform.py
+++ b/tests/testutils/platform.py
@@ -17,7 +17,7 @@
 #  Authors:
 #        Angelos Evripiotis <jevripiotis@bloomberg.net>
 
-import collections
+import collections.abc
 from contextlib import contextmanager
 import platform
 
@@ -45,7 +45,7 @@ def override_platform_uname(*, system=None, machine=None):
         #  2. We need to create a new subclass because the constructor of
         #     `platform.uname_result` doesn't share the same interface between
         #     Python 3.8 and 3.9.
-        uname_result = collections.namedtuple("uname_result", "system node release version machine processor")
+        uname_result = collections.abc.namedtuple("uname_result", "system node release version machine processor")
         return uname_result(system, node, release, version, machine, processor)
 
     platform.uname = override_func


### PR DESCRIPTION
collections is deprecated since version 3.3, will be removed in version 3.10

See https://docs.python.org/3/library/collections.html#module-collections

Part of #1483 