### PR TITLE
Let me use riscv architecture options.

### DIFF
--- a/src/buildstream/_platform/platform.py
+++ b/src/buildstream/_platform/platform.py
@@ -111,6 +111,8 @@ class Platform:
             "powerpc64le": "power-isa-le",  # Used in GCC/LLVM
             "ppc64": "power-isa-be",
             "ppc64le": "power-isa-le",
+            "riscv32": "riscv32",
+            "riscv64": "riscv64",
             "sparc": "sparc-v9",
             "sparc64": "sparc-v9",
             "sparc-v9": "sparc-v9",


### PR DESCRIPTION
This change adds riscv32 and riscv64 to the list of possible values
for the architecture option type.

NOTE: This has originally submitted by https://github.com/robjh at https://gitlab.com/BuildStream/buildstream/-/merge_requests/2087

I only open this here again as this is blocking freedesktop-sdk to be compiled in RISC-V (works ok with bst-1): https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/jobs/2012261945

Fixes #1578 