### PR TITLE
.github/workflows/ci.yml: Drop push trigger, add workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ name: PR Checks
 # redundant, we avoid concurrency with the below configuration.
 #
 on:
-  push:
   pull_request:
+  workflow_dispatch:
 
 # Use the concurrency feature to ensure we don't run redundant workflows
 #


### PR DESCRIPTION
Triggering the workflow on both `push` and `pull_request` leads to redundant workflow runs despite the concurrency configuration.

Drop the `push` trigger to prevent this while still triggering workflows on all pull requests (including forks).

Add the `workflow_dispatch` trigger as alternative for branches in the main repository without an open PR. The downside is that this trigger is manual.