### PR TITLE
_stream.py: Fix double pull scheduling on the same element in `bst sh…

### DIFF
--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -295,10 +295,14 @@ class Stream:
             element = self.targets[0]
             element._set_required(scope)
 
+            if scope == _Scope.BUILD:
+                pull_elements = [element] + elements
+            else:
+                pull_elements = elements
+
             # Check whether the required elements are cached, and then
             # try to pull them if they are not already cached.
             #
-            pull_elements = [element] + elements
             self.query_cache(pull_elements)
             self._pull_missing_artifacts(pull_elements)
 


### PR DESCRIPTION
…ell`

When running `bst shell --build` we need to add the toplevel element to
the dependency list for the `pull` invocation, but this is not needed
when running without the `--build` option.