### PR TITLE
Remove SandboxFlags from public API surface

### DIFF
--- a/src/buildstream/__init__.py
+++ b/src/buildstream/__init__.py
@@ -28,7 +28,7 @@ if "_BST_COMPLETION" not in os.environ:
     del get_versions
 
     from .utils import UtilError, ProgramNotFoundError
-    from .sandbox import Sandbox, SandboxFlags, SandboxCommandError
+    from .sandbox import Sandbox, SandboxCommandError
     from .storage import Directory
     from .types import CoreWarnings, OverlapAction
     from .node import MappingNode, Node, ProvenanceInformation, ScalarNode, SequenceNode

--- a/src/buildstream/buildelement.py
+++ b/src/buildstream/buildelement.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2016 Codethink Limited
+#  Copyright (C) 2022 Codethink Limited
 #  Copyright (C) 2018 Bloomberg Finance LP
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -171,7 +171,6 @@ artifact collection purposes.
 import os
 
 from .element import Element
-from .sandbox import SandboxFlags
 
 
 _command_steps = ["configure-commands", "build-commands", "install-commands", "strip-commands"]
@@ -287,7 +286,7 @@ class BuildElement(Element):
         root_list = self.__layout.get("/", None)
         if root_list:
             element_list = [element for element, _ in root_list]
-            with self.timed_activity("Integrating sandbox", silent_nested=True), sandbox.batch(SandboxFlags.NONE):
+            with self.timed_activity("Integrating sandbox", silent_nested=True), sandbox.batch():
                 for dep in self.dependencies(element_list):
                     dep.integrate(sandbox)
 
@@ -301,7 +300,7 @@ class BuildElement(Element):
             if not commands or command_name == "configure-commands":
                 continue
 
-            with sandbox.batch(SandboxFlags.ROOT_READ_ONLY, label="Running {}".format(command_name)):
+            with sandbox.batch(root_read_only=True, label="Running {}".format(command_name)):
                 for cmd in commands:
                     self.__run_command(sandbox, cmd)
 
@@ -347,7 +346,7 @@ class BuildElement(Element):
                 # Already prepared
                 return
 
-        with sandbox.batch(SandboxFlags.ROOT_READ_ONLY, label="Running configure-commands"):
+        with sandbox.batch(root_read_only=True, label="Running configure-commands"):
             for cmd in commands:
                 self.__run_command(sandbox, cmd)
 
@@ -371,4 +370,4 @@ class BuildElement(Element):
         # Note the -e switch to 'sh' means to exit with an error
         # if any untested command fails.
         #
-        sandbox.run(["sh", "-c", "-e", cmd + "\n"], SandboxFlags.ROOT_READ_ONLY, label=cmd)
+        sandbox.run(["sh", "-c", "-e", cmd + "\n"], root_read_only=True, label=cmd)

--- a/src/buildstream/plugins/elements/autotools.py
+++ b/src/buildstream/plugins/elements/autotools.py
@@ -54,7 +54,7 @@ See :ref:`built-in functionality documentation <core_buildelement_builtins>` for
 details on common configuration options for build elements.
 """
 
-from buildstream import BuildElement, SandboxFlags
+from buildstream import BuildElement
 
 
 # Element implementation for the 'autotools' kind.
@@ -66,7 +66,7 @@ class AutotoolsElement(BuildElement):
     # Enable command batching across prepare() and assemble()
     def configure_sandbox(self, sandbox):
         super().configure_sandbox(sandbox)
-        self.batch_prepare_assemble(SandboxFlags.ROOT_READ_ONLY, collect=self.get_variable("install-root"))
+        self.batch_prepare_assemble(root_read_only=True, collect=self.get_variable("install-root"))
 
 
 # Plugin entry point

--- a/src/buildstream/plugins/elements/compose.py
+++ b/src/buildstream/plugins/elements/compose.py
@@ -114,7 +114,7 @@ class ComposeElement(Element):
                     snapshot = set(vbasedir.list_relative_paths())
                     vbasedir.mark_unmodified()
 
-                with sandbox.batch(0):
+                with sandbox.batch():
                     for dep in self.dependencies():
                         dep.integrate(sandbox)
 

--- a/src/buildstream/plugins/elements/manual.py
+++ b/src/buildstream/plugins/elements/manual.py
@@ -30,7 +30,7 @@ See :ref:`built-in functionality documentation <core_buildelement_builtins>` for
 details on common configuration options for build elements.
 """
 
-from buildstream import BuildElement, SandboxFlags
+from buildstream import BuildElement
 
 
 # Element implementation for the 'manual' kind.
@@ -42,7 +42,7 @@ class ManualElement(BuildElement):
     # Enable command batching across prepare() and assemble()
     def configure_sandbox(self, sandbox):
         super().configure_sandbox(sandbox)
-        self.batch_prepare_assemble(SandboxFlags.ROOT_READ_ONLY, collect=self.get_variable("install-root"))
+        self.batch_prepare_assemble(root_read_only=True, collect=self.get_variable("install-root"))
 
 
 # Plugin entry point

--- a/src/buildstream/sandbox/__init__.py
+++ b/src/buildstream/sandbox/__init__.py
@@ -1,5 +1,5 @@
 #
-#  Copyright (C) 2017 Codethink Limited
+#  Copyright (C) 2022 Codethink Limited
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 #  Authors:
 #        Tristan Maat <tristan.maat@codethink.co.uk>
 
-from .sandbox import Sandbox, SandboxFlags, SandboxCommandError
+from .sandbox import Sandbox, SandboxCommandError
+from .sandbox import _SandboxFlags
 from ._sandboxremote import SandboxRemote
 from ._sandboxdummy import SandboxDummy

--- a/src/buildstream/sandbox/_sandboxbuildboxrun.py
+++ b/src/buildstream/sandbox/_sandboxbuildboxrun.py
@@ -22,7 +22,7 @@ from contextlib import ExitStack
 import psutil
 
 from .. import utils, _signals
-from . import SandboxFlags
+from . import _SandboxFlags
 from .._exceptions import SandboxError
 from .._platform import Platform
 from .._protos.build.bazel.remote.execution.v2 import remote_execution_pb2
@@ -121,7 +121,7 @@ class SandboxBuildBoxRun(SandboxREAPI):
             # If we're interactive, we want to inherit our stdin,
             # otherwise redirect to /dev/null, ensuring process
             # disconnected from terminal.
-            if flags & SandboxFlags.INTERACTIVE:
+            if flags & _SandboxFlags.INTERACTIVE:
                 stdin = sys.stdin
 
                 if "bind-mount" in self._capabilities:
@@ -132,7 +132,7 @@ class SandboxBuildBoxRun(SandboxREAPI):
                 stdin = subprocess.DEVNULL
 
             self._run_buildbox(
-                buildbox_command, stdin, stdout, stderr, interactive=(flags & SandboxFlags.INTERACTIVE),
+                buildbox_command, stdin, stdout, stderr, interactive=(flags & _SandboxFlags.INTERACTIVE),
             )
 
             return remote_execution_pb2.ActionResult().FromString(result_file.read())

--- a/src/buildstream/sandbox/_sandboxdummy.py
+++ b/src/buildstream/sandbox/_sandboxdummy.py
@@ -24,7 +24,7 @@ class SandboxDummy(Sandbox):
         super().__init__(*args, **kwargs)
         self._reason = kwargs.get("dummy_reason", "no reason given")
 
-    def _run(self, command, flags, *, cwd, env):
+    def _run(self, command, *, flags, cwd, env):
 
         if not self._has_command(command[0], env):
             raise SandboxCommandError(


### PR DESCRIPTION
The SandboxFlags expose internal details that are not suitable for
consumption by plugin authors.

Change summary:

  * sandbox/sandbox.py: Remove SandboxFlags as argument in public API
    surfaces, and expose a boolean `root_read_only` argument instead,
    while providing an internal `Sandbox._run_with_flags()` API for
    internal use.

  * __init__.py, sandbox/__init__.py:
    Updated to remove SandboxFlags from public API

  * buildelement.py, scriptelement.py, plugins/elements/autotools.py,
    plugins/elements/compose.py, plugins/elements/manual.py:
    Stop using SandboxFlags, use `root_read_only` parameter instead.

  * element.py: Adapt to API changes, use internal `_run_with_flags()` only
    for special cases such as running shells.

  * sandbox/_sandboxbuildboxrun.py, sandbox/_sandboxdummy.py,
    sandbox/_sandboxreapi.py: Adapt to API changes

Fixes #265