### PR TITLE
Fix shutdown of test server

### DIFF
--- a/src/buildstream/_cas/casserver.py
+++ b/src/buildstream/_cas/casserver.py
@@ -147,6 +147,7 @@ def create_server(repo, *, enable_push, quota, index_only, log_level=LogLevel.Le
             yield server
 
     finally:
+        casd_channel.request_shutdown()
         casd_channel.close()
         casd_manager.release_resources()
 


### PR DESCRIPTION
buildbox-casd processes used by test servers were not terminated and kept running after the end of the tests (or crashed because the test deleted the directories used by buildbox-casd).