### PR TITLE
source.py: Split up staging functions into separate codepaths.

### DIFF
--- a/src/buildstream/plugins/sources/local.py
+++ b/src/buildstream/plugins/sources/local.py
@@ -90,7 +90,7 @@ class LocalSource(Source):
         # Nothing to do here for a local source
         pass  # pragma: nocover
 
-    def stage(self, directory):
+    def stage_directory(self, directory):
         #
         # We've already prepared the CAS while resolving the cache key which
         # will happen before staging.
@@ -102,7 +102,7 @@ class LocalSource(Source):
         with self._cache_directory(digest=self.__digest) as cached_directory:
             directory.import_files(cached_directory)
 
-    def init_workspace(self, directory):
+    def init_workspace_directory(self, directory):
         #
         # FIXME: We should be able to stage the workspace from the content
         #        cached in CAS instead of reimporting from the filesystem

--- a/src/buildstream/plugins/sources/workspace.py
+++ b/src/buildstream/plugins/sources/workspace.py
@@ -92,13 +92,13 @@ class WorkspaceSource(Source):
     # init_workspace()
     #
     # Raises AssertionError: existing workspaces should not be reinitialized
-    def init_workspace(self, directory: str) -> None:
+    def init_workspace_directory(self, directory: Directory) -> None:
         raise AssertionError("Attempting to re-open an existing workspace")
 
     def fetch(self, *, previous_sources_dir=None) -> None:  # pylint: disable=arguments-differ
         pass  # pragma: nocover
 
-    def stage(self, directory):
+    def stage_directory(self, directory):
         #
         # We've already prepared the CAS while resolving the cache key which
         # will happen before staging.


### PR DESCRIPTION
Currently we pass a file path string or Directory object to these methods
depending on whether BST_STAGE_VIRTUAL_DIRECTORY is set, which is not very
pretty for plugin developers especially if they are using type annotations
and need to handle `Union[str, Directory]` in these methods.

Instead, created Source.stage_directory() and Source.init_workspace_directory()
to handle the Directory variants of these methods separately.

Also updated `local` and `workspace` plugins to use the new methods.