### PR TITLE
Add porting guide

### DIFF
--- a/doc/source/core_plugins.rst
+++ b/doc/source/core_plugins.rst
@@ -62,8 +62,11 @@ information.
 
 External plugins
 ----------------
-External plugins need to be installed separately, here is
-a list of BuildStream plugin projects known to us at this time:
+External plugins need to be :ref:`loading through junctions <project_plugins_junction>`,
+or alternatively installed separately in the python environment where you are
+running BuildStream and loaded using the :ref:`pip method <project_plugins_pip>`.
+
+Here is a list of BuildStream plugin projects known to us at this time:
 
 * `bst-plugins-experimental <http://buildstream.gitlab.io/bst-plugins-experimental/>`_
 * `bst-plugins-container <https://pypi.org/project/bst-plugins-container/>`_

--- a/doc/source/format_declaring.rst
+++ b/doc/source/format_declaring.rst
@@ -97,7 +97,7 @@ Element naming rules
 ''''''''''''''''''''
 When naming the elements, use the following rules:
 
-* The name of the file must have ``.bst`` extension.
+* The name of the file must have the ``.bst`` extension.
 
 * All characters in the name must be printable 7-bit ASCII characters.
 

--- a/doc/source/format_project.rst
+++ b/doc/source/format_project.rst
@@ -389,8 +389,8 @@ When loading plugins from the ``pip`` plugin origin, it is possible to
 specify constraints on the versions of packages you want to load
 your plugins from.
 
-The syntax for specifying constraints are `explained here <https://python-poetry.org/docs/versions/>`_,
-and they are the same format supported by the ``pip`` package manager.
+The syntax for specifying versioning constraints is the same format supported by
+the ``pip`` package manager.
 
 .. note::
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -20,6 +20,7 @@ Later sections provide detailed information on BuildStream internals.
    main_install
    main_using
    main_core
+   main_porting.rst
    CONTRIBUTING
    main_architecture
    main_glossary

--- a/doc/source/main_porting.rst
+++ b/doc/source/main_porting.rst
@@ -1,0 +1,16 @@
+
+
+.. _main_porting:
+
+Porting guide
+=============
+This document focuses on porting your existing BuildStream 1 projects to
+using BuildStream 2.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   porting_user_configuration
+   porting_command_line
+   porting_project

--- a/doc/source/porting_command_line.rst
+++ b/doc/source/porting_command_line.rst
@@ -4,3 +4,170 @@
 
 Porting command line usage
 ==========================
+This document outlines breaking changes made to the :ref:`command line interface <commands>`
+in BuildStream 2.
+
+
+:ref:`bst init <invoking_init>`
+-------------------------------
+
+* The global ``--directory`` option is no longer observed by ``bst init``, instead
+  the command accepts an optional target directory argument.
+
+* The ``--format-version`` option has been removed in favor of the new ``--min-version`` option.
+
+
+:ref:`bst build <invoking_build>`
+---------------------------------
+
+* Tracking is no longer supported at build time and must be performed separately, this
+  removes the ``--track``, ``--track-all``, ``--track-except``, ``--track-cross-junctions``
+  and ``--track-save`` options from the command.
+
+  To track your elements in BuildStream 2, use the :ref:`bst source track <invoking_source_track>`
+  command instead.
+
+* The ``--all`` option which was used to indicate that all dependencies should be built
+  regardless of whether they are needed for producing the target elements has been removed
+  in favor of adding the ``--deps`` option.
+
+  To acheive the same functionality, use ``bst build --deps all ...``.
+
+
+:ref:`bst show <invoking_show>`
+-------------------------------
+
+* The ``plan`` value is no longer supported as a value for the ``--deps`` option.
+
+* Values for the ``%{state}`` format have changed
+
+  * :mod:`junction <elements.junction>` elements will display ``junction``, as these cannot be built
+  * In the case a cached failed build artifact is found, then ``failed`` will be displayed
+  * Due to changes in the scheduler, we may observe changes as to when ``waiting``, ``buildable``, ``fetch needed``
+    are displayed for a given element.
+
+
+:ref:`bst fetch <invoking_source_fetch>`
+----------------------------------------
+
+* This command has been removed as a top-level command and now exists as :ref:`bst source fetch <invoking_source_fetch>`
+
+* Tracking is no longer supported at fetch time and must be performed separately, this
+  removes the ``--track`` and ``--track-cross-junctions`` options from the command.
+
+  To track your elements in BuildStream 2, use the :ref:`bst source track <invoking_source_track>`
+  command instead.
+
+* The ``plan`` value is no longer supported as a value for the ``--deps`` option. The default
+  value for the ``--deps`` option is now ``none``.
+
+
+:ref:`bst track <invoking_source_track>`
+----------------------------------------
+
+* This command has been removed as a top-level command and now exists as :ref:`bst source track <invoking_source_track>`
+
+
+:ref:`bst pull <invoking_artifact_pull>`
+----------------------------------------
+
+* This command has been removed as a top-level command and now exists as :ref:`bst artifact pull <invoking_artifact_pull>`
+
+* The ``--remote`` option has been removed in favor the ``--artifact-remote`` option, which can be
+  specified multiple times.
+
+* The values which can be specified by ``--artifact-remote`` options have a new format which
+  is :ref:`documented here <invoking_specify_remotes>`.
+
+
+:ref:`bst push <invoking_artifact_push>`
+----------------------------------------
+
+* This command has been removed as a top-level command and now exists as :ref:`bst artifact push <invoking_artifact_push>`
+
+* The ``--remote`` option has been removed in favor the ``--artifact-remote`` option, which can be
+  specified multiple times.
+
+* The values which can be specified by ``--artifact-remote`` options have a new format which
+  is :ref:`documented here <invoking_specify_remotes>`.
+
+
+
+:ref:`bst checkout <invoking_artifact_checkout>`
+------------------------------------------------
+
+* This command has been removed as a top-level command and now exists as :ref:`bst artifact checkout <invoking_artifact_checkout>`
+
+* The trailing ``LOCATION`` argument has been removed in favor of a ``--directory`` option.
+
+  **BuildStream 1:**
+
+  .. code:: shell
+
+     bst checkout element.bst ~/checkout
+
+  **BuildStream 2:**
+
+  .. code:: shell
+
+     bst artifact checkout --directory ~/checkout element.bst
+
+
+:ref:`bst shell <invoking_shell>`
+---------------------------------
+
+* The ``--sysroot`` option has been completely removed.
+
+  This is no longer needed for failed builds as the build tree will be cached in a failed build artifact.
+
+* Sources and artifacts required to produce the shell environment will now be downloaded
+  automatically by default.
+
+
+:ref:`bst workspace open <invoking_workspace_open>`
+---------------------------------------------------
+
+* The ``--track`` option is now removed.
+
+* The trailing ``LOCATION`` argument has been removed in favor of a ``--directory`` option.
+
+  **BuildStream 1:**
+
+  .. code:: shell
+
+     bst workspace open element.bst ~/workspace
+
+  **BuildStream 2:**
+
+  .. code:: shell
+
+     bst workspace open --directory ~/workspace element.bst
+
+
+:ref:`bst workspace reset <invoking_workspace_reset>`
+-----------------------------------------------------
+
+* The ``--track`` option is now removed.
+
+
+:ref:`bst source-bundle <invoking_source_checkout>`
+---------------------------------------------------
+This command has been completely removed, but similar behavior can be achieved
+using the :ref:`bst source checkout <invoking_source_checkout>` command.
+
+
+**BuildStream 1:**
+
+.. code:: shell
+
+   bst source-bundle --directory ~/bundle element.bst
+
+**BuildStream 2:**
+
+.. code:: shell
+
+   bst source checkout \
+       --tar ~/sources.tgz \
+       --compression gz \
+       --include-build-scripts \
+       element.bst

--- a/doc/source/porting_command_line.rst
+++ b/doc/source/porting_command_line.rst
@@ -1,0 +1,6 @@
+
+
+.. _porting_command_line:
+
+Porting command line usage
+==========================

--- a/doc/source/porting_project.rst
+++ b/doc/source/porting_project.rst
@@ -1,0 +1,6 @@
+
+
+.. _porting_project:
+
+Porting the project.conf
+========================

--- a/doc/source/porting_project.rst
+++ b/doc/source/porting_project.rst
@@ -2,5 +2,359 @@
 
 .. _porting_project:
 
-Porting the project.conf
-========================
+Porting the project format
+==========================
+This document outlines breaking changes made to the project format in BuildStream 2.
+
+
+The project.conf
+----------------
+This section outlines breaking changes made to the :ref:`project.conf format <projectconf>`.
+
+
+Project name
+~~~~~~~~~~~~
+Various features related to :mod:`junction <elements.junction>` elements have been added
+which allow addressing projects by their :ref:`project names <project_format_name>`. For this
+reason, it is important to ensure that your project names are appropriately unique.
+
+
+Project versioning
+~~~~~~~~~~~~~~~~~~
+Instead of maintaining a separate version number for the format and for BuildStream releases,
+projects now declare the minimum version of BuildStream 2 they depend on.
+
+The ``format-version`` attribute should be removed from your project.conf (if present) and
+the :ref:`min-version <project_min_version>` attribute must be added.
+
+
+Some attributes can only be specified in project.conf
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Whenever specifying any of the following toplevel project attributes, they must be
+specified inside the project.conf itself and cannot be :ref:`included <format_directives_include>`
+from a separate file:
+
+* :ref:`name <project_format_name>`
+* :ref:`element-path <project_element_path>`
+* :ref:`min-version <project_min_version>`
+* :ref:`plugins <project_plugins>`
+
+
+Artifact cache configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The format for declaring :ref:`artifact caches <project_artifact_cache>` which are associated to
+your project have been completely redesigned.
+
+**BuildStream 1:**
+
+.. code:: yaml
+
+   #
+   # We used to specify a single URL
+   #
+   artifacts:
+     url: https://foo.com/artifacts
+
+**BuildStream 2:**
+
+.. code:: yaml
+
+   #
+   # Now we declare a list, and credentials have been split
+   # out into a separate "auth" dictionary
+   #
+   artifacts:
+   - url: https://foo.com:11001
+     auth:
+       server-cert: server.crt
+
+
+Loading plugins
+~~~~~~~~~~~~~~~
+The format for :ref:`loading plugins <project_plugins>` has been completely redesigned.
+
+.. tip::
+
+   A new method for :ref:`loading plugins through junctions <project_plugins_junction>`
+   has been added. In the interest of ensuring strong determinism and reliability it is
+   strongly recommended to use this new method.
+
+
+Local plugins
+'''''''''''''
+Here is an example of how loading :ref:`local plugins <project_plugins_local>` has changed.
+
+**BuildStream 1:**
+
+.. code:: yaml
+
+   plugins:
+
+   - origin: local
+     path: plugins/sources
+
+     #
+     # We used to specify version numbers, these no longer exist.
+     #
+     sources:
+       mysource: 0
+
+**BuildStream 2:**
+
+.. code:: yaml
+
+   plugins:
+
+   - origin: local
+     path: plugins/sources
+
+     #
+     # Now we merely specify a list of plugins to load from
+     # a given project local directory
+     #
+     sources:
+     - mysource
+
+
+Pip plugins
+'''''''''''
+Here is an example of how loading :ref:`pip plugins <project_plugins_pip>` has changed.
+
+**BuildStream 1:**
+
+.. code:: yaml
+
+   plugins:
+
+   - origin: pip
+
+     package-name: vegetables
+
+     #
+     # We used to specify version numbers, these no longer exist.
+     #
+     elements:
+       potato: 0
+
+**BuildStream 2:**
+
+.. code:: yaml
+
+   plugins:
+
+   - origin: pip
+
+     #
+     # We can now specify version constraints
+     #
+     package-name: vegetables>=1.2
+
+     #
+     # Now we merely specify a list of plugins to load from
+     # a given pip package that is expected to be installed
+     #
+     elements:
+     - potato
+
+
+Core elements
+-------------
+This section outlines breaking changes made to :ref:`core element plugins <plugins>` which
+may require you to make changes to your project.
+
+
+The :mod:`stack <elements.stack>` element
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Stack elements dependencies are now hard required to be both build and runtime dependencies.
+
+
+The :mod:`script <elements.script>` element
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``layout`` attribute has now been removed in favor of dependency level configuration.
+
+Here is an example script which collects a manifest of all files in the hypothetical
+``system.bst`` element, using a hypothetical base runtime element ``base-utilities.bst``.
+
+**BuildStream 1:**
+
+.. code:: yaml
+
+   kind: script
+
+   build-depends:
+   - base-utilities.bst
+   - system.bst
+
+   config:
+     #
+     # The old format was redundant and required explicit layout
+     # of the dependencies already declared above.
+     #
+     layout:
+     - element: base-utilities.bst
+       destination: /
+     - element: system.bst
+       destination: "%{build-root}"
+
+     commands:
+     - find %{build-root} > %{install-root}/manifest.log
+
+**BuildStream 2:**
+
+.. code:: yaml
+
+   kind: script
+
+   #
+   # The default location is "/" so there is no need to configure
+   # the "base-utilities.bst" dependency
+   #
+   build-depends:
+   - base-utilities.bst
+   - system.bst
+     config:
+       location: "%{build-root}"
+
+   config:
+     commands:
+     - find %{build-root} > %{install-root}/manifest.log
+
+.. tip::
+
+   The ``location`` dependency level configuration is also supported by all
+   :mod:`BuildElement <buildstream.buildelement>` plugins.
+
+
+The :mod:`junction <elements.junction>` element
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The YAML format for declaring junctions has not changed, however the way that
+multiple junctions interact in a loaded pipeline has changed significantly.
+
+Specifically, the :ref:`element name <format_element_names>` used to declare
+a junction no longer has any special significance, whereas in BuildStream 1
+the junction's name is used to coalesce matching junctions in subprojects.
+
+BuildStream 2 offers more flexibility in this regard, and allows you to *inherit*
+a junction from a subproject, by using a :mod:`link <elements.link>` element directly
+in place of a junction, and/or explicitly override the configuration of a subproject's
+junction using the new ``overrides`` configuration attribute which the junction
+element now provides.
+
+Consult the :mod:`junction <elements.junction>` element documentation for a more
+detailed explanation.
+
+
+Migrated plugins
+----------------
+A majority of the plugins which used to be considered core plugins have been removed
+from BuildStream in favor of a more modular and distributed approach. The remaining
+core plugins are :ref:`documented here <plugins>`.
+
+Any core plugins which you have been using in BuildStream 1 which have been migrated
+to separate repositories will need to be accessed externally.
+
++---------------+----------------------------------------------------------------------------------+
+| Plugin        | New location                                                                     |
++===============+==================================================================================+
+| **Element plugins**                                                                              |
++---------------+----------------------------------------------------------------------------------+
+| make          | `bst-plugins-experimental <https://pypi.org/project/bst-plugins-experimental/>`_ |
++---------------+----------------------------------------------------------------------------------+
+| cmake         | `bst-plugins-experimental <https://pypi.org/project/bst-plugins-experimental/>`_ |
++---------------+----------------------------------------------------------------------------------+
+| qmake         | `bst-plugins-experimental <https://pypi.org/project/bst-plugins-experimental/>`_ |
++---------------+----------------------------------------------------------------------------------+
+| distutils     | `bst-plugins-experimental <https://pypi.org/project/bst-plugins-experimental/>`_ |
++---------------+----------------------------------------------------------------------------------+
+| makemaker     | `bst-plugins-experimental <https://pypi.org/project/bst-plugins-experimental/>`_ |
++---------------+----------------------------------------------------------------------------------+
+| modulebuild   | `bst-plugins-experimental <https://pypi.org/project/bst-plugins-experimental/>`_ |
++---------------+----------------------------------------------------------------------------------+
+| meson         | `bst-plugins-experimental <https://pypi.org/project/bst-plugins-experimental/>`_ |
++---------------+----------------------------------------------------------------------------------+
+| pip           | `bst-plugins-experimental <https://pypi.org/project/bst-plugins-experimental/>`_ |
++---------------+----------------------------------------------------------------------------------+
+| **Source plugins**                                                                               |
++---------------+----------------------------------------------------------------------------------+
+| ostree        | `bst-plugins-experimental <https://pypi.org/project/bst-plugins-experimental/>`_ |
++---------------+----------------------------------------------------------------------------------+
+| deb           | `bst-plugins-experimental <https://pypi.org/project/bst-plugins-experimental/>`_ |
++---------------+----------------------------------------------------------------------------------+
+
+.. attention::
+
+   **YAML composition with externally loaded plugins**
+
+   Note that when :ref:`YAML composition <format_composition>` occurs with plugins loaded
+   from external projects, the *plugin defaults* will be composited with *your project.conf*
+   and not with the project.conf originating in the external project containing the plugin.
+
+
+Example of externally loaded plugin
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+It is recommended to transition directly :ref:`loading these plugins through junctions <project_plugins_junction>`,
+which can be done as follows.
+
+
+Create an alias for PyPI in your project.conf
+'''''''''''''''''''''''''''''''''''''''''''''
+
+.. code:: yaml
+
+   aliases:
+     pypi: https://files.pythonhosted.org/packages/
+
+
+Create bst-plugins-experimental-junction.bst
+''''''''''''''''''''''''''''''''''''''''''''
+Create a junction which accesses the release tarball of the plugin repository.
+
+.. code:: yaml
+
+   kind: junction
+   sources:
+     kind: tar
+     url: pypi:83/dd/dc9dfe4c5054f46b1385707e3c286fccc72c9c71ef1b133677e2dbb28ffc/bst-plugins-experimental-1.93.6.tar.gz
+     ref: b20fff88f800da3ab6a666031bb13b4c3f7df0f8fe6943848717efa0d43ac990
+
+
+Declare the plugin you want to use in your project.conf
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''
+This will make the ``make`` and ``meson`` element plugins from the ``bst-plugins-experimental``
+project available for use in your project.
+
+.. code:: yaml
+
+   plugins:
+   - origin: junction
+     junction: bst-plugins-experimental-junction.bst
+     elements:
+     - make
+     - meson
+
+
+Miscellaneous
+-------------
+Here we list some miscellaneous breaking changes to the format in general.
+
+
+Element naming
+~~~~~~~~~~~~~~
+The names of elements have :ref:`become more restrictive <format_element_names>`, for example
+they must have the ``.bst`` extension.
+
+
+Overlap whitelist
+~~~~~~~~~~~~~~~~~
+The :ref:`overlap whitelist <public_overlap_whitelist>`, which is the public data
+found on elements which indicate which files an element can overwrite, must now
+be expressed with absolute paths.
+
+
+Strip commands
+~~~~~~~~~~~~~~
+The default ``strip-commands`` which :mod:`BuildElement <buildstream.buildelement>` implementations
+use to split out debug symbols from binaries have been removed.
+
+This can be solved by declaring a value for the ``%{strip-binaries}`` variable which
+will be used for this purpose.

--- a/doc/source/porting_user_configuration.rst
+++ b/doc/source/porting_user_configuration.rst
@@ -1,0 +1,6 @@
+
+
+.. _porting_user_configuration:
+
+Porting the buildstream.conf
+============================

--- a/doc/source/porting_user_configuration.rst
+++ b/doc/source/porting_user_configuration.rst
@@ -4,3 +4,42 @@
 
 Porting the buildstream.conf
 ============================
+This document outlines breaking changes made to the :ref:`user configuration <user_config>`
+in BuildStream 2.
+
+
+Filename and parallel installation
+----------------------------------
+The default filename to load user configuration remains unchanged, however,
+if you plan to install and use both versions of BuildStream on the same
+host, it is recommended to keep your BuildStream 2 configuration in a
+file named ``buildstream2.conf``.
+
+
+Working directories
+-------------------
+The ``builddir`` and ``artifactdir`` have been removed in favor of the new ``cachedir``.
+
+
+BuildStream 1:
+~~~~~~~~~~~~~~
+
+.. code:: yaml
+
+   builddir: ${XDG_CACHE_HOME}/buildstream/build
+   artifactdir: ${XDG_CACHE_HOME}/buildstream/artifacts
+
+
+BuildStream 2:
+~~~~~~~~~~~~~~
+
+.. code:: yaml
+
+   cachedir: ${XDG_CACHE_HOME}/buildstream/cache
+
+
+Remote cache configuration
+--------------------------
+The configuration for remote artifact caches has been completely
+redesigned, please refer to the :ref:`artifact cache configuration documentation <config_artifact_caches>`
+for details on how to configure remotes in BuildStream 2.

--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -958,7 +958,7 @@ def source_track(app, elements, deps, except_, cross_junctions):
     default=None,
     metavar="LOCATION",
     type=click.Path(),
-    help="Create a tarball containing the sources instead " "of a file tree.",
+    help="Create a tarball containing the sources instead of a file tree.",
 )
 @click.option(
     "--compression",


### PR DESCRIPTION
This branch adds a porting guide for porting your projects from BuildStream 1 to BuildStream 2.
