### PR TITLE
data/projectconfig.yaml: Syncrhonize SOURCE_DATE_EPOCH

### DIFF
--- a/src/buildstream/data/projectconfig.yaml
+++ b/src/buildstream/data/projectconfig.yaml
@@ -56,8 +56,8 @@ environment:
   HOME: /tmp
   TZ: UTC
 
-  # For reproducible builds we use 2011-11-11 as a constant
-  SOURCE_DATE_EPOCH: 1320937200
+  # For reproducible builds we use 2011-11-11 UTC as a constant
+  SOURCE_DATE_EPOCH: 1320969600
 
 # List of environment variables which should not be taken into
 # account when calculating a cache key for a given element.


### PR DESCRIPTION
This was intended to be equal to BST_ARBITRARY_TIMESTAMP at 2011-11-11,
but was erronously set to 3pm UTC (and midnight korea time).

Fixes #1384