### PR TITLE
tox.ini: Update bst-plugins-external ref to pass CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ isolated_build = true
 
 # Configuration variables to share across environments
 [config]
-BST_PLUGINS_EXPERIMENTAL_VERSION = 1.93.4
+BST_PLUGINS_EXPERIMENTAL_VERSION = 8d65392b50be975371b7efb36f36440f668b05a7
 
 #
 # Defaults for all environments


### PR DESCRIPTION
The plugins CI which tests bst-plugins-experimental against current buildstream
needed to be updated to use a reference to bst-plugins-experimental which has
been updated to use newly changed buildstream APIs.