### PR TITLE
Update grpc minimum version to 1.30

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,5 @@
 Click
-grpcio >= 1.10
+grpcio >= 1.30
 jinja2 >= 2.10
 pluginbase
 protobuf >= 3.6


### PR DESCRIPTION
This rebases @jjardon's patch against `bst-1`, replacing pull request #1489
