### PR TITLE
requirements/requirements.in: It depends on grpc >= 1.34

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,5 @@
 Click >= 7.0
-grpcio >= 1.10
+grpcio >= 1.34
 Jinja2 >= 2.10
 pluginbase
 protobuf >= 3.6


### PR DESCRIPTION
Make explicit what is already in requirements.txt

with older version you will get errors like this accessing the CAS:
[--:--:--][][] WARNING Failed to initialize remote https://freedesktop-sdk-cache.codethink.co.uk:11001: Received http2 header with status: 404