### PR TITLE
data/projectconfig.yaml: Fix previous fix of SOURCE_DATE_EPOCH

### DIFF
--- a/src/buildstream/data/projectconfig.yaml
+++ b/src/buildstream/data/projectconfig.yaml
@@ -56,8 +56,8 @@ environment:
   HOME: /tmp
   TZ: UTC
 
-  # For reproducible builds we use 2011-11-11 UTC as a constant
-  SOURCE_DATE_EPOCH: 1320969600
+  # For reproducible builds we use 2011-11-11 11:11:11 UTC as a constant
+  SOURCE_DATE_EPOCH: 1321009871
 
 # List of environment variables which should not be taken into
 # account when calculating a cache key for a given element.


### PR DESCRIPTION
I didn't notice the BST_ARBITRARY_TIMESTAMP was using 11:11:11 in the morning
and had omitted this part from the derived UTC posix timestamp.

Fixes #1384 again.