### PR TITLE
Error out on invalid element names

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,12 @@
 (unreleased)
 ============
 
+Format
+------
+  o BREAKING CHANGE: Element names must now bare the `.bst` suffix and not
+    contain invalid characters, as was already documented. Now the warning
+    is replaced by an unconditional error.
+
 CLI
 ---
   o BREAKING CHANGE: Removed `--deps plan` from all commands

--- a/src/buildstream/exceptions.py
+++ b/src/buildstream/exceptions.py
@@ -146,3 +146,15 @@ class LoadErrorReason(Enum):
 
     CIRCULAR_REFERENCE = 26
     """A circular element reference was detected"""
+
+    BAD_ELEMENT_SUFFIX = 27
+    """
+    This warning will be produced when an element whose name does not end in .bst
+    is referenced either on the command line or by another element
+    """
+
+    BAD_CHARACTERS_IN_NAME = 28
+    """
+    This warning will be produced when a filename for a target contains invalid
+    characters in its name.
+    """

--- a/src/buildstream/types.py
+++ b/src/buildstream/types.py
@@ -113,18 +113,6 @@ class CoreWarnings:
     which is found to be invalid based on the configured track
     """
 
-    BAD_ELEMENT_SUFFIX = "bad-element-suffix"
-    """
-    This warning will be produced when an element whose name does not end in .bst
-    is referenced either on the command line or by another element
-    """
-
-    BAD_CHARACTERS_IN_NAME = "bad-characters-in-name"
-    """
-    This warning will be produced when a filename for a target contains invalid
-    characters in its name.
-    """
-
     UNALIASED_URL = "unaliased-url"
     """
     A URL used for fetching a sources was specified without specifying any

--- a/tests/format/elementnames.py
+++ b/tests/format/elementnames.py
@@ -1,0 +1,29 @@
+# Pylint doesn't play well with fixtures and dependency injection from pytest
+# pylint: disable=redefined-outer-name
+
+import os
+import pytest
+
+from buildstream.exceptions import ErrorDomain, LoadErrorReason
+from buildstream.testing import cli  # pylint: disable=unused-import
+
+DATA_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+@pytest.mark.parametrize(
+    "target,reason,provenance",
+    [
+        ("farm.pony", LoadErrorReason.BAD_ELEMENT_SUFFIX, None),
+        ('The "quoted" pony.bst', LoadErrorReason.BAD_CHARACTERS_IN_NAME, None),
+        ("bad-suffix-dep.bst", LoadErrorReason.BAD_ELEMENT_SUFFIX, "bad-suffix-dep.bst [line 3 column 2]"),
+        ("bad-chars-dep.bst", LoadErrorReason.BAD_CHARACTERS_IN_NAME, "bad-chars-dep.bst [line 3 column 2]"),
+    ],
+    ids=["toplevel-bad-suffix", "toplevel-bad-chars", "dependency-bad-suffix", "dependency-bad-chars"],
+)
+@pytest.mark.datafiles(DATA_DIR)
+def test_invalid_element_names(cli, datafiles, target, reason, provenance):
+    project = os.path.join(str(datafiles), "elementnames")
+    result = cli.run(project=project, silent=True, args=["show", target])
+    result.assert_main_error(ErrorDomain.LOAD, reason)
+    if provenance:
+        assert provenance in result.stderr

--- a/tests/format/elementnames/bad-chars-dep.bst
+++ b/tests/format/elementnames/bad-chars-dep.bst
@@ -1,0 +1,3 @@
+kind: stack
+depends:
+- <invalid>.bst

--- a/tests/format/elementnames/bad-suffix-dep.bst
+++ b/tests/format/elementnames/bad-suffix-dep.bst
@@ -1,0 +1,3 @@
+kind: stack
+depends:
+- rainbow.pony

--- a/tests/format/elementnames/project.conf
+++ b/tests/format/elementnames/project.conf
@@ -1,0 +1,4 @@
+# Basic project configuration that doesnt override anything
+#
+name: test
+min-version: 2.0

--- a/tests/frontend/buildcheckout.py
+++ b/tests/frontend/buildcheckout.py
@@ -10,7 +10,7 @@ import pytest
 
 from buildstream.testing import cli  # pylint: disable=unused-import
 from buildstream.testing import create_repo
-from buildstream.testing._utils.site import IS_WINDOWS, CASD_SEPARATE_USER
+from buildstream.testing._utils.site import CASD_SEPARATE_USER
 from buildstream import _yaml
 from buildstream.exceptions import ErrorDomain, LoadErrorReason
 from buildstream import utils
@@ -167,60 +167,6 @@ def test_non_strict_checkout_uncached(datafiles, cli, tmpdir):
             project=project, args=["--no-strict", "artifact", "checkout", element_name, "--directory", checkout]
         )
         result.assert_main_error(ErrorDomain.STREAM, "uncached-checkout-attempt")
-
-
-@pytest.mark.datafiles(DATA_DIR)
-@pytest.mark.parametrize("strict,hardlinks", [("non-strict", "hardlinks"),])
-def test_build_invalid_suffix(datafiles, cli, strict, hardlinks):
-    project = str(datafiles)
-
-    result = cli.run(project=project, args=strict_args(["build", "target.foo"], strict))
-    result.assert_main_error(ErrorDomain.LOAD, "bad-element-suffix")
-
-
-@pytest.mark.datafiles(DATA_DIR)
-@pytest.mark.parametrize("strict,hardlinks", [("non-strict", "hardlinks"),])
-def test_build_invalid_suffix_dep(datafiles, cli, strict, hardlinks):
-    project = str(datafiles)
-
-    # target2.bst depends on an element called target.foo
-    result = cli.run(project=project, args=strict_args(["build", "target2.bst"], strict))
-    result.assert_main_error(ErrorDomain.LOAD, "bad-element-suffix")
-
-
-@pytest.mark.skipif(IS_WINDOWS, reason="Not available on Windows")
-@pytest.mark.datafiles(DATA_DIR)
-def test_build_invalid_filename_chars(datafiles, cli):
-    project = str(datafiles)
-    element_name = "invalid-chars|<>-in-name.bst"
-
-    # The name of this file contains characters that are not allowed by
-    # BuildStream, using it should raise a warning.
-    element = {
-        "kind": "stack",
-    }
-    _yaml.roundtrip_dump(element, os.path.join(project, "elements", element_name))
-
-    result = cli.run(project=project, args=strict_args(["build", element_name], "non-strict"))
-    result.assert_main_error(ErrorDomain.LOAD, "bad-characters-in-name")
-
-
-@pytest.mark.skipif(IS_WINDOWS, reason="Not available on Windows")
-@pytest.mark.datafiles(DATA_DIR)
-def test_build_invalid_filename_chars_dep(datafiles, cli):
-    project = str(datafiles)
-    element_name = "invalid-chars|<>-in-name.bst"
-
-    # The name of this file contains characters that are not allowed by
-    # BuildStream, and is listed as a dependency of 'invalid-chars-in-dep.bst'.
-    # This should also raise a warning.
-    element = {
-        "kind": "stack",
-    }
-    _yaml.roundtrip_dump(element, os.path.join(project, "elements", element_name))
-
-    result = cli.run(project=project, args=strict_args(["build", "invalid-chars-in-dep.bst"], "non-strict"))
-    result.assert_main_error(ErrorDomain.LOAD, "bad-characters-in-name")
 
 
 @pytest.mark.datafiles(DATA_DIR)

--- a/tests/frontend/project/elements/invalid-chars-in-dep.bst
+++ b/tests/frontend/project/elements/invalid-chars-in-dep.bst
@@ -1,8 +1,0 @@
-kind: stack
-description: |
-
-  This element itself has a valid name, but depends on elements that have
-  invalid names. This should also result in a warning.
-
-depends:
-- invalid-chars|<>-in-name.bst

--- a/tests/frontend/project/elements/target2.bst
+++ b/tests/frontend/project/elements/target2.bst
@@ -1,7 +1,0 @@
-kind: stack
-description: |
-
-  Main stack target for the bst build test
-
-depends:
-- target.foo

--- a/tests/frontend/project/project.conf
+++ b/tests/frontend/project/project.conf
@@ -2,7 +2,3 @@
 name: test
 min-version: 2.0
 element-path: elements
-
-fatal-warnings:
-- bad-element-suffix
-- bad-characters-in-name


### PR DESCRIPTION
This makes BuildStream strict about element naming instead of raising configurable warnings, which means we can now rely on elements having the `.bst` suffix, which can help us in some ways (such as distinguishing element names and artifact names on the command line).

As a bonus, the provenance is now included in the errors and the tests have been appropriately moved to the format testing area.

