### PR TITLE
ci: update image version

### DIFF
--- a/.github/common.env
+++ b/.github/common.env
@@ -1,6 +1,6 @@
 # Shared common variables
 
-CI_IMAGE_VERSION=master-402069631
+CI_IMAGE_VERSION=master-422795815
 CI_TOXENV_MAIN=py36,py37,py38-nocover,py39-nocover,py310-nocover
 CI_TOXENV_PLUGINS=py36-plugins,py37-plugins,py38-plugins-nocover,py39-plugins-nocover,py310-plugins-nocover
 CI_TOXENV_ALL="${CI_TOXENV_MAIN},${CI_TOXENV_PLUGINS}"


### PR DESCRIPTION
See https://gitlab.com/BuildStream/buildstream-docker-images/-/merge_requests/188
(The single most important reason for the update is https://gitlab.com/BuildGrid/buildbox/buildbox-fuse/-/merge_requests/39)