### PR TITLE
Remove selection mode "plan"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@
 (unreleased)
 ============
 
+CLI
+---
+  o BREAKING CHANGE: Removed `--deps plan` from all commands
+
 
 ==================
 buildstream 1.93.6

--- a/doc/source/using_config.rst
+++ b/doc/source/using_config.rst
@@ -324,7 +324,7 @@ Attributes
   This instructs what dependencies of the target elements should be built, valid
   values for this attribute are:
 
-  * ``plan``: Only build elements required to generate the expected target artifacts
+  * ``none``: Only build elements required to generate the expected target artifacts
   * ``all``: Build elements even if they are build dependencies of artifacts which are already cached
 
 

--- a/src/buildstream/_context.py
+++ b/src/buildstream/_context.py
@@ -423,10 +423,10 @@ class Context:
         self.build_max_jobs = build.get_int("max-jobs")
 
         dependencies = build.get_str("dependencies")
-        if dependencies not in ["plan", "all"]:
+        if dependencies not in ["none", "all"]:
             provenance = build.get_scalar("dependencies").get_provenance()
             raise LoadError(
-                "{}: Invalid value for 'dependencies'. Choose 'plan' or 'all'.".format(provenance),
+                "{}: Invalid value for 'dependencies'. Choose 'none' or 'all'.".format(provenance),
                 LoadErrorReason.INVALID_DATA,
             )
         self.build_dependencies = _PipelineSelection(dependencies)

--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -427,7 +427,7 @@ def init(app, project_name, min_version, element_path, force, target_directory):
     "-d",
     default=None,
     type=FastEnumType(
-        _PipelineSelection, [_PipelineSelection.BUILD, _PipelineSelection.PLAN, _PipelineSelection.ALL],
+        _PipelineSelection, [_PipelineSelection.NONE, _PipelineSelection.BUILD, _PipelineSelection.ALL],
     ),
     help="The dependencies to build",
 )
@@ -473,12 +473,15 @@ def build(
     When this command is executed from a workspace directory, the default
     is to build the workspace element.
 
-    Specify `--deps` to control which dependencies to build:
+    Specify `--deps` to control which dependencies must be built:
 
     \b
-        plan:  Only dependencies required for the build plan
+        none:  No dependencies, just the element itself
         build: Build time dependencies, excluding the element itself
         all:   All dependencies
+
+    Dependencies that are consequently required to build the requested
+    elements will be built on demand.
     """
     with app.initialized(session_name="Build"):
         ignore_junction_targets = False
@@ -516,13 +519,7 @@ def build(
     show_default=True,
     type=FastEnumType(
         _PipelineSelection,
-        [
-            _PipelineSelection.NONE,
-            _PipelineSelection.PLAN,
-            _PipelineSelection.RUN,
-            _PipelineSelection.BUILD,
-            _PipelineSelection.ALL,
-        ],
+        [_PipelineSelection.NONE, _PipelineSelection.RUN, _PipelineSelection.BUILD, _PipelineSelection.ALL,],
     ),
     help="The dependencies to show",
 )
@@ -561,7 +558,6 @@ def show(app, elements, deps, except_, order, format_):
 
     \b
         none:  No dependencies, just the element itself
-        plan:  Dependencies required for a build plan
         run:   Runtime dependencies, including the element itself
         build: Build time dependencies, excluding the element itself
         all:   All dependencies
@@ -762,17 +758,11 @@ def source():
 @click.option(
     "--deps",
     "-d",
-    default=_PipelineSelection.PLAN,
+    default=_PipelineSelection.NONE,
     show_default=True,
     type=FastEnumType(
         _PipelineSelection,
-        [
-            _PipelineSelection.PLAN,
-            _PipelineSelection.NONE,
-            _PipelineSelection.BUILD,
-            _PipelineSelection.RUN,
-            _PipelineSelection.ALL,
-        ],
+        [_PipelineSelection.NONE, _PipelineSelection.BUILD, _PipelineSelection.RUN, _PipelineSelection.ALL,],
     ),
     help="The dependencies to fetch",
 )
@@ -798,16 +788,13 @@ def source_fetch(app, elements, deps, except_, source_remotes, ignore_project_so
     When this command is executed from a workspace directory, the default
     is to fetch the workspace element.
 
-    By default this will only try to fetch sources which are
-    required for the build plan of the specified target element,
-    omitting sources for any elements which are already built
-    and available in the artifact cache.
+    By default this will only try to fetch sources for the specified
+    elements.
 
     Specify `--deps` to control which sources to fetch:
 
     \b
         none:  No dependencies, just the element itself
-        plan:  Only dependencies required for the build plan
         run:   Runtime dependencies, including the element itself
         build: Build time dependencies, excluding the element itself
         all:   All dependencies
@@ -843,13 +830,7 @@ def source_fetch(app, elements, deps, except_, source_remotes, ignore_project_so
     show_default=True,
     type=FastEnumType(
         _PipelineSelection,
-        [
-            _PipelineSelection.NONE,
-            _PipelineSelection.PLAN,
-            _PipelineSelection.BUILD,
-            _PipelineSelection.RUN,
-            _PipelineSelection.ALL,
-        ],
+        [_PipelineSelection.NONE, _PipelineSelection.BUILD, _PipelineSelection.RUN, _PipelineSelection.ALL,],
     ),
     help="The dependencies to push",
 )
@@ -875,11 +856,13 @@ def source_push(app, elements, deps, except_, source_remotes, ignore_project_sou
     When this command is executed from a workspace directory, the default
     is to push the sources of the workspace element.
 
+    By default this will only try to push sources for the specified
+    elements.
+
     Specify `--deps` to control which sources to fetch:
 
     \b
         none:  No dependencies, just the element itself
-        plan:  Only dependencies required for the build plan
         run:   Runtime dependencies, including the element itself
         build: Build time dependencies, excluding the element itself
         all:   All dependencies

--- a/src/buildstream/data/userconfig.yaml
+++ b/src/buildstream/data/userconfig.yaml
@@ -68,7 +68,7 @@ build:
   #
   # Control which dependencies to build
   #
-  dependencies: plan
+  dependencies: none
 
 
 #

--- a/src/buildstream/testing/runcli.py
+++ b/src/buildstream/testing/runcli.py
@@ -463,7 +463,7 @@ class Cli:
     # Fetch the elements that would be in the pipeline with the given
     # arguments.
     #
-    def get_pipeline(self, project, elements, except_=None, scope="plan"):
+    def get_pipeline(self, project, elements, except_=None, scope="all"):
         if except_ is None:
             except_ = []
 

--- a/src/buildstream/types.py
+++ b/src/buildstream/types.py
@@ -281,9 +281,6 @@ class _PipelineSelection(FastEnum):
     # As NONE, but redirect elements that are capable of it
     REDIRECT = "redirect"
 
-    # Select elements which must be built for the associated targets to be built
-    PLAN = "plan"
-
     # All dependencies of all targets, including the targets
     ALL = "all"
 

--- a/tests/format/dependencies.py
+++ b/tests/format/dependencies.py
@@ -214,27 +214,6 @@ def test_scope_build_of_child(cli, datafiles):
 
 
 @pytest.mark.datafiles(DATA_DIR)
-def test_no_recurse(cli, datafiles):
-    project = os.path.join(str(datafiles), "dependencies2")
-    elements = ["target.bst"]
-
-    # We abuse the 'plan' scope here to ensure that we call
-    # element.dependencies() with recurse=False - currently, no `bst
-    # show` option does this directly.
-    element_list = cli.get_pipeline(project, elements, scope="plan")
-
-    assert element_list == [
-        "build-build.bst",
-        "run-build.bst",
-        "build.bst",
-        "dep-one.bst",
-        "run.bst",
-        "dep-two.bst",
-        "target.bst",
-    ]
-
-
-@pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.parametrize(
     "target", ["merge-separate-lists.bst", "merge-single-list.bst",], ids=["separate-lists", "single-list"],
 )

--- a/tests/frontend/completions.py
+++ b/tests/frontend/completions.py
@@ -156,8 +156,8 @@ def test_options(cli, cmd, word_idx, expected):
     [
         ("bst --on-error ", 2, ["continue ", "quit ", "terminate "]),
         ("bst --cache-buildtrees ", 2, ["always ", "auto ", "never "]),
-        ("bst show --deps ", 3, ["all ", "build ", "none ", "plan ", "run "]),
-        ("bst show --deps=", 2, ["all ", "build ", "none ", "plan ", "run "]),
+        ("bst show --deps ", 3, ["all ", "build ", "none ", "run "]),
+        ("bst show --deps=", 2, ["all ", "build ", "none ", "run "]),
         ("bst show --deps b", 3, ["build "]),
         ("bst show --deps=b", 2, ["build "]),
         ("bst show --deps r", 3, ["run "]),

--- a/tests/frontend/show.py
+++ b/tests/frontend/show.py
@@ -4,7 +4,6 @@
 import os
 import sys
 import shutil
-import itertools
 import pytest
 from buildstream.testing import cli  # pylint: disable=unused-import
 from buildstream import _yaml
@@ -211,37 +210,6 @@ def test_show_except(cli, datafiles, targets, exceptions, expected):
     results = cli.get_pipeline(basedir, targets, except_=exceptions, scope="all")
     if results != expected:
         raise AssertionError("Expected elements:\n{}\nInstead received elements:\n{}".format(expected, results))
-
-
-###############################################################
-#                   Testing multiple targets                  #
-###############################################################
-@pytest.mark.datafiles(os.path.join(DATA_DIR, "project"))
-def test_parallel_order(cli, datafiles):
-    project = str(datafiles)
-    elements = ["multiple_targets/order/0.bst", "multiple_targets/order/1.bst"]
-
-    args = ["show", "-d", "plan", "-f", "%{name}", *elements]
-    result = cli.run(project=project, args=args)
-
-    result.assert_success()
-
-    # Get the planned order
-    names = result.output.splitlines()
-    names = [name[len("multiple_targets/order/") :] for name in names]
-
-    # Create all possible 'correct' topological orderings
-    orderings = itertools.product(
-        [("5.bst", "6.bst")],
-        itertools.permutations(["4.bst", "7.bst"]),
-        itertools.permutations(["3.bst", "8.bst"]),
-        itertools.permutations(["2.bst", "9.bst"]),
-        itertools.permutations(["0.bst", "1.bst", "run.bst"]),
-    )
-    orderings = [list(itertools.chain.from_iterable(perm)) for perm in orderings]
-
-    # Ensure that our order is among the correct orderings
-    assert names in orderings, "We got: {}".format(", ".join(names))
 
 
 @pytest.mark.datafiles(os.path.join(DATA_DIR, "project"))

--- a/tests/frontend/show.py
+++ b/tests/frontend/show.py
@@ -217,12 +217,12 @@ def test_target_is_dependency(cli, datafiles):
     project = str(datafiles)
     elements = ["multiple_targets/dependency/zebry.bst", "multiple_targets/dependency/horsey.bst"]
 
-    args = ["show", "-d", "plan", "-f", "%{name}", *elements]
+    args = ["show", "-d", "all", "-f", "%{name}", *elements]
     result = cli.run(project=project, args=args)
 
     result.assert_success()
 
-    # Get the planned order
+    # Get the order
     names = result.output.splitlines()
     names = [name[len("multiple_targets/dependency/") :] for name in names]
 

--- a/tests/frontend/workspace.py
+++ b/tests/frontend/workspace.py
@@ -1011,7 +1011,7 @@ def test_external_fetch(cli, datafiles, tmpdir_factory, subdir, guess_element):
     assert cli.get_element_state(str(datafiles), depend_element) == "fetch needed"
 
     # Fetch the workspaced element
-    result = cli.run(project=project, args=["-C", call_dir, "source", "fetch", *arg_elm])
+    result = cli.run(project=project, args=["-C", call_dir, "source", "fetch", "--deps", "all", *arg_elm])
     result.assert_success()
 
     # Assert that the depended element has now been fetched


### PR DESCRIPTION
Remove PipelineSelection.PLAN and any related frontend options.
    
This removes the `--deps plan` option from all commands, including the internal selection mode.

This is a part of addressing #1349
