### PR TITLE
tests: xfail integration tests that fail without buildbox-fuse

### DIFF
--- a/src/buildstream/_testing/_utils/site.py
+++ b/src/buildstream/_testing/_utils/site.py
@@ -75,6 +75,12 @@ try:
 except (ProgramNotFoundError, OSError, subprocess.CalledProcessError):
     pass
 
+try:
+    utils.get_host_tool("buildbox-fuse")
+    HAVE_BUILDBOX_FUSE = True
+except ProgramNotFoundError:
+    HAVE_BUILDBOX_FUSE = False
+
 
 # Check if we have subsecond mtime support on the
 # filesystem where @directory is located.

--- a/tests/integration/script.py
+++ b/tests/integration/script.py
@@ -6,7 +6,7 @@ import pytest
 
 from buildstream import _yaml
 from buildstream._testing import cli_integration as cli  # pylint: disable=unused-import
-from buildstream._testing._utils.site import HAVE_SANDBOX, BUILDBOX_RUN
+from buildstream._testing._utils.site import HAVE_SANDBOX, BUILDBOX_RUN, HAVE_BUILDBOX_FUSE
 
 
 pytestmark = pytest.mark.integration
@@ -95,6 +95,7 @@ def test_script_root(cli, datafiles):
 
 @pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.skipif(not HAVE_SANDBOX, reason="Only available with a functioning sandbox")
+@pytest.mark.xfail(not HAVE_BUILDBOX_FUSE, reason="I don't know, seems like a bug")
 def test_script_no_root(cli, datafiles):
     project = str(datafiles)
     element_path = os.path.join(project, "elements")
@@ -171,6 +172,7 @@ def test_script_layout(cli, datafiles):
     HAVE_SANDBOX == "buildbox-run" and BUILDBOX_RUN == "buildbox-run-userchroot",
     reason="Root directory not writable with userchroot",
 )
+@pytest.mark.xfail(not HAVE_BUILDBOX_FUSE, reason="Root directory not writable without buildbox-fuse")
 def test_regression_cache_corruption(cli, datafiles):
     project = str(datafiles)
     checkout_original = os.path.join(cli.directory, "checkout-original")
@@ -215,6 +217,7 @@ def test_regression_tmpdir(cli, datafiles):
     HAVE_SANDBOX == "buildbox-run" and BUILDBOX_RUN == "buildbox-run-userchroot",
     reason="Root directory not writable with userchroot",
 )
+@pytest.mark.xfail(not HAVE_BUILDBOX_FUSE, reason="Root directory not writable without buildbox-fuse")
 def test_regression_cache_corruption_2(cli, datafiles):
     project = str(datafiles)
     checkout_original = os.path.join(cli.directory, "checkout-original")


### PR DESCRIPTION
Two of them are known (they are already marked as xfail when using buildbox-run-userchroot) but the third seems weird. It's probably a bug.