### PR TITLE
.github/common.env: Update Docker images

### DIFF
--- a/.github/common.env
+++ b/.github/common.env
@@ -1,6 +1,6 @@
 # Shared common variables
 
-CI_IMAGE_VERSION=master-450607952
+CI_IMAGE_VERSION=master-488745436
 CI_TOXENV_MAIN=py37,py38-nocover,py39-nocover,py310-nocover
 CI_TOXENV_PLUGINS=py37-plugins,py38-plugins-nocover,py39-plugins-nocover,py310-plugins-nocover
 CI_TOXENV_ALL="${CI_TOXENV_MAIN},${CI_TOXENV_PLUGINS}"


### PR DESCRIPTION
These images include buildbox-common and buildbox-casd 0.0.58, which should fix #1582.