### PR TITLE
sandbox/_sandboxbwrap.py: don't try to delete symlinks as directories

### DIFF
--- a/buildstream/sandbox/_sandboxbwrap.py
+++ b/buildstream/sandbox/_sandboxbwrap.py
@@ -201,7 +201,7 @@ class SandboxBwrap(Sandbox):
         # there just in case so that we can safely cleanup the debris.
         #
         existing_basedirs = {
-            directory: os.path.exists(os.path.join(root_directory, directory))
+            directory: os.path.lexists(os.path.join(root_directory, directory))
             for directory in ['dev/shm', 'tmp', 'dev', 'proc']
         }
 


### PR DESCRIPTION
This prevents breaking projects that have workarounds for it