### PR TITLE
sandbox/sandbox.py: Remove DEVICES variable

### DIFF
--- a/src/buildstream/sandbox/sandbox.py
+++ b/src/buildstream/sandbox/sandbox.py
@@ -71,7 +71,6 @@ class Sandbox:
     """
 
     # Minimal set of devices for the sandbox
-    DEVICES = ["/dev/urandom", "/dev/random", "/dev/zero", "/dev/null"]
     _dummy_reasons = []  # type: List[str]
 
     def __init__(self, context: "Context", project: "Project", directory: str, **kwargs):


### PR DESCRIPTION
This is completely unused, and shows up in the public API surface.