### PR TITLE
.github: Explicitly set job timeouts to 4 hours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
   tests:
     runs-on: ubuntu-20.04
     continue-on-error: ${{ matrix.allow-failure || false }}
+    timeout-minutes: 240
 
     strategy:
       fail-fast: false
@@ -63,6 +64,7 @@ jobs:
   # Matrix of tests which run against remote services which we bring up adjacently
   service-tests:
     runs-on: ubuntu-20.04
+    timeout-minutes: 240
 
     strategy:
       matrix:
@@ -87,6 +89,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-20.04
+    timeout-minutes: 240
     steps:
       - name: Check out repository
         uses: actions/checkout@v2

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     name: Build documentation
     runs-on: ubuntu-20.04
+    timeout-minutes: 240
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -45,6 +46,7 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-20.04
+    timeout-minutes: 240
     steps:
 
     - name: Download artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     name: Upload Release Asset
     runs-on: ubuntu-20.04
+    timeout-minutes: 240
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Given that the runners have a tendency to be fairly crappy, what
takes about 20min to run on your typical laptop ends up taking over
an hour in CI.

Lets not take any chances and bump the timeout to 4 hours across the board.