### PR TITLE
Revert to expecting '.bst' on the command line to disambiguate elements and artifacts

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,10 @@ CLI
   o The `--pull` option is removed from the `bst shell` and `bst artifact checkout`
     commands, which will now unconditionally try to pull required artifacts.
 
+  o BREAKING CHANGE: Now the artifact commands only accept element names if specified
+    with a `.bst` suffix (including wildcard expressions), and otherwise assumes the
+    command means to specify an artifact name.
+
 
 ==================
 buildstream 1.93.6

--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -1190,20 +1190,28 @@ def artifact():
 
     \b
     - artifact refs: triples of the form <project name>/<element name>/<cache key>
-    - element paths
+    - element names
 
-    When elements are given, the artifact corresponding to the element is used.
+    When elements are given, the artifact is looked up by observing the element
+    and it's current cache key.
 
     The commands also support shell-style wildcard expansion: `?` matches a
-    single character, and `*` matches zero or more. The patterns are matched
-    against artifact refs by default. If the pattern ends with `.bst` then
-    it matches element paths instead. Some example arguments are:
+    single character, `*` matches zero or more characters but does not match the `/`
+    path separator, and `**` matches zero or more characters including `/` path separators.
+
+    If the wildcard expression ends with `.bst`, then it will be used to search
+    element names found in the project, otherwise, it will be used to search artifacts
+    that are present in the local artifact cache.
+
+    Some example arguments are:
 
     \b
     - `myproject/hello/8276376b077eda104c812e6ec2f488c7c9eea211ce572c83d734c10bf241209f`
     - `myproject/he*/827637*`
-    - `*.bst` (all elements)
-    - `myproject/*` (all artifacts from myproject)
+    - `core/*.bst` (all elements in the core directory)
+    - `**.bst` (all elements)
+    - `myproject/**` (all artifacts from myproject)
+    - `myproject/myelement/*` (all cached artifacts for a specific element)
     """
     # Note that the backticks in the above docstring are important for the
     # generated docs. When sphinx is generating rst output from the help output

--- a/src/buildstream/_loader/loader.py
+++ b/src/buildstream/_loader/loader.py
@@ -298,18 +298,6 @@ class Loader:
 
                 raise LoadError(message, LoadErrorReason.MISSING_FILE, detail=detail) from e
 
-            if e.reason == LoadErrorReason.LOADING_DIRECTORY:
-                # If a <directory>.bst file exists in the element path,
-                # let's suggest this as a plausible alternative.
-                message = str(e)
-                if provenance_node:
-                    message = "{}: {}".format(provenance_node.get_provenance(), message)
-                detail = None
-                if os.path.exists(os.path.join(self._basedir, filename + ".bst")):
-                    element_name = filename + ".bst"
-                    detail = "Did you mean '{}'?\n".format(element_name)
-                raise LoadError(message, LoadErrorReason.LOADING_DIRECTORY, detail=detail) from e
-
             # Otherwise, we don't know the reason, so just raise
             raise
 

--- a/tests/format/elementnames.py
+++ b/tests/format/elementnames.py
@@ -11,19 +11,33 @@ DATA_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 @pytest.mark.parametrize(
-    "target,reason,provenance",
+    "target,domain,reason,provenance",
     [
-        ("farm.pony", LoadErrorReason.BAD_ELEMENT_SUFFIX, None),
-        ('The "quoted" pony.bst', LoadErrorReason.BAD_CHARACTERS_IN_NAME, None),
-        ("bad-suffix-dep.bst", LoadErrorReason.BAD_ELEMENT_SUFFIX, "bad-suffix-dep.bst [line 3 column 2]"),
-        ("bad-chars-dep.bst", LoadErrorReason.BAD_CHARACTERS_IN_NAME, "bad-chars-dep.bst [line 3 column 2]"),
+        # When specifying a bad suffix on the command line we get a different error, we
+        # catch this error earlier on in the load sequence while sorting out element and
+        # artifact names and glob expressions.
+        #
+        ("farm.pony", ErrorDomain.STREAM, "invalid-element-names", None),
+        ('The "quoted" pony.bst', ErrorDomain.LOAD, LoadErrorReason.BAD_CHARACTERS_IN_NAME, None),
+        (
+            "bad-suffix-dep.bst",
+            ErrorDomain.LOAD,
+            LoadErrorReason.BAD_ELEMENT_SUFFIX,
+            "bad-suffix-dep.bst [line 3 column 2]",
+        ),
+        (
+            "bad-chars-dep.bst",
+            ErrorDomain.LOAD,
+            LoadErrorReason.BAD_CHARACTERS_IN_NAME,
+            "bad-chars-dep.bst [line 3 column 2]",
+        ),
     ],
     ids=["toplevel-bad-suffix", "toplevel-bad-chars", "dependency-bad-suffix", "dependency-bad-chars"],
 )
 @pytest.mark.datafiles(DATA_DIR)
-def test_invalid_element_names(cli, datafiles, target, reason, provenance):
+def test_invalid_element_names(cli, datafiles, target, domain, reason, provenance):
     project = os.path.join(str(datafiles), "elementnames")
     result = cli.run(project=project, silent=True, args=["show", target])
-    result.assert_main_error(ErrorDomain.LOAD, reason)
+    result.assert_main_error(domain, reason)
     if provenance:
         assert provenance in result.stderr

--- a/tests/frontend/artifact_show.py
+++ b/tests/frontend/artifact_show.py
@@ -150,30 +150,6 @@ def test_artifact_show_glob(cli, tmpdir, datafiles, pattern, expected_prefixes):
         assert found, "Expected result {} not found".format(expected_prefix)
 
 
-# Test artifact show glob behaviors
-@pytest.mark.datafiles(SIMPLE_DIR)
-@pytest.mark.parametrize(
-    "pattern",
-    [
-        # Catch all glob will match everything, that is an error since the glob matches
-        # both elements and artifacts
-        #
-        "**",
-        # This glob is more selective but will also match both artifacts and elements
-        #
-        "**import-bin**",
-    ],
-)
-def test_artifact_show_doubly_matched_glob_error(cli, tmpdir, datafiles, pattern):
-    project = str(datafiles)
-
-    result = cli.run(project=project, args=["build", "target.bst"])
-    result.assert_success()
-
-    result = cli.run(project=project, args=["artifact", "show", pattern])
-    result.assert_main_error(ErrorDomain.STREAM, "glob-elements-and-artifacts")
-
-
 # Test artifact show artifact in remote
 @pytest.mark.datafiles(DATA_DIR)
 def test_artifact_show_element_available_remotely(cli, tmpdir, datafiles):

--- a/tests/frontend/show.py
+++ b/tests/frontend/show.py
@@ -55,9 +55,6 @@ def test_show_fail(cli, datafiles):
 @pytest.mark.parametrize(
     "pattern,expected_elements",
     [
-        # Use catch all glob. This should report all elements.
-        #
-        ("**", ["import-bin.bst", "import-dev.bst", "compose-all.bst", "target.bst", "subdir/target.bst"]),
         # Only bst files, same as "**" for `bst show`
         #
         ("**.bst", ["import-bin.bst", "import-dev.bst", "compose-all.bst", "target.bst", "subdir/target.bst"]),
@@ -67,18 +64,15 @@ def test_show_fail(cli, datafiles):
         ("*.bst", ["import-bin.bst", "import-dev.bst", "compose-all.bst", "target.bst"]),
         # Report only targets in the subdirectory
         #
-        ("subdir/*", ["subdir/target.bst"]),
+        ("subdir/*.bst", ["subdir/target.bst"]),
         # Report both targets which end in "target.bst"
         #
         ("**target.bst", ["target.bst", "subdir/target.bst"]),
         # All elements starting with the prefix "import"
         #
-        ("import*", ["import-bin.bst", "import-dev.bst"]),
-        # Glob would match artifact refs, but `bst show` does not accept these as input.
-        #
-        ("test/**", []),
+        ("import*.bst", ["import-bin.bst", "import-dev.bst"]),
     ],
-    ids=["**", "**.bst", "*.bst", "subdir/*", "**target.bst", "import*", "test/**"],
+    ids=["**.bst", "*.bst", "subdir/*", "**target.bst", "import*"],
 )
 def test_show_glob(cli, tmpdir, datafiles, pattern, expected_elements):
     project = str(datafiles)

--- a/tests/frontend/workspace.py
+++ b/tests/frontend/workspace.py
@@ -215,7 +215,7 @@ def test_open_multi_unwritable(cli, tmpdir, datafiles):
         # Using this finally to make sure we always put thing back how they should be.
         os.chmod(workspace_object.workspace_cmd, cwdstat.st_mode)
 
-    result.assert_main_error(ErrorDomain.STREAM, None)
+    result.assert_main_error(ErrorDomain.STREAM, "workspace-directory-failure")
     # Normally we avoid checking stderr in favour of using the mechine readable result.assert_main_error
     # But Tristan was very keen that the names of the elements left needing workspaces were present in the out put
     assert " ".join([element_name for element_name, workspace_dir_suffix in element_tuples[1:]]) in result.stderr

--- a/tests/internals/loader.py
+++ b/tests/internals/loader.py
@@ -90,7 +90,8 @@ def test_invalid_key(datafiles):
 def test_invalid_directory_load(datafiles):
 
     basedir = str(datafiles)
+    os.makedirs(os.path.join(basedir, "element.bst"))
     with make_loader(basedir) as loader, pytest.raises(LoadError) as exc:
-        loader.load(["elements/"])
+        loader.load(["element.bst"])
 
     assert exc.value.reason == LoadErrorReason.LOADING_DIRECTORY


### PR DESCRIPTION
Summary of changes:

  * _stream.py: Treat targets with `.bst` suffixes as elements and other
    targets as artifacts, and improve error reporting around this.

    Also use a new machine readable error string to denote when we fail
    to create a directory when creating a workspace.

  * _loader/loader.py: Remove handling of LoadErrorReason.LOADING_DIRECTORY

    This additional handling was only to suggest that maybe the user
    meant to specify "<directory_name>.bst" in the case a directory is
    encountered, but now we will bail out earlier if an element target
    is specified without a ".bst" suffix anyway.

    The only way to reach this error is to load a directory which itself
    already has a ".bst" suffix, in which case the additional suggestion
    is no longer useful.

  * tests/format/elementnames.py: Expect different error for target elements

  * tests/frontend/artifact_show.py: Removed test that is no longer relevant,
    it is now impossible to glob for both elements and artifacts with the
    same glob expression.

  * tests/frontend/show.py: Removed some parameters of the glob test which
    were expecting to get element results without specifying a ".bst" suffix

  * tests/frontend/workspace.py: Specify a newly added machine readable reason
    for the error of failing to create a directory while opening a workspace

  * tests/internals/loader.py: Trigger the LoadErrorReason.LOADING_DIRECTORY
    error by creating a directory named "element.bst", so that it gets by
    the initial element name suffix checks.

Fixes #1411