### PR TITLE
Add `project-root` and `toplevel-root` variables

### DIFF
--- a/doc/source/format_declaring.rst
+++ b/doc/source/format_declaring.rst
@@ -652,6 +652,61 @@ read-only variables are also dynamically declared by BuildStream:
 
   The name of project where BuildStream is being used.
 
+* ``project-root`` & ``project-root-uri``
+
+  The directory where the project is located on the host.
+
+  This variable is only available when declaring
+  :ref:`source alias values <project_source_aliases>` or
+  :ref:`source mirror values <project_essentials_mirrors>` and allows
+  access to files in a project on the build host.
+
+  * The ``project-root`` variable is a regular absolute path
+  * The ``project-root-uri`` variable is a properly quoted ``file://`` URI
+
+  .. tip::
+
+     Use this variable to declare :ref:`source alias values <project_source_aliases>`
+     to refer to files which you store as a part of your project, e.g. tarballs
+     which you have committed to you BuildStream project.
+
+  .. attention::
+
+     This feature has been provided for convenience when putting together a
+     project without the use of proper infrastructure.
+
+     A better long term solution for accessing internal binaries and source
+     code is to setup internal infrastructure in your organization and use
+     the regular ways to access these sources from a well known internal URI.
+
+* ``toplevel-root`` & ``toplevel-root-uri``
+
+  The directory where the toplevel project is located on the host.
+
+  This variable is only available when declaring
+  :ref:`source alias values <project_source_aliases>` or
+  :ref:`source mirror values <project_essentials_mirrors>` and allows
+  access to files in a project on the build host.
+
+  * The ``toplevel-root`` variable is a regular absolute path
+  * The ``toplevel-root-uri`` variable is a properly quoted ``file://`` URI
+
+  .. tip::
+
+     Use this variable to declare :ref:`source alias values <project_source_aliases>`
+     to refer to files which you do not store as a part of your project, e.g.
+     tarballs or git repositories which must be placed in a directory within
+     the toplevel project before running the build.
+
+  .. attention::
+
+     This feature has been provided for convenience when putting together a
+     project without the use of proper infrastructure.
+
+     A better long term solution for accessing internal binaries and source
+     code is to setup internal infrastructure in your organization and use
+     the regular ways to access these sources from a well known internal URI.
+
 * ``max-jobs``
 
   Maximum number of parallel build processes within a given

--- a/tests/frontend/fetch.py
+++ b/tests/frontend/fetch.py
@@ -5,7 +5,6 @@ import os
 import pytest
 
 from buildstream.testing import cli  # pylint: disable=unused-import
-from buildstream.testing import generate_project
 from buildstream import _yaml
 from buildstream.exceptions import ErrorDomain, LoadErrorReason
 
@@ -37,9 +36,6 @@ DATA_DIR = os.path.join(TOP_DIR, "project")
 )
 def test_fetch_deps(cli, datafiles, deps, expected_states):
     project = str(datafiles)
-    generate_project(project)
-    generate_project(project, {"aliases": {"project-root": "file:///" + project}})
-
     target = "bananas.bst"
     build_dep = "apples.bst"
     runtime_dep = "oranges.bst"

--- a/tests/frontend/mirror.py
+++ b/tests/frontend/mirror.py
@@ -472,3 +472,44 @@ def test_mirror_fallback_git_with_submodules(cli, tmpdir, datafiles):
 
     assert os.path.exists(os.path.join(checkout, "bin", "bin", "hello"))
     assert os.path.exists(os.path.join(checkout, "dev", "include", "pony.h"))
+
+
+@pytest.mark.datafiles(DATA_DIR)
+@pytest.mark.usefixtures("datafiles")
+def test_mirror_expand_project_and_toplevel_root(cli, tmpdir):
+    output_file = os.path.join(str(tmpdir), "output.txt")
+    project_dir = str(tmpdir)
+    element_dir = os.path.join(project_dir, "elements")
+    os.makedirs(element_dir, exist_ok=True)
+    element_name = "test.bst"
+    element_path = os.path.join(element_dir, element_name)
+    element = generate_element(output_file)
+    _yaml.roundtrip_dump(element, element_path)
+
+    project_file = os.path.join(project_dir, "project.conf")
+    project = {
+        "name": "test",
+        "min-version": "2.0",
+        "element-path": "elements",
+        "aliases": {"foo": "FOO/", "bar": "BAR/",},
+        "mirrors": [
+            {"name": "middle-earth", "aliases": {"foo": ["OOF/"], "bar": ["RAB/"],},},
+            {"name": "arrakis", "aliases": {"foo": ["%{project-root}/OFO/"], "bar": ["%{project-root}/RBA/"],},},
+            {"name": "oz", "aliases": {"foo": ["ooF/"], "bar": ["raB/"],}},
+        ],
+        "plugins": [{"origin": "local", "path": "sources", "sources": ["fetch_source"]}],
+    }
+
+    _yaml.roundtrip_dump(project, project_file)
+
+    result = cli.run(project=project_dir, args=["--default-mirror", "arrakis", "source", "fetch", element_name])
+    result.assert_success()
+    with open(output_file, encoding="utf-8") as f:
+        contents = f.read()
+        print(contents)
+        foo_str = os.path.join(project_dir, "OFO/repo1")
+        bar_str = os.path.join(project_dir, "RBA/repo2")
+
+        # Success if the expanded %{project-root} is found
+        assert foo_str in contents
+        assert bar_str in contents

--- a/tests/frontend/source-fetch/project.conf
+++ b/tests/frontend/source-fetch/project.conf
@@ -1,0 +1,5 @@
+name: test
+min-version: 2.0
+
+aliases:
+  project-root: "%{project-root-uri}"


### PR DESCRIPTION
This addresses the long lasting problem of using sources which usually download from remote URIs with local project-relative user provided data.

This adds two similar variables with slightly different use cases:
* `project-root`: This is to use for source alias and mirror value expansions, and is suitable for things like tarballs which you have committed in your BuildStream project
  * When your project is accessed via a junction, things will *just work*
* `toplevel-root`: This is to use for source alias and mirror value expansions, and is suitable for things like tarballs or git repositories which must be placed somewhere adjacent to your project before launching a build
  * When your project is accessed via a junction, the sources will be appropriately looked up in a location that is relative to the toplevel project being built

Once merged, this will close #1047.
