### PR TITLE
README.rst: Remove old gitlab badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,12 +7,6 @@ About
 .. image:: https://docs.buildstream.build/master/_static/snapshot.svg
    :target: https://docs.buildstream.build/master/_static/snapshot.html
 
-.. image:: https://gitlab.com/BuildStream/buildstream/badges/master/pipeline.svg
-   :target: https://gitlab.com/BuildStream/buildstream/commits/master
-
-.. image:: https://gitlab.com/BuildStream/buildstream/badges/master/coverage.svg?job=coverage
-   :target: https://gitlab.com/BuildStream/buildstream/commits/master
-
 .. image:: https://img.shields.io/pypi/v/BuildStream.svg
    :target: https://pypi.org/project/BuildStream
 


### PR DESCRIPTION
We still had some badges which refer to the old gitlab project site.