### PR TITLE
requirements: Limit grpcio to >= 1.34 and < 1.39

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -84,6 +84,7 @@ disable=#####################################
         # Messages that are of no use to us #
         #####################################
         ,
+	consider-using-f-string,
         fixme,
         missing-docstring,
         no-self-use,

--- a/requirements/cov-requirements.txt
+++ b/requirements/cov-requirements.txt
@@ -1,12 +1,12 @@
 coverage==4.4
 pytest-cov==2.10.1
-pytest==6.2.4
+pytest==6.2.5
 Cython==0.29.24
 ## The following requirements were added by pip freeze:
 attrs==21.2.0
 iniconfig==1.1.1
 packaging==21.0
-pluggy==0.13.1
+pluggy==1.0.0
 py==1.10.0
-pyparsing==2.4.7
+pyparsing==3.0.3
 toml==0.10.2

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,14 +1,14 @@
 pexpect==4.8.0
-pylint==2.10.2
+pylint==2.11.1
 # Pytest 6.0.0 doesn't play well with pylint
-pytest==6.2.4
+pytest==6.2.5
 pytest-datafiles==2.0
 pytest-env==0.6.2
-pytest-xdist==2.3.0
-pytest-timeout==1.4.2
+pytest-xdist==2.4.0
+pytest-timeout==2.0.1
 pyftpdlib==1.5.6
 ## The following requirements were added by pip freeze:
-astroid==2.7.2
+astroid==2.8.4
 attrs==21.2.0
 execnet==1.9.0
 iniconfig==1.1.1
@@ -16,11 +16,12 @@ isort==5.9.3
 lazy-object-proxy==1.6.0
 mccabe==0.6.1
 packaging==21.0
-platformdirs==2.2.0
-pluggy==0.13.1
+platformdirs==2.4.0
+pluggy==1.0.0
 ptyprocess==0.7.0
 py==1.10.0
-pyparsing==2.4.7
+pyparsing==3.0.3
 pytest-forked==1.3.0
 toml==0.10.2
-wrapt==1.12.1
+typing-extensions==3.10.0.2
+wrapt==1.13.2

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,5 +1,8 @@
 Click >= 7.0
-grpcio >= 1.34
+#
+# We are experiencing crashes with grpcio >= 1.39
+#
+grpcio >= 1.34, < 1.39
 Jinja2 >= 2.10
 pluginbase
 protobuf >= 3.6

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,14 +1,15 @@
-click==8.0.1
-grpcio==1.39.0
-Jinja2==3.0.1
+click==8.0.3
+#
+grpcio==1.38.1
+Jinja2==3.0.2
 pluginbase==1.0.1
-protobuf==3.17.3
+protobuf==3.19.1
 psutil==5.8.0
-ruamel.yaml==0.17.13
+ruamel.yaml==0.17.16
 ruamel.yaml.clib==0.2.6
 setuptools==44.1.1
 pyroaring==0.3.3
-ujson==4.1.0
+ujson==4.2.0
 python-dateutil==2.8.2
 ## The following requirements were added by pip freeze:
 MarkupSafe==2.0.1

--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -206,9 +206,9 @@ def override_completions(orig_args, cmd, cmd_param, args, incomplete):
     # modifying click itself, so just do some weak special casing
     # right here and select which parameters we want to handle specially.
     if isinstance(cmd_param.type, click.Path):
-        if cmd_param.name == "elements" or cmd_param.name == "element" or cmd_param.name == "except_":
+        if cmd_param.name in ("elements", "element", "except_"):
             return complete_target(args, incomplete)
-        if cmd_param.name == "artifacts" or cmd_param.name == "target":
+        if cmd_param.name in ("artifacts", "target"):
             return complete_artifact(orig_args, args, incomplete)
 
     raise CompleteUnhandled()

--- a/src/buildstream/_signals.py
+++ b/src/buildstream/_signals.py
@@ -98,7 +98,7 @@ def terminator_handler(signal_, frame):
 #
 @contextmanager
 def terminator(terminate_func):
-    global terminator_stack  # pylint: disable=global-statement
+    global terminator_stack  # pylint: disable=global-statement,global-variable-not-assigned
 
     outermost = bool(not terminator_stack)
 
@@ -174,7 +174,7 @@ def suspend_handler(sig, frame):
 #
 @contextmanager
 def suspendable(suspend_callback, resume_callback):
-    global suspendable_stack  # pylint: disable=global-statement
+    global suspendable_stack  # pylint: disable=global-statement,global-variable-not-assigned
 
     outermost = bool(not suspendable_stack)
     assert threading.current_thread() == threading.main_thread() or not outermost

--- a/src/buildstream/utils.py
+++ b/src/buildstream/utils.py
@@ -429,7 +429,7 @@ def safe_link(src: str, dest: str, *, result: Optional[FileListResult] = None, _
         if e.errno == errno.EEXIST and not _unlink:
             # Target exists already, unlink and try again
             safe_link(src, dest, result=result, _unlink=True)
-        elif e.errno == errno.EXDEV or e.errno == errno.EPERM:
+        elif e.errno in (errno.EXDEV, errno.EPERM):
             safe_copy(src, dest)
         else:
             raise UtilError("Failed to link '{} -> {}': {}".format(src, dest, e)) from e

--- a/tests/frontend/workspace.py
+++ b/tests/frontend/workspace.py
@@ -92,8 +92,7 @@ class WorkspaceCreator:
         if suffixs is None:
             suffixs = ["",] * len(kinds)
         else:
-            if len(suffixs) != len(kinds):
-                raise "terable error"
+            assert len(suffixs) == len(kinds)
 
         for suffix, kind in zip(suffixs, kinds):
             element_name, _, workspace_dir = self.create_workspace_element(


### PR DESCRIPTION
We are experiencing segfaults with grpcio > 1.39, consistently with
python3.9 and spuriously with other versions of python too.