### PR TITLE
Fix `MappingNode._composite()`

### DIFF
--- a/src/buildstream/node.pyx
+++ b/src/buildstream/node.pyx
@@ -446,7 +446,7 @@ cdef class ScalarNode(Node):
                                        self.get_provenance(),
                                        target_value.get_provenance()))
 
-        target.value[key] = self
+        target.value[key] = self.clone()
 
     cdef bint _is_composite_list(self) except *:
         return False
@@ -973,7 +973,7 @@ cdef class MappingNode(Node):
         if self._is_composite_list():
             if key not in target.value:
                 # Composite list clobbers empty space
-                target.value[key] = self
+                target.value[key] = self.clone()
             else:
                 target_value = target.value[key]
 
@@ -1420,7 +1420,7 @@ cdef class SequenceNode(Node):
             (<SequenceNode> target.value[key]).value.extend(self.value)
         else:
             # Looks good, clobber it
-            target.value[key] = self
+            target.value[key] = self.clone()
 
     cdef bint _is_composite_list(self) except *:
         return False

--- a/tests/format/variables/notparallel/notparallel.bst
+++ b/tests/format/variables/notparallel/notparallel.bst
@@ -1,0 +1,4 @@
+kind: custom
+
+variables:
+  notparallel: true

--- a/tests/format/variables/notparallel/parallel.bst
+++ b/tests/format/variables/notparallel/parallel.bst
@@ -1,0 +1,4 @@
+kind: custom
+
+depends:
+- notparallel.bst

--- a/tests/format/variables/notparallel/plugins/custom.py
+++ b/tests/format/variables/notparallel/plugins/custom.py
@@ -1,0 +1,12 @@
+from buildstream import BuildElement
+
+
+# A custom build element
+class CustomElement(BuildElement):
+
+    BST_MIN_VERSION = "2.0"
+
+
+# Plugin entry point
+def setup():
+    return CustomElement

--- a/tests/format/variables/notparallel/plugins/custom.yaml
+++ b/tests/format/variables/notparallel/plugins/custom.yaml
@@ -1,0 +1,10 @@
+#
+# This element tests an odd corner case we've discovered with
+# elements which use the `%{max-jobs}` to substitute a nocache
+# environment variable.
+#
+environment:
+  MAKEFLAGS: -j%{max-jobs}
+
+environment-nocache:
+- MAKEFLAGS

--- a/tests/format/variables/notparallel/project.conf
+++ b/tests/format/variables/notparallel/project.conf
@@ -1,0 +1,13 @@
+# Basic project configuration that doesnt override anything
+#
+name: zebra
+min-version: 2.0
+
+variables:
+  notparallel: false
+
+plugins:
+- origin: local
+  path: plugins
+  elements:
+  - custom


### PR DESCRIPTION
This branch fixes `Node._composite()` so that mutable data in the *source* nodes are no longer given away to the composite *target*, leaving the *source* vulnerable to later mutations when the *target* is mutated. Instead clones of source values are provided when they are composited onto a target node.
