### PR TITLE
_workspaces.py: Use bst2 specific data directory for private project …

### DIFF
--- a/src/buildstream/_workspaces.py
+++ b/src/buildstream/_workspaces.py
@@ -317,7 +317,7 @@ class Workspaces:
 
         # A project without a directory can happen
         if toplevel_project.directory:
-            self._bst_directory = os.path.join(toplevel_project.directory, ".bst")
+            self._bst_directory = os.path.join(toplevel_project.directory, ".bst2")
             self._workspaces = self._load_config()
         else:
             self._bst_directory = None

--- a/tests/frontend/workspace.py
+++ b/tests/frontend/workspace.py
@@ -830,8 +830,8 @@ def test_detect_modifications(cli, tmpdir, datafiles, modification, strict):
 )
 def test_list_unsupported_workspace(cli, datafiles, workspace_cfg):
     project = str(datafiles)
-    os.makedirs(os.path.join(project, ".bst"))
-    workspace_config_path = os.path.join(project, ".bst", "workspaces.yml")
+    os.makedirs(os.path.join(project, ".bst2"))
+    workspace_config_path = os.path.join(project, ".bst2", "workspaces.yml")
 
     _yaml.roundtrip_dump(workspace_cfg, workspace_config_path)
 


### PR DESCRIPTION
…state

This ensures that bst-1 and bst-2 do not step on eachothers toes when working
on the same directory, which can typically happen when a project is in
transition to bst-2, and a user needs to work on multiple branches.

When transitioning to bst2, workspaces which appear to be open in bst1 are
ignored by bst2, and workspaces opened with bst2 are ignored by bst1, however
both can be configured to use the same directory for a given workspace if
the user requires this.

Fixes #1266