### PR TITLE
Add Python 3.10 support and test on Fedora 35

### DIFF
--- a/.github/common.env
+++ b/.github/common.env
@@ -1,6 +1,6 @@
 # Shared common variables
 
-CI_IMAGE_VERSION=master-359695845
+CI_IMAGE_VERSION=master-402069631
 CI_TOXENV_MAIN=py36,py37,py38-nocover,py39-nocover,py310-nocover
 CI_TOXENV_PLUGINS=py36-plugins,py37-plugins,py38-plugins-nocover,py39-plugins-nocover,py310-plugins-nocover
 CI_TOXENV_ALL="${CI_TOXENV_MAIN},${CI_TOXENV_PLUGINS}"

--- a/.github/common.env
+++ b/.github/common.env
@@ -1,6 +1,6 @@
 # Shared common variables
 
 CI_IMAGE_VERSION=master-359695845
-CI_TOXENV_MAIN=py36,py37,py38-nocover,py39-nocover
-CI_TOXENV_PLUGINS=py36-plugins,py37-plugins,py38-plugins-nocover,py39-plugins-nocover
+CI_TOXENV_MAIN=py36,py37,py38-nocover,py39-nocover,py310-nocover
+CI_TOXENV_PLUGINS=py36-plugins,py37-plugins,py38-plugins-nocover,py39-plugins-nocover,py310-plugins-nocover
 CI_TOXENV_ALL="${CI_TOXENV_MAIN},${CI_TOXENV_PLUGINS}"

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 
 x-tests-template: &tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:34-${CI_IMAGE_VERSION:-latest}
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:35-${CI_IMAGE_VERSION:-latest}
     command: tox -vvvvv -- --color=yes --integration
     environment:
       TOXENV: ${CI_TOXENV_ALL}
@@ -29,6 +29,10 @@ services:
   fedora-34:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:34-${CI_IMAGE_VERSION:-latest}
+
+  fedora-35:
+    <<: *tests-template
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:35-${CI_IMAGE_VERSION:-latest}
 
   debian-10:
     <<: *tests-template

--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -105,6 +105,7 @@ if [ -z "${test_names}" ]; then
     runTest "debian-10"
     runTest "fedora-33"
     runTest "fedora-34"
+    runTest "fedora-35"
     runTest "ubuntu-18.04"
     runTest "centos-7.7.1908"
     runTest "fedora-missing-deps"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           - debian-10
           - fedora-33
           - fedora-34
+          - fedora-35
           - ubuntu-18.04
           - centos-7.7.1908
           - fedora-missing-deps

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,10 @@
 (unreleased)
 ============
 
+Core
+----
+  o BuildStream now also supports Python 3.10.
+
 Format
 ------
   o BREAKING CHANGE: Element names must now bare the `.bst` suffix and not

--- a/setup.py
+++ b/setup.py
@@ -327,6 +327,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Software Development :: Build Tools",
     ],
     description="A framework for modelling build pipelines in YAML",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # Tox global configuration
 #
 [tox]
-envlist = py{36,37},py38-nocover,py39-nocover
+envlist = py{36,37},py{38,39,310}-nocover
 skip_missing_interpreters = true
 isolated_build = true
 
@@ -18,29 +18,29 @@ BST_PLUGINS_EXPERIMENTAL_VERSION = 1.93.4
 [testenv]
 usedevelop =
     # This is required by Cython in order to get coverage for cython files.
-    py{36,37,38,39}-!nocover: True
+    py{36,37,38,39,310}-!nocover: True
 
 commands =
     # Running with coverage reporting enabled
-    py{36,37,38,39}-!plugins-!nocover: pytest --basetemp {envtmpdir} --cov=buildstream --cov-config .coveragerc {posargs}
+    py{36,37,38,39,310}-!plugins-!nocover: pytest --basetemp {envtmpdir} --cov=buildstream --cov-config .coveragerc {posargs}
     # Running with coverage reporting disabled
-    py{36,37,38,39}-!plugins-nocover: pytest --basetemp {envtmpdir} {posargs}
+    py{36,37,38,39,310}-!plugins-nocover: pytest --basetemp {envtmpdir} {posargs}
     # Running external plugins tests with coverage reporting enabled
-    py{36,37,38,39}-plugins-!nocover: pytest --basetemp {envtmpdir} --cov=buildstream --cov-config .coveragerc --plugins {posargs}
+    py{36,37,38,39,310}-plugins-!nocover: pytest --basetemp {envtmpdir} --cov=buildstream --cov-config .coveragerc --plugins {posargs}
     # Running external plugins tests with coverage disabled
-    py{36,37,38,39}-plugins-nocover: pytest --basetemp {envtmpdir} --plugins {posargs}
+    py{36,37,38,39,310}-plugins-nocover: pytest --basetemp {envtmpdir} --plugins {posargs}
 commands_post:
-    py{36,37,38,39}-!nocover: mkdir -p .coverage-reports
-    py{36,37,38,39}-!nocover: mv {envtmpdir}/.coverage {toxinidir}/.coverage-reports/.coverage.{env:COVERAGE_PREFIX:}{envname}
+    py{36,37,38,39,310}-!nocover: mkdir -p .coverage-reports
+    py{36,37,38,39,310}-!nocover: mv {envtmpdir}/.coverage {toxinidir}/.coverage-reports/.coverage.{env:COVERAGE_PREFIX:}{envname}
 deps =
-    py{36,37,38,39}: -rrequirements/requirements.txt
-    py{36,37,38,39}: -rrequirements/dev-requirements.txt
+    py{36,37,38,39,310}: -rrequirements/requirements.txt
+    py{36,37,38,39,310}: -rrequirements/dev-requirements.txt
 
     # Install local sample plugins for testing pip plugin origins
-    py{36,37,38,39}: {toxinidir}/tests/plugins/sample-plugins
+    py{36,37,38,39,310}: {toxinidir}/tests/plugins/sample-plugins
 
     # Install external plugins for plugin tests
-    py{36,37,38,39}-plugins: git+https://gitlab.com/buildstream/bst-plugins-experimental.git@{env:BST_PLUGINS_EXPERIMENTAL_VERSION:{[config]BST_PLUGINS_EXPERIMENTAL_VERSION}}#egg=bst_plugins_experimental[deb]
+    py{36,37,38,39,310}-plugins: git+https://gitlab.com/buildstream/bst-plugins-experimental.git@{env:BST_PLUGINS_EXPERIMENTAL_VERSION:{[config]BST_PLUGINS_EXPERIMENTAL_VERSION}}#egg=bst_plugins_experimental[deb]
 
     # Only require coverage and pytest-cov when using it
     !nocover: -rrequirements/cov-requirements.txt
@@ -68,17 +68,17 @@ passenv =
 # These keys are not inherited by any other sections
 #
 setenv =
-    py{36,37,38,39}: COVERAGE_FILE = {envtmpdir}/.coverage
-    py{36,37,38,39}: BST_TEST_HOME = {envtmpdir}
-    py{36,37,38,39}: BST_TEST_XDG_CACHE_HOME = {envtmpdir}/cache
-    py{36,37,38,39}: BST_TEST_XDG_CONFIG_HOME = {envtmpdir}/config
-    py{36,37,38,39}: BST_TEST_XDG_DATA_HOME = {envtmpdir}/share
+    py{36,37,38,39,310}: COVERAGE_FILE = {envtmpdir}/.coverage
+    py{36,37,38,39,310}: BST_TEST_HOME = {envtmpdir}
+    py{36,37,38,39,310}: BST_TEST_XDG_CACHE_HOME = {envtmpdir}/cache
+    py{36,37,38,39,310}: BST_TEST_XDG_CONFIG_HOME = {envtmpdir}/config
+    py{36,37,38,39,310}: BST_TEST_XDG_DATA_HOME = {envtmpdir}/share
     # This is required to get coverage for Cython
-    py{36,37,38,39}-!nocover: BST_CYTHON_TRACE = 1
+    py{36,37,38,39,310}-!nocover: BST_CYTHON_TRACE = 1
     randomized: PYTEST_ADDOPTS="--random-order-bucket=global"
 
 whitelist_externals =
-    py{36,37,38,39}:
+    py{36,37,38,39,310}:
         mv
         mkdir
 


### PR DESCRIPTION
This adds a tox test environment for Python 3.10 and expands CI to test on Fedora 35, which includes Python 3.10.