### PR TITLE
Stop running CI for distro versions with Python 3.6

### DIFF
--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -34,14 +34,6 @@ services:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-debian:10-${CI_IMAGE_VERSION:-latest}
 
-  ubuntu-18.04:
-    <<: *tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-ubuntu:18.04-${CI_IMAGE_VERSION:-latest}
-
-  centos-7.7.1908:
-    <<: *tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-centos:7.7.1908-${CI_IMAGE_VERSION:-latest}
-
   docs:
     <<: *tests-template
     command: tox -e docs

--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -69,8 +69,6 @@ if [ -z "${test_names}" ]; then
     runTest "debian-10"
     runTest "fedora-34"
     runTest "fedora-35"
-    runTest "ubuntu-18.04"
-    runTest "centos-7.7.1908"
 else
     for test_name in "${test_names}"; do
 	runTest "${test_name}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
           - debian-10
           - fedora-34
           - fedora-35
-          - ubuntu-18.04
-          - centos-7.7.1908
           - lint
 
     steps:

--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,9 @@ buildstream 1.6.4
 
   o script element plugin now supports `create-dev-shm`
 
+  o Python 3.6 is no longer tested in CI but support is maintained on
+    best effort level.
+
 =================
 buildstream 1.6.3
 =================


### PR DESCRIPTION
This does not drop Python 3.6 support and fixes for Python 3.6 compatibility are accepted.
Part of https://github.com/apache/buildstream/issues/1588