### PR TITLE
.github/run-ci.sh: Fix test suite to properly fail in CI

### DIFF
--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -97,7 +97,7 @@ function runServiceTest() {
 
 # Lazily ensure that the script exits when a command fails
 #
-set -x
+set -e
 
 if [ -z "${test_names}" ]; then
     runTest "lint"


### PR DESCRIPTION
Silly typo was causing tests to pass even when they fail.