### PR TITLE
fuse: Pass through the underlying filesystem's inode numbers

### DIFF
--- a/buildstream/_fuse/hardlinks.py
+++ b/buildstream/_fuse/hardlinks.py
@@ -126,11 +126,11 @@ class SafeHardlinkOps(Operations):
     def readdir(self, path, fh):
         full_path = self._full_path(path)
 
-        dirents = ['.', '..']
+        dir_entries = ['.', '..']
         if os.path.isdir(full_path):
-            dirents.extend(os.listdir(full_path))
-        for r in dirents:
-            yield r
+            dir_entries.extend(os.listdir(full_path))
+        for entry in dir_entries:
+            yield entry
 
     def readlink(self, path):
         pathname = os.readlink(self._full_path(path))

--- a/buildstream/_fuse/hardlinks.py
+++ b/buildstream/_fuse/hardlinks.py
@@ -121,7 +121,8 @@ class SafeHardlinkOps(Operations):
         st = os.lstat(full_path)
         return dict((key, getattr(st, key)) for key in (
             'st_atime', 'st_ctime', 'st_gid', 'st_mode',
-            'st_mtime', 'st_nlink', 'st_size', 'st_uid'))
+            'st_mtime', 'st_nlink', 'st_size', 'st_uid',
+            'st_ino'))
 
     def readdir(self, path, fh):
         full_path = self._full_path(path)
@@ -130,7 +131,13 @@ class SafeHardlinkOps(Operations):
         if os.path.isdir(full_path):
             dir_entries.extend(os.listdir(full_path))
         for entry in dir_entries:
-            yield entry
+            entry_full_path = os.path.join(full_path, entry)
+            st = os.stat(entry_full_path, follow_symlinks=False)
+
+            attrs = dict((key, getattr(st, key)) for key in (
+                'st_ino', 'st_mode'))
+
+            yield entry, attrs, 0
 
     def readlink(self, path):
         pathname = os.readlink(self._full_path(path))

--- a/buildstream/_fuse/mount.py
+++ b/buildstream/_fuse/mount.py
@@ -184,7 +184,7 @@ class Mount():
         # Run fuse in foreground in this child process, internally libfuse
         # will handle SIGTERM and gracefully exit it's own little main loop.
         #
-        FUSE(self.__operations, self.__mountpoint, nothreads=True, foreground=True)
+        FUSE(self.__operations, self.__mountpoint, nothreads=True, foreground=True, use_ino=True)
 
         # Explicit 0 exit code, if the operations crashed for some reason, the exit
         # code will not be 0, and we want to know about it.


### PR DESCRIPTION
This PR fixes the following issue detected by `gnulib`:
```
...
checking whether this system has an arbitrary file name length limit... yes
checking for d_ino member in directory struct... no
```
See commit messages for more information.