### PR TITLE
__init__.py: Adding FastEnum

### DIFF
--- a/src/buildstream/__init__.py
+++ b/src/buildstream/__init__.py
@@ -30,7 +30,7 @@ if "_BST_COMPLETION" not in os.environ:
     from .utils import UtilError, ProgramNotFoundError
     from .sandbox import Sandbox, SandboxCommandError
     from .storage import Directory, DirectoryError, FileType, FileStat
-    from .types import CoreWarnings, OverlapAction
+    from .types import CoreWarnings, OverlapAction, FastEnum
     from .node import MappingNode, Node, ProvenanceInformation, ScalarNode, SequenceNode
     from .plugin import Plugin
     from .source import Source, SourceError, SourceFetcher


### PR DESCRIPTION
The BuildStream API is constructed such that plugins can import any
data type from the main package without digging into subpackages, it
was missing FastEnum.