### PR TITLE
Update mypy to 0.910

### DIFF
--- a/src/buildstream/plugin.py
+++ b/src/buildstream/plugin.py
@@ -213,7 +213,7 @@ class Plugin:
         which are included in the buildstream namespace.
     """
 
-    BST_MIN_VERSION = None
+    BST_MIN_VERSION: Optional[str] = None
     """The minimum required version of BuildStream required by this plugin.
 
     The version must be expressed as the string *"<major>.<minor>"*, where the
@@ -278,7 +278,7 @@ class Plugin:
     __TABLE = WeakValueDictionary()  # type: WeakValueDictionary[int, Plugin]
 
     try:
-        __multiprocessing_context = multiprocessing.get_context("forkserver")
+        __multiprocessing_context: multiprocessing.context.BaseContext = multiprocessing.get_context("forkserver")
     except ValueError:
         # We are on a system without `forkserver` support. Let's default to
         # spawn. This seems to be hanging however in some rare cases.

--- a/src/buildstream/plugins/sources/tar.py
+++ b/src/buildstream/plugins/sources/tar.py
@@ -72,7 +72,8 @@ class ReadableTarInfo(tarfile.TarInfo):
            so that the owner-read bit is always set.
     """
 
-    @property
+    # https://github.com/python/mypy/issues/4125
+    @property  # type: ignore
     def mode(self):
         # Respect umask instead of the file mode stored in the archive.
         # The only bit used from the embedded mode is the executable bit for files.

--- a/src/buildstream/plugins/sources/workspace.py
+++ b/src/buildstream/plugins/sources/workspace.py
@@ -93,10 +93,10 @@ class WorkspaceSource(Source):
     # init_workspace()
     #
     # Raises AssertionError: existing workspaces should not be reinitialized
-    def init_workspace(self, directory: Directory) -> None:
+    def init_workspace(self, directory: str) -> None:
         raise AssertionError("Attempting to re-open an existing workspace")
 
-    def fetch(self) -> None:  # pylint: disable=arguments-differ
+    def fetch(self, *, previous_sources_dir=None) -> None:  # pylint: disable=arguments-differ
         pass  # pragma: nocover
 
     def stage(self, directory):
@@ -133,5 +133,5 @@ class WorkspaceSource(Source):
 
 
 # Plugin entry point
-def setup() -> WorkspaceSource:
+def setup():
     return WorkspaceSource

--- a/tox.ini
+++ b/tox.ini
@@ -159,7 +159,11 @@ skip_install = True
 commands =
     mypy {posargs}
 deps =
-    mypy==0.730
+    mypy==0.910
+    types-protobuf
+    types-python-dateutil
+    types-setuptools
+    types-ujson
     -rrequirements/requirements.txt
     -rrequirements/dev-requirements.txt
 


### PR DESCRIPTION
mypy 0.730 is not compatible with Python 3.9, resulting in the following
bogus error message:

    src/buildstream/_cas/cascache.py:417: error: syntax error in type comment