### PR TITLE
use ruamel-yaml < 0.17 

### DIFF
--- a/requirements/cov-requirements.txt
+++ b/requirements/cov-requirements.txt
@@ -7,5 +7,5 @@ packaging==21.3
 pluggy==1.0.0
 py==1.11.0
 pyparsing==3.0.7
-pytest==7.0.0
+pytest==7.0.1
 tomli==2.0.1

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,6 +1,6 @@
 pep8==1.7.1
 pylint==2.12.2
-pytest==7.0.0
+pytest==7.0.1
 pytest-datafiles==2.0
 pytest-env==0.6.2
 pytest-xdist==2.5.0
@@ -15,12 +15,12 @@ isort==5.10.1
 lazy-object-proxy==1.7.1
 mccabe==0.6.1
 packaging==21.3
-platformdirs==2.4.1
+platformdirs==2.5.0
 pluggy==1.0.0
 py==1.11.0
 pyparsing==3.0.7
 pytest-forked==1.4.0
 toml==0.10.2
 tomli==2.0.1
-typing_extensions==4.0.1
+typing_extensions==4.1.1
 wrapt==1.13.3

--- a/requirements/plugin-requirements.txt
+++ b/requirements/plugin-requirements.txt
@@ -1,1 +1,2 @@
 arpy==2.2.0
+## The following requirements were added by pip freeze:

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -4,6 +4,6 @@ jinja2 >= 2.10
 pluginbase
 protobuf >= 3.6
 psutil
-ruamel.yaml >= 0.16
+ruamel.yaml < 0.17
 setuptools
 ujson

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,7 +4,7 @@ Jinja2==3.0.3
 pluginbase==1.0.1
 protobuf==3.19.4
 psutil==5.9.0
-ruamel.yaml==0.17.20
+ruamel.yaml==0.16.13
 setuptools==59.6.0
 ujson==5.1.0
 ## The following requirements were added by pip freeze:


### PR DESCRIPTION
somewhere in the 0.17 series, ruamel.yaml broke round-tripping for the old API (See #1495)

