### PR TITLE
requirements/requirements.in: It depends on grpc >= 1.30

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,16 @@
 =================
+buildstream 1.6.2
+=================
+
+  o Fix some issues with a previous fix for #532
+
+  o Ported to github CI infrastructure
+
+  o Ensure paths specified in user configuration are absolute
+
+  o Import some symbols from collections.abc, required for python 3.10
+
+=================
 buildstream 1.6.1
 =================
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,5 @@
 Click
-grpcio >= 1.10
+grpcio >= 1.30
 jinja2 >= 2.10
 pluginbase
 protobuf >= 3.5

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 Click==7.0
-grpcio==1.23.0
+grpcio==1.30.0
 pluginbase==1.0.0
 protobuf==3.9.1
 psutil==5.6.3


### PR DESCRIPTION
with older version you will get errors like this accessing the CAS:
```
[--:--:--][][] WARNING Failed to initialize remote https://freedesktop-sdk-cache.codethink.co.uk:11001: Received http2 header with status: 404
```