### PR TITLE
tests/testutils/artifactshare.py: Use 127.0.0.1 instead of localhost for CAS server tests

### DIFF
--- a/tests/testutils/artifactshare.py
+++ b/tests/testutils/artifactshare.py
@@ -47,7 +47,7 @@ class BaseArtifactShare:
         with ExitStack() as stack:
             try:
                 server = stack.enter_context(self._create_server())
-                port = server.add_insecure_port("localhost:0")
+                port = server.add_insecure_port("127.0.0.1:0")
                 server.start()
             except Exception:
                 q.put(None)


### PR DESCRIPTION
In some CI runners this is needed, otherwise the tests which spin up a CAS
server hang for a while before timing out trying to open a port on "localhost:0".

We have observed the following error with `bst-1` and verified that this change fixes the issue, this is a forward port of #1619

```
________________________________ test_push_pull ________________________________
cli = <tests.testutils.runcli.Cli object at 0x7f37ef7207c0>
tmpdir = local('/builds/codethink/ccs/toolchain-stpa/buildstream/tmp/test_push_pull0')
datafiles = local('/builds/codethink/ccs/toolchain-stpa/buildstream/tmp/test_push_pull0')
    @pytest.mark.datafiles(DATA_DIR)
    def test_push_pull(cli, tmpdir, datafiles):
        project = os.path.join(str(datafiles), 'foo')
        base_project = os.path.join(str(project), 'base')
    
>       with create_artifact_share(os.path.join(str(tmpdir), 'artifactshare-foo')) as share,\
            create_artifact_share(os.path.join(str(tmpdir), 'artifactshare-base')) as base_share:
tests/artifactcache/junctions.py:44: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3.9/contextlib.py:119: in __enter__
    return next(self.gen)
tests/testutils/artifactshare.py:183: in create_artifact_share
    share = ArtifactShare(directory, total_space=total_space, free_space=free_space,
tests/testutils/artifactshare.py:65: in __init__
    port = q.get()
/usr/lib/python3.9/multiprocessing/queues.py:103: in get
    res = self._recv_bytes()
/usr/lib/python3.9/multiprocessing/connection.py:221: in recv_bytes
    buf = self._recv_bytes(maxlength)
/usr/lib/python3.9/multiprocessing/connection.py:419: in _recv_bytes
    buf = self._recv(4)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <multiprocessing.connection.Connection object at 0x7f37ef727d00>
size = 4, read = <built-in function read>
    def _recv(self, size, read=_read):
        buf = io.BytesIO()
        handle = self._handle
        remaining = size
        while remaining > 0:
>           chunk = read(handle, remaining)
E           Failed: Timeout >1800.0s
/usr/lib/python3.9/multiprocessing/connection.py:384: Failed
----------------------------- Captured stderr call -----------------------------
E0317 06:05:10.803813454      75 server_chttp2.cc:50]        {"created":"@1647497110.803611148","description":"No address added out of total 1 resolved","file":"src/core/ext/transport/chttp2/server/chttp2_server.cc","file_line":873,"referenced_errors":[{"created":"@1647497110.803594258","description":"Unable to configure socket","fd":18,"file":"src/core/lib/iomgr/tcp_server_utils_posix_common.cc","file_line":214,"referenced_errors":[{"created":"@1647497110.803579747","description":"Cannot assign requested address","errno":99,"file":"src/core/lib/iomgr/tcp_server_utils_posix_common.cc","file_line":188,"os_error":"Cannot assign requested address","syscall":"bind"}]}]}
Process Process-1:
Traceback (most recent call last):
  File "/usr/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/usr/lib/python3.9/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/builds/codethink/ccs/toolchain-stpa/buildstream/tests/testutils/artifactshare.py", line 92, in run
    port = server.add_insecure_port('localhost:0')
  File "/usr/lib/python3.9/site-packages/grpc/_server.py", line 961, in add_insecure_port
    return _common.validate_port_binding_result(
  File "/usr/lib/python3.9/site-packages/grpc/_common.py", line 166, in validate_port_binding_result
    raise RuntimeError(_ERROR_MESSAGE_PORT_BINDING_FAILED % address)
RuntimeError: Failed to bind to address localhost:0; set GRPC_VERBOSITY=debug environment variable to see detailed error message.
```