### PR TITLE
tox.ini: Updating black to version 22.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -294,7 +294,12 @@ def register_cython_module(module_name, dependencies=None):
         depends.append(def_file)
 
     BUILD_EXTENSIONS.append(
-        Extension(name=module_name, sources=[implementation_file], depends=depends, define_macros=extension_macros,)
+        Extension(
+            name=module_name,
+            sources=[implementation_file],
+            depends=depends,
+            define_macros=extension_macros,
+        )
     )
 
 

--- a/src/buildstream/_elementsourcescache.py
+++ b/src/buildstream/_elementsourcescache.py
@@ -268,7 +268,9 @@ class ElementSourcesCache(AssetCache):
 
         try:
             remote.push_blob(
-                [uri], source_digest, references_directories=referenced_directories,
+                [uri],
+                source_digest,
+                references_directories=referenced_directories,
             )
         except grpc.RpcError as e:
             raise SourceCacheError("Failed to push source with status {}: {}".format(e.code().name, e.details()))

--- a/src/buildstream/_frontend/app.py
+++ b/src/buildstream/_frontend/app.py
@@ -360,7 +360,12 @@ class App:
     #    target_directory (str): The target directory the project should be initialized in
     #
     def init_project(
-        self, project_name, min_version=None, element_path="elements", force=False, target_directory=None,
+        self,
+        project_name,
+        min_version=None,
+        element_path="elements",
+        force=False,
+        target_directory=None,
     ):
         if target_directory:
             directory = os.path.abspath(target_directory)
@@ -970,7 +975,10 @@ class App:
 
         click.echo("", err=True)
         min_version = click.prompt(
-            self._content_profile.fmt("Minimum version"), value_proc=min_version_proc, default=min_version, err=True,
+            self._content_profile.fmt("Minimum version"),
+            value_proc=min_version_proc,
+            default=min_version,
+            err=True,
         )
         click.echo("", err=True)
 

--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -369,8 +369,7 @@ def cli(context, **kwargs):
 @click.argument("command", nargs=-1, metavar="COMMAND")
 @click.pass_context
 def help_command(ctx, command):
-    """Print usage information about a given command
-    """
+    """Print usage information about a given command"""
     command_ctx = search_command(command, context=ctx.parent)
     if not command_ctx:
         click.echo("Not a valid command: '{} {}'".format(ctx.parent.info_name, " ".join(command)), err=True)
@@ -394,7 +393,11 @@ def help_command(ctx, command):
 @cli.command(short_help="Initialize a new BuildStream project")
 @click.option("--project-name", type=click.STRING, help="The project name to use")
 @click.option(
-    "--min-version", type=click.STRING, default="2.0", show_default=True, help="The required format version",
+    "--min-version",
+    type=click.STRING,
+    default="2.0",
+    show_default=True,
+    help="The required format version",
 )
 @click.option(
     "--element-path",
@@ -427,7 +430,8 @@ def init(app, project_name, min_version, element_path, force, target_directory):
     "-d",
     default=None,
     type=FastEnumType(
-        _PipelineSelection, [_PipelineSelection.NONE, _PipelineSelection.BUILD, _PipelineSelection.ALL],
+        _PipelineSelection,
+        [_PipelineSelection.NONE, _PipelineSelection.BUILD, _PipelineSelection.ALL],
     ),
     help="The dependencies to build",
 )
@@ -519,7 +523,12 @@ def build(
     show_default=True,
     type=FastEnumType(
         _PipelineSelection,
-        [_PipelineSelection.NONE, _PipelineSelection.RUN, _PipelineSelection.BUILD, _PipelineSelection.ALL,],
+        [
+            _PipelineSelection.NONE,
+            _PipelineSelection.RUN,
+            _PipelineSelection.BUILD,
+            _PipelineSelection.ALL,
+        ],
     ),
     help="The dependencies to show",
 )
@@ -758,7 +767,12 @@ def source():
     show_default=True,
     type=FastEnumType(
         _PipelineSelection,
-        [_PipelineSelection.NONE, _PipelineSelection.BUILD, _PipelineSelection.RUN, _PipelineSelection.ALL,],
+        [
+            _PipelineSelection.NONE,
+            _PipelineSelection.BUILD,
+            _PipelineSelection.RUN,
+            _PipelineSelection.ALL,
+        ],
     ),
     help="The dependencies to fetch",
 )
@@ -826,7 +840,12 @@ def source_fetch(app, elements, deps, except_, source_remotes, ignore_project_so
     show_default=True,
     type=FastEnumType(
         _PipelineSelection,
-        [_PipelineSelection.NONE, _PipelineSelection.BUILD, _PipelineSelection.RUN, _PipelineSelection.ALL,],
+        [
+            _PipelineSelection.NONE,
+            _PipelineSelection.BUILD,
+            _PipelineSelection.RUN,
+            _PipelineSelection.ALL,
+        ],
     ),
     help="The dependencies to push",
 )

--- a/src/buildstream/_frontend/widget.py
+++ b/src/buildstream/_frontend/widget.py
@@ -91,7 +91,11 @@ class WallclockTime(Widget):
 
         fields = [
             self.content_profile.fmt("{:02d}".format(x))
-            for x in [message.creation_time.hour, message.creation_time.minute, message.creation_time.second,]
+            for x in [
+                message.creation_time.hour,
+                message.creation_time.minute,
+                message.creation_time.second,
+            ]
         ]
         text = self.format_profile.fmt(":").join(fields)
 

--- a/src/buildstream/_gitsourcebase.py
+++ b/src/buildstream/_gitsourcebase.py
@@ -89,7 +89,8 @@ class _GitMirror(SourceFetcher):
         if not os.path.exists(self.mirror):
             with self.source.tempdir() as tmpdir:
                 self.source.call(
-                    [self.source.host_git, "init", "--bare", tmpdir], fail="Failed to initialise repository",
+                    [self.source.host_git, "init", "--bare", tmpdir],
+                    fail="Failed to initialise repository",
                 )
 
                 try:

--- a/src/buildstream/_loader/loader.py
+++ b/src/buildstream/_loader/loader.py
@@ -858,8 +858,9 @@ class Loader:
             )
         except LoadError as e:
             if e.reason == LoadErrorReason.MISSING_PROJECT_CONF:
-                message = provenance_str() + "Could not find the project.conf file in the project " "referred to by junction element '{}'.".format(
-                    element.name
+                message = (
+                    provenance_str() + "Could not find the project.conf file in the project "
+                    "referred to by junction element '{}'.".format(element.name)
                 )
                 if element.path:
                     message += " Was expecting it at path '{}' in the junction's source.".format(element.path)

--- a/src/buildstream/_messenger.py
+++ b/src/buildstream/_messenger.py
@@ -517,7 +517,7 @@ class Messenger:
 
         timecode = EMPTYTIME
         if message.message_type in (MessageType.SUCCESS, MessageType.FAIL):
-            hours, remainder = divmod(int(message.elapsed.total_seconds()), 60 ** 2)
+            hours, remainder = divmod(int(message.elapsed.total_seconds()), 60**2)
             minutes, seconds = divmod(remainder, 60)
             timecode = "{0:02d}:{1:02d}:{2:02d}".format(hours, minutes, seconds)
 

--- a/src/buildstream/_pluginfactory/pluginfactory.py
+++ b/src/buildstream/_pluginfactory/pluginfactory.py
@@ -87,7 +87,8 @@ class PluginFactory:
             self._site_plugins_path = _site.element_plugins
 
         self._site_source = self._plugin_base.make_plugin_source(
-            searchpath=[self._site_plugins_path], identifier=self._identifier + "site",
+            searchpath=[self._site_plugins_path],
+            identifier=self._identifier + "site",
         )
 
     ######################################################
@@ -224,7 +225,8 @@ class PluginFactory:
                 # Make the PluginSource object
                 #
                 source = self._plugin_base.make_plugin_source(
-                    searchpath=[location], identifier=self._identifier + location + kind,
+                    searchpath=[location],
+                    identifier=self._identifier + location + kind,
                 )
 
                 # Keep a reference on the PluginSources (see comment in __init__)

--- a/src/buildstream/_remotespec.py
+++ b/src/buildstream/_remotespec.py
@@ -173,7 +173,9 @@ class RemoteSpec:
     def credentials(self) -> ChannelCredentials:
         if not self._credentials:
             self._credentials = grpc.ssl_channel_credentials(
-                root_certificates=self.server_cert, private_key=self.client_key, certificate_chain=self.client_cert,
+                root_certificates=self.server_cert,
+                private_key=self.client_key,
+                certificate_chain=self.client_cert,
             )
         return self._credentials
 

--- a/src/buildstream/_testing/__init__.py
+++ b/src/buildstream/_testing/__init__.py
@@ -91,7 +91,7 @@ def register_repo_kind(kind, cls, plugin_package):
 
 
 def sourcetests_collection_hook(session):
-    """ Used to hook the templated source plugin tests into a pyest test suite.
+    """Used to hook the templated source plugin tests into a pyest test suite.
 
     This should be called via the `pytest_sessionstart
     hook <https://docs.pytest.org/en/latest/reference.html#collection-hooks>`_.

--- a/src/buildstream/_testing/_sourcetests/mirror.py
+++ b/src/buildstream/_testing/_sourcetests/mirror.py
@@ -82,7 +82,14 @@ def test_mirror_fetch(cli, tmpdir, datafiles, kind):
 
     _set_project_mirrors_and_aliases(
         project_dir,
-        [{"name": "middle-earth", "aliases": {alias: [mirror_map + "/"],},},],
+        [
+            {
+                "name": "middle-earth",
+                "aliases": {
+                    alias: [mirror_map + "/"],
+                },
+            },
+        ],
         {alias: upstream_map + "/"},
     )
 
@@ -120,7 +127,12 @@ def test_mirror_fetch_upstream_absent(cli, tmpdir, datafiles, kind):
 
     _set_project_mirrors_and_aliases(
         project_dir,
-        [{"name": "middle-earth", "aliases": {alias: [mirror_map + "/"]},},],
+        [
+            {
+                "name": "middle-earth",
+                "aliases": {alias: [mirror_map + "/"]},
+            },
+        ],
         {alias: "http://www.example.com"},
     )
 
@@ -157,12 +169,23 @@ def test_mirror_from_includes(cli, tmpdir, datafiles, kind):
     os.makedirs(config_project_dir, exist_ok=True)
     config_project = {"name": "config", "min-version": "2.0"}
     _yaml.roundtrip_dump(config_project, os.path.join(config_project_dir, "project.conf"))
-    extra_mirrors = {"mirrors": [{"name": "middle-earth", "aliases": {alias: [mirror_map + "/"],}}]}
+    extra_mirrors = {
+        "mirrors": [
+            {
+                "name": "middle-earth",
+                "aliases": {
+                    alias: [mirror_map + "/"],
+                },
+            }
+        ]
+    }
     _yaml.roundtrip_dump(extra_mirrors, os.path.join(config_project_dir, "mirrors.yml"))
     generate_junction(str(tmpdir.join("config_repo")), config_project_dir, os.path.join(element_dir, "config.bst"))
 
     _set_project_includes_and_aliases(
-        project_dir, ["config.bst:mirrors.yml"], {alias: upstream_map + "/"},
+        project_dir,
+        ["config.bst:mirrors.yml"],
+        {alias: upstream_map + "/"},
     )
 
     # Now make the upstream unavailable.
@@ -200,7 +223,16 @@ def test_mirror_junction_from_includes(cli, tmpdir, datafiles, kind):
     os.makedirs(config_project_dir, exist_ok=True)
     config_project = {"name": "config", "min-version": "2.0"}
     _yaml.roundtrip_dump(config_project, os.path.join(config_project_dir, "project.conf"))
-    extra_mirrors = {"mirrors": [{"name": "middle-earth", "aliases": {alias: [mirror_map + "/"],}}]}
+    extra_mirrors = {
+        "mirrors": [
+            {
+                "name": "middle-earth",
+                "aliases": {
+                    alias: [mirror_map + "/"],
+                },
+            }
+        ]
+    }
     _yaml.roundtrip_dump(extra_mirrors, os.path.join(config_project_dir, "mirrors.yml"))
     generate_junction(str(tmpdir.join("config_repo")), config_project_dir, os.path.join(element_dir, "config.bst"))
 
@@ -246,7 +278,14 @@ def test_mirror_track_upstream_present(cli, tmpdir, datafiles, kind):
 
     _set_project_mirrors_and_aliases(
         project_dir,
-        [{"name": "middle-earth", "aliases": {alias: [mirror_map + "/"],},},],
+        [
+            {
+                "name": "middle-earth",
+                "aliases": {
+                    alias: [mirror_map + "/"],
+                },
+            },
+        ],
         {alias: upstream_map + "/"},
     )
 
@@ -294,7 +333,14 @@ def test_mirror_track_upstream_absent(cli, tmpdir, datafiles, kind):
 
     _set_project_mirrors_and_aliases(
         project_dir,
-        [{"name": "middle-earth", "aliases": {alias: [mirror_map + "/"],},},],
+        [
+            {
+                "name": "middle-earth",
+                "aliases": {
+                    alias: [mirror_map + "/"],
+                },
+            },
+        ],
         {alias: "http://www.example.com"},
     )
 

--- a/src/buildstream/_testing/_sourcetests/track.py
+++ b/src/buildstream/_testing/_sourcetests/track.py
@@ -111,7 +111,13 @@ def test_track_recurse(cli, tmpdir, datafiles, kind, amount):
     #
     # This stresses the Source plugins and helps to ensure that
     # they handle concurrent access to the store correctly.
-    cli.configure({"scheduler": {"fetchers": amount,}})
+    cli.configure(
+        {
+            "scheduler": {
+                "fetchers": amount,
+            }
+        }
+    )
 
     # Create our repo object of the given source type with
     # the dev files, and then collect the initial ref.

--- a/src/buildstream/_testing/_sourcetests/utils.py
+++ b/src/buildstream/_testing/_sourcetests/utils.py
@@ -70,7 +70,11 @@ def add_plugins_conf(project, plugin_kind):
 
     if plugin_package is not None:
         project_conf["plugins"] = [
-            {"origin": "pip", "package-name": plugin_package, "sources": [plugin_kind],},
+            {
+                "origin": "pip",
+                "package-name": plugin_package,
+                "sources": [plugin_kind],
+            },
         ]
 
     _yaml.roundtrip_dump(project_conf, project_conf_file)

--- a/src/buildstream/_testing/_update_cachekeys.py
+++ b/src/buildstream/_testing/_update_cachekeys.py
@@ -50,7 +50,9 @@ def update_keys():
         # Run bst show
         cli = Cli(directory, verbose=True)
         result = cli.run(
-            project=project_dir, silent=True, args=["--no-colors", "show", "--format", "%{name}::%{full-key}"],
+            project=project_dir,
+            silent=True,
+            args=["--no-colors", "show", "--format", "%{name}::%{full-key}"],
         )
 
         # Load the actual keys, and the expected ones if they exist

--- a/src/buildstream/_testing/_utils/junction.py
+++ b/src/buildstream/_testing/_utils/junction.py
@@ -53,7 +53,12 @@ class _SimpleGit(Repo):
         return self.latest_commit()
 
     def latest_commit(self):
-        return self._run_git("rev-parse", "HEAD", stdout=subprocess.PIPE, universal_newlines=True,).stdout.strip()
+        return self._run_git(
+            "rev-parse",
+            "HEAD",
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
+        ).stdout.strip()
 
     def source_config(self, ref=None):
         return self.source_config_extra(ref)

--- a/src/buildstream/_testing/repo.py
+++ b/src/buildstream/_testing/repo.py
@@ -74,7 +74,7 @@ class Repo:
         raise NotImplementedError("source_config method has not been implemeted")
 
     def copy_directory(self, src, dest):
-        """ Copies the content of src to the directory dest
+        """Copies the content of src to the directory dest
 
         Like shutil.copytree(), except dest is expected
         to exist.

--- a/src/buildstream/_testing/runcli.py
+++ b/src/buildstream/_testing/runcli.py
@@ -752,7 +752,10 @@ def cli_integration(tmpdir, integration_cache):
     # We want to cache sources for integration tests more permanently,
     # to avoid downloading the huge base-sdk repeatedly
     fixture.configure(
-        {"cachedir": integration_cache.cachedir, "sourcedir": integration_cache.sources,}
+        {
+            "cachedir": integration_cache.cachedir,
+            "sourcedir": integration_cache.sources,
+        }
     )
 
     yield fixture
@@ -805,7 +808,17 @@ def cli_remote_execution(tmpdir, remote_services):
         fixture.configure({"remote-execution": remote_execution})
 
     if remote_services.source_service:
-        fixture.configure({"source-caches": {"servers": [{"url": remote_services.source_service,}]}})
+        fixture.configure(
+            {
+                "source-caches": {
+                    "servers": [
+                        {
+                            "url": remote_services.source_service,
+                        }
+                    ]
+                }
+            }
+        )
 
     return fixture
 

--- a/src/buildstream/downloadablefilesource.py
+++ b/src/buildstream/downloadablefilesource.py
@@ -180,7 +180,9 @@ class DownloadableFileSource(Source):
 
         # Download the file, raise hell if the sha256sums don't match,
         # and mirror the file otherwise.
-        sha256 = self._ensure_mirror("Fetching {}".format(self.url),)
+        sha256 = self._ensure_mirror(
+            "Fetching {}".format(self.url),
+        )
         if sha256 != self.ref:
             raise SourceError(
                 "File downloaded from {} has sha256sum '{}', not '{}'!".format(self.url, sha256, self.ref)

--- a/src/buildstream/plugins/sources/tar.py
+++ b/src/buildstream/plugins/sources/tar.py
@@ -65,10 +65,10 @@ from buildstream import utils
 
 class ReadableTarInfo(tarfile.TarInfo):
     """
-           The goal is to override `TarFile`'s `extractall` semantics by ensuring that on extraction, the
-           files are readable by the owner of the file. This is done by overriding the accessor for the
-           `mode` attribute in `TarInfo`, the class that encapsulates the internal meta-data of the tarball,
-           so that the owner-read bit is always set.
+    The goal is to override `TarFile`'s `extractall` semantics by ensuring that on extraction, the
+    files are readable by the owner of the file. This is done by overriding the accessor for the
+    `mode` attribute in `TarInfo`, the class that encapsulates the internal meta-data of the tarball,
+    so that the owner-read bit is always set.
     """
 
     # https://github.com/python/mypy/issues/4125

--- a/src/buildstream/sandbox/_sandboxbuildboxrun.py
+++ b/src/buildstream/sandbox/_sandboxbuildboxrun.py
@@ -131,7 +131,11 @@ class SandboxBuildBoxRun(SandboxREAPI):
                 stdin = subprocess.DEVNULL
 
             self._run_buildbox(
-                buildbox_command, stdin, stdout, stderr, interactive=(flags & _SandboxFlags.INTERACTIVE),
+                buildbox_command,
+                stdin,
+                stdout,
+                stderr,
+                interactive=(flags & _SandboxFlags.INTERACTIVE),
             )
 
             return remote_execution_pb2.ActionResult().FromString(result_file.read())
@@ -172,7 +176,12 @@ class SandboxBuildBoxRun(SandboxREAPI):
                 stack.enter_context(_signals.terminator(kill_proc))
 
             process = subprocess.Popen(  # pylint: disable=consider-using-with
-                argv, close_fds=True, stdin=stdin, stdout=stdout, stderr=stderr, start_new_session=new_session,
+                argv,
+                close_fds=True,
+                stdin=stdin,
+                stdout=stdout,
+                stderr=stderr,
+                start_new_session=new_session,
             )
 
             # Wait for the child process to finish, ensuring that

--- a/src/buildstream/sandbox/sandbox.py
+++ b/src/buildstream/sandbox/sandbox.py
@@ -623,7 +623,9 @@ class _SandboxBatch:
         if command.label:
             context = self.sandbox._get_context()
             context.messenger.status(
-                "Running command", detail=command.label, element_name=self.sandbox._get_element_name(),
+                "Running command",
+                detail=command.label,
+                element_name=self.sandbox._get_element_name(),
             )
 
         exitcode = self.sandbox._run(command.command, flags=self.flags, cwd=command.cwd, env=command.env)

--- a/src/buildstream/storage/_casbaseddirectory.py
+++ b/src/buildstream/storage/_casbaseddirectory.py
@@ -180,7 +180,9 @@ class CasBasedDirectory(Directory):
         result = FileListResult()
         if self.__check_replacement(os.path.basename(external_pathspec), os.path.dirname(external_pathspec), result):
             self.__add_file(
-                os.path.basename(external_pathspec), external_pathspec, properties=None,
+                os.path.basename(external_pathspec),
+                external_pathspec,
+                properties=None,
             )
             result.files_written.append(external_pathspec)
         return result
@@ -690,7 +692,12 @@ class CasBasedDirectory(Directory):
             utils._get_file_protobuf_mtimestamp(mtime, path)
 
         entry = _IndexEntry(
-            self.__cas_cache, name, FileType.REGULAR_FILE, digest=digest, is_executable=is_executable, mtime=mtime,
+            self.__cas_cache,
+            name,
+            FileType.REGULAR_FILE,
+            digest=digest,
+            is_executable=is_executable,
+            mtime=mtime,
         )
         self.__index[name] = entry
 

--- a/src/buildstream/storage/_filebaseddirectory.py
+++ b/src/buildstream/storage/_filebaseddirectory.py
@@ -276,7 +276,11 @@ class FileBasedDirectory(Directory):
 
             import_result = FileListResult()
             self.__import_files_from_directory(
-                external_pathspec, copy_action, filter_callback, update_mtime=update_mtime, result=import_result,
+                external_pathspec,
+                copy_action,
+                filter_callback,
+                update_mtime=update_mtime,
+                result=import_result,
             )
 
         return import_result
@@ -345,7 +349,8 @@ class FileBasedDirectory(Directory):
                         current_dir = current_dir.__open_directory(newpaths, follow_symlinks=True)
                 else:
                     raise DirectoryError(
-                        "Cannot open '{}': '{}' is not a directory".format(path, new_path), reason="not-a-directory",
+                        "Cannot open '{}': '{}' is not a directory".format(path, new_path),
+                        reason="not-a-directory",
                     )
             except FileNotFoundError:
                 if create:

--- a/src/buildstream/storage/directory.py
+++ b/src/buildstream/storage/directory.py
@@ -167,7 +167,10 @@ class Directory:
 
     # Import and export of files and links
     def import_files(
-        self, external_pathspec: Union["Directory", str], *, filter_callback: Optional[Callable[[str], bool]] = None,
+        self,
+        external_pathspec: Union["Directory", str],
+        *,
+        filter_callback: Optional[Callable[[str], bool]] = None,
     ) -> FileListResult:
         """Imports some or all files from external_path into this directory.
 
@@ -185,7 +188,10 @@ class Directory:
         Raises:
            DirectoryError: if any system error occurs.
         """
-        return self._import_files_internal(external_pathspec, filter_callback=filter_callback,)
+        return self._import_files_internal(
+            external_pathspec,
+            filter_callback=filter_callback,
+        )
 
     def import_single_file(self, external_pathspec: str) -> FileListResult:
         """Imports a single file from an external path
@@ -294,7 +300,7 @@ class Directory:
         raise NotImplementedError()
 
     def remove(self, path: str, *, recursive: bool = False) -> None:
-        """ Remove a file, symlink or directory. Symlinks are not followed.
+        """Remove a file, symlink or directory. Symlinks are not followed.
 
         Args:
            path: A :ref:`path <directory_path>` relative to this directory.
@@ -306,7 +312,7 @@ class Directory:
         raise NotImplementedError()
 
     def rename(self, src: str, dest: str) -> None:
-        """ Rename a file, symlink or directory. If destination path exists
+        """Rename a file, symlink or directory. If destination path exists
         already and is a file or empty directory, it will be replaced.
 
         Args:
@@ -319,7 +325,7 @@ class Directory:
         raise NotImplementedError()
 
     def isfile(self, path: str, *, follow_symlinks: bool = False) -> bool:
-        """ Check whether the specified path is an existing regular file.
+        """Check whether the specified path is an existing regular file.
 
         Args:
            path: A :ref:`path <directory_path>` relative to this directory.
@@ -335,7 +341,7 @@ class Directory:
             return False
 
     def isdir(self, path: str, *, follow_symlinks: bool = False) -> bool:
-        """ Check whether the specified path is an existing directory.
+        """Check whether the specified path is an existing directory.
 
         Args:
            path: A :ref:`path <directory_path>` relative to this directory.
@@ -351,7 +357,7 @@ class Directory:
             return False
 
     def islink(self, path: str, *, follow_symlinks: bool = False) -> bool:
-        """ Check whether the specified path is an existing symlink.
+        """Check whether the specified path is an existing symlink.
 
         Args:
            path: A :ref:`path <directory_path>` relative to this directory.
@@ -400,7 +406,10 @@ class Directory:
         properties: Optional[List[str]] = None,
     ) -> FileListResult:
         return self._import_files(
-            external_pathspec, filter_callback=filter_callback, update_mtime=update_mtime, properties=properties,
+            external_pathspec,
+            filter_callback=filter_callback,
+            update_mtime=update_mtime,
+            properties=properties,
         )
 
     # _import_files()

--- a/src/buildstream/utils.py
+++ b/src/buildstream/utils.py
@@ -96,8 +96,7 @@ class ProgramNotFoundError(BstError):
 
 
 class DirectoryExistsError(OSError):
-    """Raised when a `os.rename` is attempted but the destination is an existing directory.
-    """
+    """Raised when a `os.rename` is attempted but the destination is an existing directory."""
 
 
 class FileListResult:
@@ -223,7 +222,7 @@ def _set_file_mtime(fullpath: str, seconds: Union[int, float]) -> None:
     """
     assert isinstance(fullpath, str), "Path to file must be a string: {}".format(str(fullpath))
     assert isinstance(seconds, (int, float)), "Mtime to set must be a float or integer: {}".format(str(seconds))
-    set_mtime = seconds * 10 ** 9
+    set_mtime = seconds * 10**9
     try:
         os.utime(fullpath, times=None, ns=(int(set_mtime), int(set_mtime)))
     except OSError:
@@ -1611,7 +1610,9 @@ def _parse_version(version: str) -> Tuple[int, int]:
         major = int(versions[0])
         minor = int(versions[1])
     except (IndexError, ValueError, AttributeError) as e:
-        raise UtilError("Malformed version string: {}".format(version),) from e
+        raise UtilError(
+            "Malformed version string: {}".format(version),
+        ) from e
 
     return major, minor
 

--- a/tests/artifactcache/capabilities.py
+++ b/tests/artifactcache/capabilities.py
@@ -13,7 +13,10 @@ from tests.testutils import dummy_context
 from tests.testutils.artifactshare import create_dummy_artifact_share
 
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 @pytest.mark.datafiles(DATA_DIR)
@@ -27,7 +30,14 @@ def test_artifact_cache_with_missing_capabilities_is_skipped(cli, tmpdir, datafi
         user_config_file = str(tmpdir.join("buildstream.conf"))
         user_config = {
             "scheduler": {"pushers": 1},
-            "artifacts": {"servers": [{"url": share.repo, "push": True,}]},
+            "artifacts": {
+                "servers": [
+                    {
+                        "url": share.repo,
+                        "push": True,
+                    }
+                ]
+            },
             "cachedir": cache_dir,
         }
         _yaml.roundtrip_dump(user_config, file=user_config_file)

--- a/tests/artifactcache/config.py
+++ b/tests/artifactcache/config.py
@@ -181,13 +181,21 @@ def test_only_one(cli, datafiles, override_caches, project_caches, user_caches):
         [
             {
                 "url": "http://localhost.test",
-                "auth": {"server-cert": "~/server.crt", "client-cert": "~/client.crt", "client-key": "~/client.key",},
+                "auth": {
+                    "server-cert": "~/server.crt",
+                    "client-cert": "~/client.crt",
+                    "client-key": "~/client.key",
+                },
             }
         ],
         [
             {
                 "url": "http://localhost.test",
-                "auth": {"server-cert": "~/server.crt", "client-cert": "~/client.crt", "client-key": "~/client.key",},
+                "auth": {
+                    "server-cert": "~/server.crt",
+                    "client-cert": "~/client.crt",
+                    "client-key": "~/client.key",
+                },
             },
             {
                 "url": "http://localhost2.test",

--- a/tests/artifactcache/expiry.py
+++ b/tests/artifactcache/expiry.py
@@ -69,7 +69,13 @@ def test_artifact_expires(cli, datafiles):
     if not have_subsecond_mtime(project):
         pytest.skip("Filesystem does not support subsecond mtime precision: {}".format(project))
 
-    cli.configure({"cache": {"quota": 10000000,}})
+    cli.configure(
+        {
+            "cache": {
+                "quota": 10000000,
+            }
+        }
+    )
 
     # Create an element that uses almost the entire cache (an empty
     # ostree cache starts at about ~10KiB, so we need a bit of a
@@ -310,7 +316,11 @@ def test_invalid_cache_quota(cli, datafiles, quota, err_domain, err_reason):
     os.makedirs(os.path.join(project, "elements"))
 
     cli.configure(
-        {"cache": {"quota": quota,},}
+        {
+            "cache": {
+                "quota": quota,
+            },
+        }
     )
 
     res = cli.run(project=project, args=["workspace", "list"])
@@ -329,7 +339,13 @@ def test_cleanup_first(cli, datafiles):
     project = str(datafiles)
     element_path = "elements"
 
-    cli.configure({"cache": {"quota": 10000000,}})
+    cli.configure(
+        {
+            "cache": {
+                "quota": 10000000,
+            }
+        }
+    )
 
     # Create an element that uses almost the entire cache (an empty
     # ostree cache starts at about ~10KiB, so we need a bit of a
@@ -345,7 +361,14 @@ def test_cleanup_first(cli, datafiles):
     #
     # Fix the fetchers and builders just to ensure a predictable
     # sequence of events (although it does not effect this test)
-    cli.configure({"cache": {"quota": 5000000,}, "scheduler": {"fetchers": 1, "builders": 1}})
+    cli.configure(
+        {
+            "cache": {
+                "quota": 5000000,
+            },
+            "scheduler": {"fetchers": 1, "builders": 1},
+        }
+    )
 
     # Our cache is now more than full, BuildStream
     create_element_size("target2.bst", project, element_path, [], 4000000)

--- a/tests/artifactcache/junctions.py
+++ b/tests/artifactcache/junctions.py
@@ -11,7 +11,10 @@ from buildstream._testing import cli  # pylint: disable=unused-import
 from tests.testutils import create_artifact_share, assert_shared, assert_not_shared
 
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "junctions",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "junctions",
+)
 
 
 def project_set_artifacts(project, url):

--- a/tests/artifactcache/pull.py
+++ b/tests/artifactcache/pull.py
@@ -14,7 +14,10 @@ from tests.testutils import create_artifact_share, dummy_context
 
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 def tree_maker(cas, tree, directory):
@@ -41,7 +44,14 @@ def test_pull(cli, tmpdir, datafiles):
         user_config_file = str(tmpdir.join("buildstream.conf"))
         user_config = {
             "scheduler": {"pushers": 1},
-            "artifacts": {"servers": [{"url": share.repo, "push": True,}]},
+            "artifacts": {
+                "servers": [
+                    {
+                        "url": share.repo,
+                        "push": True,
+                    }
+                ]
+            },
             "cachedir": cache_dir,
         }
 
@@ -106,7 +116,14 @@ def test_pull_tree(cli, tmpdir, datafiles):
         user_config_file = str(tmpdir.join("buildstream.conf"))
         user_config = {
             "scheduler": {"pushers": 1},
-            "artifacts": {"servers": [{"url": share.repo, "push": True,}]},
+            "artifacts": {
+                "servers": [
+                    {
+                        "url": share.repo,
+                        "push": True,
+                    }
+                ]
+            },
             "cachedir": rootcache_dir,
         }
 

--- a/tests/artifactcache/push.py
+++ b/tests/artifactcache/push.py
@@ -14,7 +14,10 @@ from tests.testutils import create_artifact_share, create_split_share, dummy_con
 
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 # Push the given element and return its artifact key for assertions.
@@ -62,7 +65,14 @@ def test_push(cli, tmpdir, datafiles):
         user_config_file = str(tmpdir.join("buildstream.conf"))
         user_config = {
             "scheduler": {"pushers": 1},
-            "artifacts": {"servers": [{"url": share.repo, "push": True,}]},
+            "artifacts": {
+                "servers": [
+                    {
+                        "url": share.repo,
+                        "push": True,
+                    }
+                ]
+            },
             "cachedir": rootcache_dir,
         }
 
@@ -121,7 +131,14 @@ def test_push_message(tmpdir, datafiles):
         user_config_file = str(tmpdir.join("buildstream.conf"))
         user_config = {
             "scheduler": {"pushers": 1},
-            "artifacts": {"servers": [{"url": share.repo, "push": True,}]},
+            "artifacts": {
+                "servers": [
+                    {
+                        "url": share.repo,
+                        "push": True,
+                    }
+                ]
+            },
             "cachedir": rootcache_dir,
         }
 

--- a/tests/cachekey/cachekey.py
+++ b/tests/cachekey/cachekey.py
@@ -52,7 +52,10 @@ from buildstream import _yaml
 
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 # The cache key test uses a project which exercises all plugins,

--- a/tests/elements/filter.py
+++ b/tests/elements/filter.py
@@ -11,7 +11,10 @@ from buildstream._testing import cli  # pylint: disable=unused-import
 from buildstream.exceptions import ErrorDomain
 from buildstream import _yaml
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "filter",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "filter",
+)
 
 
 @pytest.mark.datafiles(os.path.join(DATA_DIR, "basic"))

--- a/tests/examples/developing.py
+++ b/tests/examples/developing.py
@@ -54,7 +54,17 @@ def test_open_workspace(cli, tmpdir, datafiles):
     project = str(datafiles)
     workspace_dir = os.path.join(str(tmpdir), "workspace_hello")
 
-    result = cli.run(project=project, args=["workspace", "open", "-f", "--directory", workspace_dir, "hello.bst",])
+    result = cli.run(
+        project=project,
+        args=[
+            "workspace",
+            "open",
+            "-f",
+            "--directory",
+            workspace_dir,
+            "hello.bst",
+        ],
+    )
     result.assert_success()
 
     result = cli.run(project=project, args=["workspace", "list"])

--- a/tests/format/dependencies.py
+++ b/tests/format/dependencies.py
@@ -215,7 +215,12 @@ def test_scope_build_of_child(cli, datafiles):
 
 @pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.parametrize(
-    "target", ["merge-separate-lists.bst", "merge-single-list.bst",], ids=["separate-lists", "single-list"],
+    "target",
+    [
+        "merge-separate-lists.bst",
+        "merge-single-list.bst",
+    ],
+    ids=["separate-lists", "single-list"],
 )
 def test_merge(cli, datafiles, target):
     project = os.path.join(str(datafiles), "dependencies2")
@@ -241,7 +246,12 @@ def test_config_unsupported(cli, datafiles):
 
 @pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.parametrize(
-    "target,number", [("supported1.bst", 1), ("supported2.bst", 2),], ids=["one", "two"],
+    "target,number",
+    [
+        ("supported1.bst", 1),
+        ("supported2.bst", 2),
+    ],
+    ids=["one", "two"],
 )
 def test_config_supported(cli, datafiles, target, number):
     project = os.path.join(str(datafiles), "dependencies3")
@@ -264,7 +274,12 @@ def test_config_runtime_error(cli, datafiles):
 
 @pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.parametrize(
-    "target,number", [("shorthand-config.bst", 2), ("shorthand-junction.bst", 2),], ids=["config", "junction"],
+    "target,number",
+    [
+        ("shorthand-config.bst", 2),
+        ("shorthand-junction.bst", 2),
+    ],
+    ids=["config", "junction"],
 )
 def test_shorthand(cli, datafiles, target, number):
     project = os.path.join(str(datafiles), "dependencies3")

--- a/tests/format/include.py
+++ b/tests/format/include.py
@@ -327,7 +327,10 @@ def test_option_from_deep_junction(cli, tmpdir, datafiles):
     )
 
     generate_junction(
-        tmpdir, os.path.join(project, "subproject-1"), os.path.join(project, "junction-1.bst"), store_ref=True,
+        tmpdir,
+        os.path.join(project, "subproject-1"),
+        os.path.join(project, "junction-1.bst"),
+        store_ref=True,
     )
 
     result = cli.run(project=project, args=["show", "--deps", "none", "--format", "%{vars}", "element.bst"])

--- a/tests/format/junctions.py
+++ b/tests/format/junctions.py
@@ -11,7 +11,10 @@ from buildstream._testing import cli  # pylint: disable=unused-import
 from buildstream._testing import create_repo
 
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "junctions",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "junctions",
+)
 
 
 def update_project(project_path, updated_configuration):
@@ -95,7 +98,10 @@ def test_workspaced_junction_missing_project_conf(cli, datafiles):
 @pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.parametrize(
     "target,expected",
-    [("target.bst", ["sub.txt", "subsub.txt"]), ("deeptarget.bst", ["sub.txt", "subsub.txt", "subsubsub.txt"]),],
+    [
+        ("target.bst", ["sub.txt", "subsub.txt"]),
+        ("deeptarget.bst", ["sub.txt", "subsub.txt", "subsubsub.txt"]),
+    ],
     ids=["simple", "deep"],
 )
 def test_nested(cli, tmpdir, datafiles, target, expected):
@@ -180,7 +186,10 @@ def test_invalid(cli, datafiles, target, domain, reason, provenance):
 @pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.parametrize(
     "target,expect_exists,expect_not_exists",
-    [("target-default.bst", "pony.txt", "horsy.txt"), ("target-explicit.bst", "horsy.txt", "pony.txt"),],
+    [
+        ("target-default.bst", "pony.txt", "horsy.txt"),
+        ("target-explicit.bst", "horsy.txt", "pony.txt"),
+    ],
     ids=["check-values", "set-explicit-values"],
 )
 def test_options(cli, tmpdir, datafiles, target, expect_exists, expect_not_exists):
@@ -203,7 +212,10 @@ def test_options(cli, tmpdir, datafiles, target, expect_exists, expect_not_exist
 @pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.parametrize(
     "animal,expect_exists,expect_not_exists",
-    [("pony", "pony.txt", "horsy.txt"), ("horsy", "horsy.txt", "pony.txt"),],
+    [
+        ("pony", "pony.txt", "horsy.txt"),
+        ("horsy", "horsy.txt", "pony.txt"),
+    ],
     ids=["pony", "horsy"],
 )
 def test_options_propagate(cli, tmpdir, datafiles, animal, expect_exists, expect_not_exists):
@@ -411,7 +423,13 @@ def test_full_path_not_found(cli, tmpdir, datafiles, target, provenance):
         # the same element
         ("override-subsubproject.bst", ["element.txt", "subsub.txt", "subdep-override.txt"]),
     ],
-    ids=["element-with-deps", "dependency-of-element", "with-link", "using-link", "priority",],
+    ids=[
+        "element-with-deps",
+        "dependency-of-element",
+        "with-link",
+        "using-link",
+        "priority",
+    ],
 )
 def test_override_element(cli, tmpdir, datafiles, target, expected):
     project = os.path.join(str(datafiles), "override-element")
@@ -590,7 +608,16 @@ def test_conflict(cli, tmpdir, datafiles, project_dir, target, provenances):
     # Special case setup the conflicting project.conf
     if target == "plugin-conflict.bst":
         update_project(
-            project, {"plugins": [{"origin": "junction", "junction": "subproject2.bst", "elements": ["found"],}]},
+            project,
+            {
+                "plugins": [
+                    {
+                        "origin": "junction",
+                        "junction": "subproject2.bst",
+                        "elements": ["found"],
+                    }
+                ]
+            },
         )
 
     result = cli.run(project=project, args=["build", target])

--- a/tests/format/link.py
+++ b/tests/format/link.py
@@ -10,7 +10,10 @@ from buildstream._testing import cli  # pylint: disable=unused-import
 from buildstream.exceptions import ErrorDomain, LoadErrorReason
 
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "link",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "link",
+)
 
 #
 # Test links to elements, this tests both specifying the link as
@@ -109,15 +112,30 @@ def test_conditional_junctions(cli, tmpdir, datafiles, greeting, expected_file):
         # Target is a link to a non-existing local element
         ("link-target.bst", "link-target.bst [line 4 column 10]"),
         # Target is a stack depending on a link to a non-existing local element
-        ("depends-on-link-target.bst", "link-target.bst [line 4 column 10]",),
+        (
+            "depends-on-link-target.bst",
+            "link-target.bst [line 4 column 10]",
+        ),
         # Depends on non-existing subproject element, via a local link
-        ("linked-local-junction-target.bst", "linked-local-junction-target.bst [line 4 column 2]",),
+        (
+            "linked-local-junction-target.bst",
+            "linked-local-junction-target.bst [line 4 column 2]",
+        ),
         # Depends on non-existing subsubproject element, via a local link
-        ("linked-nested-junction-target.bst", "linked-nested-junction-target.bst [line 4 column 2]",),
+        (
+            "linked-nested-junction-target.bst",
+            "linked-nested-junction-target.bst [line 4 column 2]",
+        ),
         # Depends on an element via a link to a non-existing local junction
-        ("linked-local-junction.bst", "subproject-link-notfound.bst [line 4 column 10]",),
+        (
+            "linked-local-junction.bst",
+            "subproject-link-notfound.bst [line 4 column 10]",
+        ),
         # Depends on an element via a link to a non-existing subproject junction
-        ("linked-nested-junction.bst", "subsubproject-link-notfound.bst [line 4 column 10]",),
+        (
+            "linked-nested-junction.bst",
+            "subsubproject-link-notfound.bst [line 4 column 10]",
+        ),
         # Target is a link to a non-existing nested element referred to with a full path
         ("link-full-path.bst", "link-full-path.bst [line 4 column 10]"),
         # Target depends on a link to a non-existing nested element referred to with a full path

--- a/tests/format/optionbool.py
+++ b/tests/format/optionbool.py
@@ -48,7 +48,11 @@ def test_conditional_cli(cli, datafiles, target, option, expected):
 #
 @pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.parametrize(
-    "target,option,expected", [("element.bst", True, "a pony"), ("element.bst", False, "not pony"),]
+    "target,option,expected",
+    [
+        ("element.bst", True, "a pony"),
+        ("element.bst", False, "not pony"),
+    ],
 )
 def test_conditional_config(cli, datafiles, target, option, expected):
     project = os.path.join(datafiles.dirname, datafiles.basename, "option-bool")

--- a/tests/format/options.py
+++ b/tests/format/options.py
@@ -14,7 +14,12 @@ DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "options")
 @pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.parametrize(
     "project_dir",
-    [("invalid-name-spaces"), ("invalid-name-dashes"), ("invalid-name-plus"), ("invalid-name-leading-number"),],
+    [
+        ("invalid-name-spaces"),
+        ("invalid-name-dashes"),
+        ("invalid-name-plus"),
+        ("invalid-name-leading-number"),
+    ],
 )
 def test_invalid_option_name(cli, datafiles, project_dir):
     project = os.path.join(datafiles.dirname, datafiles.basename, project_dir)
@@ -23,7 +28,13 @@ def test_invalid_option_name(cli, datafiles, project_dir):
 
 
 @pytest.mark.datafiles(DATA_DIR)
-@pytest.mark.parametrize("project_dir", [("invalid-variable-name-spaces"), ("invalid-variable-name-plus"),])
+@pytest.mark.parametrize(
+    "project_dir",
+    [
+        ("invalid-variable-name-spaces"),
+        ("invalid-variable-name-plus"),
+    ],
+)
 def test_invalid_variable_name(cli, datafiles, project_dir):
     project = os.path.join(datafiles.dirname, datafiles.basename, project_dir)
     result = cli.run(project=project, silent=True, args=["show", "element.bst"])
@@ -94,7 +105,13 @@ def test_invalid_condition(cli, datafiles):
 
 
 @pytest.mark.datafiles(DATA_DIR)
-@pytest.mark.parametrize("opt_option,expected_prefix", [("False", "/usr"), ("True", "/opt"),])
+@pytest.mark.parametrize(
+    "opt_option,expected_prefix",
+    [
+        ("False", "/usr"),
+        ("True", "/opt"),
+    ],
+)
 def test_simple_conditional(cli, datafiles, opt_option, expected_prefix):
     project = os.path.join(datafiles.dirname, datafiles.basename, "simple-condition")
 
@@ -112,7 +129,12 @@ def test_simple_conditional(cli, datafiles, opt_option, expected_prefix):
 @pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.parametrize(
     "debug,logging,expected",
-    [("False", "False", "False"), ("True", "False", "False"), ("False", "True", "False"), ("True", "True", "True"),],
+    [
+        ("False", "False", "False"),
+        ("True", "False", "False"),
+        ("False", "True", "False"),
+        ("True", "True", "True"),
+    ],
 )
 def test_nested_conditional(cli, datafiles, debug, logging, expected):
     project = os.path.join(datafiles.dirname, datafiles.basename, "nested-condition")
@@ -144,7 +166,12 @@ def test_nested_conditional(cli, datafiles, debug, logging, expected):
 @pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.parametrize(
     "debug,logging,expected",
-    [("False", "False", "False"), ("True", "False", "False"), ("False", "True", "False"), ("True", "True", "True"),],
+    [
+        ("False", "False", "False"),
+        ("True", "False", "False"),
+        ("False", "True", "False"),
+        ("True", "True", "True"),
+    ],
 )
 def test_compound_and_conditional(cli, datafiles, debug, logging, expected):
     project = os.path.join(datafiles.dirname, datafiles.basename, "compound-and-condition")
@@ -176,7 +203,12 @@ def test_compound_and_conditional(cli, datafiles, debug, logging, expected):
 @pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.parametrize(
     "debug,logging,expected",
-    [("False", "False", "False"), ("True", "False", "True"), ("False", "True", "True"), ("True", "True", "True"),],
+    [
+        ("False", "False", "False"),
+        ("True", "False", "True"),
+        ("False", "True", "True"),
+        ("True", "True", "True"),
+    ],
 )
 def test_compound_or_conditional(cli, datafiles, debug, logging, expected):
     project = os.path.join(datafiles.dirname, datafiles.basename, "compound-or-condition")
@@ -206,7 +238,13 @@ def test_compound_or_conditional(cli, datafiles, debug, logging, expected):
 
 
 @pytest.mark.datafiles(DATA_DIR)
-@pytest.mark.parametrize("option,expected", [("False", "horsy"), ("True", "pony"),])
+@pytest.mark.parametrize(
+    "option,expected",
+    [
+        ("False", "horsy"),
+        ("True", "pony"),
+    ],
+)
 def test_deep_nesting_level1(cli, datafiles, option, expected):
     project = os.path.join(datafiles.dirname, datafiles.basename, "deep-nesting")
     result = cli.run(
@@ -223,7 +261,13 @@ def test_deep_nesting_level1(cli, datafiles, option, expected):
 
 
 @pytest.mark.datafiles(DATA_DIR)
-@pytest.mark.parametrize("option,expected", [("False", "horsy"), ("True", "pony"),])
+@pytest.mark.parametrize(
+    "option,expected",
+    [
+        ("False", "horsy"),
+        ("True", "pony"),
+    ],
+)
 def test_deep_nesting_level2(cli, datafiles, option, expected):
     project = os.path.join(datafiles.dirname, datafiles.basename, "deep-nesting")
     result = cli.run(

--- a/tests/format/stack.py
+++ b/tests/format/stack.py
@@ -15,7 +15,13 @@ DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "stack")
 # build-only dependencies.
 #
 @pytest.mark.datafiles(DATA_DIR)
-@pytest.mark.parametrize("target", ["build-only-stack.bst", "runtime-only-stack.bst",])
+@pytest.mark.parametrize(
+    "target",
+    [
+        "build-only-stack.bst",
+        "runtime-only-stack.bst",
+    ],
+)
 def test_require_build_and_run(cli, datafiles, target):
     project = str(datafiles)
     result = cli.run(project=project, args=["show", target])

--- a/tests/format/variables.py
+++ b/tests/format/variables.py
@@ -27,7 +27,8 @@ def print_warning(msg):
 #  Test proper loading of some default commands from plugins  #
 ###############################################################
 @pytest.mark.parametrize(
-    "target,varname,expected", [("autotools.bst", "make-install", 'make -j1 DESTDIR="/buildstream-install" install')],
+    "target,varname,expected",
+    [("autotools.bst", "make-install", 'make -j1 DESTDIR="/buildstream-install" install')],
 )
 @pytest.mark.datafiles(os.path.join(DATA_DIR, "defaults"))
 def test_defaults(cli, datafiles, target, varname, expected):
@@ -42,7 +43,8 @@ def test_defaults(cli, datafiles, target, varname, expected):
 #  Test overriding of variables to produce different commands  #
 ################################################################
 @pytest.mark.parametrize(
-    "target,varname,expected", [("autotools.bst", "make-install", 'make -j1 DESTDIR="/custom/install/root" install')],
+    "target,varname,expected",
+    [("autotools.bst", "make-install", 'make -j1 DESTDIR="/custom/install/root" install')],
 )
 @pytest.mark.datafiles(os.path.join(DATA_DIR, "overrides"))
 def test_overrides(cli, datafiles, target, varname, expected):
@@ -113,7 +115,8 @@ def test_circular_reference(cli, datafiles, element, provenances):
 # on a recursive algorithm limited by stack depth.
 #
 @pytest.mark.parametrize(
-    "maxvars", [50, 500, 5000],
+    "maxvars",
+    [50, 500, 5000],
 )
 @pytest.mark.datafiles(os.path.join(DATA_DIR, "defaults"))
 def test_deep_references(cli, datafiles, maxvars):

--- a/tests/frontend/artifact_checkout.py
+++ b/tests/frontend/artifact_checkout.py
@@ -63,7 +63,8 @@ def test_checkout(cli, tmpdir, datafiles, deps, expect_exist, expect_noexist, wi
 
         # Now checkout the artifact
         result = cli.run(
-            project=project, args=["artifact", "checkout", "--directory", checkout, "--deps", deps, artifact_name],
+            project=project,
+            args=["artifact", "checkout", "--directory", checkout, "--deps", deps, artifact_name],
         )
 
         if deps in ["all", "run"]:

--- a/tests/frontend/artifact_delete.py
+++ b/tests/frontend/artifact_delete.py
@@ -27,7 +27,10 @@ from tests.testutils import create_artifact_share
 
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 # Test that we can delete the artifact of the element which corresponds

--- a/tests/frontend/artifact_list_contents.py
+++ b/tests/frontend/artifact_list_contents.py
@@ -25,7 +25,10 @@ from buildstream.exceptions import ErrorDomain
 
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 @pytest.mark.datafiles(DATA_DIR)

--- a/tests/frontend/artifact_log.py
+++ b/tests/frontend/artifact_log.py
@@ -25,7 +25,10 @@ from buildstream._testing import cli  # pylint: disable=unused-import
 
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 @pytest.mark.datafiles(DATA_DIR)

--- a/tests/frontend/artifact_show.py
+++ b/tests/frontend/artifact_show.py
@@ -26,8 +26,14 @@ from tests.testutils import create_artifact_share
 
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
-SIMPLE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "simple",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
+SIMPLE_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "simple",
+)
 
 
 # Test artifact show
@@ -159,7 +165,10 @@ def test_artifact_show_element_available_remotely(cli, tmpdir, datafiles):
     local_cache = os.path.join(str(tmpdir), "artifacts")
     with create_artifact_share(os.path.join(str(tmpdir), "remote")) as remote:
         cli.configure(
-            {"artifacts": {"servers": [{"url": remote.repo, "push": True}]}, "cachedir": local_cache,}
+            {
+                "artifacts": {"servers": [{"url": remote.repo, "push": True}]},
+                "cachedir": local_cache,
+            }
         )
 
         # Build the element

--- a/tests/frontend/buildcheckout.py
+++ b/tests/frontend/buildcheckout.py
@@ -21,7 +21,10 @@ from tests.testutils import generate_junction, create_artifact_share
 from . import configure_project
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 def strict_args(args, strict):
@@ -33,7 +36,12 @@ def strict_args(args, strict):
 @pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.parametrize(
     "strict,hardlinks",
-    [("strict", "copies"), ("strict", "hardlinks"), ("non-strict", "copies"), ("non-strict", "hardlinks"),],
+    [
+        ("strict", "copies"),
+        ("strict", "hardlinks"),
+        ("non-strict", "copies"),
+        ("non-strict", "hardlinks"),
+    ],
 )
 def test_build_checkout(datafiles, cli, strict, hardlinks):
     if CASD_SEPARATE_USER and hardlinks == "hardlinks":
@@ -985,7 +993,15 @@ def test_build_junction_short_notation_with_junction(cli, tmpdir, datafiles):
 
     # Create a stack element to depend on a cross junction element, using
     # colon (:) as the separator
-    element = {"kind": "stack", "depends": [{"filename": "junction.bst:import-etc.bst", "junction": "junction.bst",}]}
+    element = {
+        "kind": "stack",
+        "depends": [
+            {
+                "filename": "junction.bst:import-etc.bst",
+                "junction": "junction.bst",
+            }
+        ],
+    }
     _yaml.roundtrip_dump(element, element_path)
 
     # Now try to build it, this should fail as filenames should not contain
@@ -1104,7 +1120,10 @@ def test_fail_no_args(datafiles, cli):
 # While we were unable to reproduce the exact experience, we can test
 # the expected behavior.
 #
-STRICT_DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "strict-scenario",)
+STRICT_DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "strict-scenario",
+)
 
 
 @pytest.mark.datafiles(STRICT_DATA_DIR)

--- a/tests/frontend/compose_splits.py
+++ b/tests/frontend/compose_splits.py
@@ -6,7 +6,10 @@ import pytest
 from buildstream._testing.runcli import cli  # pylint: disable=unused-import
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 @pytest.mark.parametrize("target", [("compose-include-bin.bst"), ("compose-exclude-dev.bst")])

--- a/tests/frontend/default_target.py
+++ b/tests/frontend/default_target.py
@@ -10,7 +10,10 @@ from buildstream._testing import cli, create_repo  # pylint: disable=unused-impo
 from tests.testutils import create_artifact_share
 
 # project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "default-target",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "default-target",
+)
 
 
 #
@@ -71,7 +74,15 @@ def test_no_default_with_junction(cli, datafiles):
     target_path = os.path.join(project, "elements", "junction-target.bst")
 
     # First, create a junction element to refer to the subproject
-    junction_config = {"kind": "junction", "sources": [{"kind": "local", "path": "files/sub-project",}]}
+    junction_config = {
+        "kind": "junction",
+        "sources": [
+            {
+                "kind": "local",
+                "path": "files/sub-project",
+            }
+        ],
+    }
     _yaml.roundtrip_dump(junction_config, junction_path)
 
     # Then, create a stack element with dependency on cross junction element

--- a/tests/frontend/large_directory.py
+++ b/tests/frontend/large_directory.py
@@ -28,7 +28,10 @@ from tests.testutils import create_artifact_share, assert_shared
 
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 @contextmanager
@@ -63,7 +66,15 @@ def test_large_directory(cli, tmpdir, datafiles):
 
     with create_artifact_share(os.path.join(str(tmpdir), "artifactshare")) as share:
         # Configure bst to push to the artifact share
-        cli.configure({"artifacts": {"servers": [{"url": share.repo, "push": True},]}})
+        cli.configure(
+            {
+                "artifacts": {
+                    "servers": [
+                        {"url": share.repo, "push": True},
+                    ]
+                }
+            }
+        )
 
         # Enforce 1 MB gRPC message limit
         with limit_grpc_message_length(MAX_MESSAGE_LENGTH):

--- a/tests/frontend/mirror.py
+++ b/tests/frontend/mirror.py
@@ -40,23 +40,77 @@ def generate_element(output_file):
 
 
 DEFAULT_MIRROR_LIST = [
-    {"name": "middle-earth", "aliases": {"foo": ["OOF/"], "bar": ["RAB/"],},},
-    {"name": "arrakis", "aliases": {"foo": ["OFO/"], "bar": ["RBA/"],},},
-    {"name": "oz", "aliases": {"foo": ["ooF/"], "bar": ["raB/"],}},
+    {
+        "name": "middle-earth",
+        "aliases": {
+            "foo": ["OOF/"],
+            "bar": ["RAB/"],
+        },
+    },
+    {
+        "name": "arrakis",
+        "aliases": {
+            "foo": ["OFO/"],
+            "bar": ["RBA/"],
+        },
+    },
+    {
+        "name": "oz",
+        "aliases": {
+            "foo": ["ooF/"],
+            "bar": ["raB/"],
+        },
+    },
 ]
 
 
 SUCCESS_MIRROR_LIST = [
-    {"name": "middle-earth", "aliases": {"foo": ["OOF/"], "bar": ["RAB/"],},},
-    {"name": "arrakis", "aliases": {"foo": ["FOO/"], "bar": ["RBA/"],},},
-    {"name": "oz", "aliases": {"foo": ["ooF/"], "bar": ["raB/"],}},
+    {
+        "name": "middle-earth",
+        "aliases": {
+            "foo": ["OOF/"],
+            "bar": ["RAB/"],
+        },
+    },
+    {
+        "name": "arrakis",
+        "aliases": {
+            "foo": ["FOO/"],
+            "bar": ["RBA/"],
+        },
+    },
+    {
+        "name": "oz",
+        "aliases": {
+            "foo": ["ooF/"],
+            "bar": ["raB/"],
+        },
+    },
 ]
 
 
 FAIL_MIRROR_LIST = [
-    {"name": "middle-earth", "aliases": {"foo": ["pony/"], "bar": ["horzy/"],},},
-    {"name": "arrakis", "aliases": {"foo": ["donkey/"], "bar": ["rabbit/"],},},
-    {"name": "oz", "aliases": {"foo": ["bear/"], "bar": ["buffalo/"],}},
+    {
+        "name": "middle-earth",
+        "aliases": {
+            "foo": ["pony/"],
+            "bar": ["horzy/"],
+        },
+    },
+    {
+        "name": "arrakis",
+        "aliases": {
+            "foo": ["donkey/"],
+            "bar": ["rabbit/"],
+        },
+    },
+    {
+        "name": "oz",
+        "aliases": {
+            "foo": ["bear/"],
+            "bar": ["buffalo/"],
+        },
+    },
 ]
 
 
@@ -438,7 +492,14 @@ def test_mirror_git_submodule_fetch(cli, tmpdir, datafiles):
         "min-version": "2.0",
         "element-path": "elements",
         "aliases": {alias: "http://www.example.com/"},
-        "mirrors": [{"name": "middle-earth", "aliases": {alias: [mirror_map + "/"],},},],
+        "mirrors": [
+            {
+                "name": "middle-earth",
+                "aliases": {
+                    alias: [mirror_map + "/"],
+                },
+            },
+        ],
     }
     project_file = os.path.join(project_dir, "project.conf")
     _yaml.roundtrip_dump(project, project_file)
@@ -510,7 +571,14 @@ def test_mirror_fallback_git_only_submodules(cli, tmpdir, datafiles):
         "min-version": "2.0",
         "element-path": "elements",
         "aliases": {alias: upstream_map + "/"},
-        "mirrors": [{"name": "middle-earth", "aliases": {alias: [mirror_map + "/"],}}],
+        "mirrors": [
+            {
+                "name": "middle-earth",
+                "aliases": {
+                    alias: [mirror_map + "/"],
+                },
+            }
+        ],
     }
     project_file = os.path.join(project_dir, "project.conf")
     _yaml.roundtrip_dump(project, project_file)
@@ -596,7 +664,14 @@ def test_mirror_fallback_git_with_submodules(cli, tmpdir, datafiles):
         "min-version": "2.0",
         "element-path": "elements",
         "aliases": {alias: upstream_map + "/"},
-        "mirrors": [{"name": "middle-earth", "aliases": {alias: [mirror_map + "/"],}}],
+        "mirrors": [
+            {
+                "name": "middle-earth",
+                "aliases": {
+                    alias: [mirror_map + "/"],
+                },
+            }
+        ],
     }
     project_file = os.path.join(project_dir, "project.conf")
     _yaml.roundtrip_dump(project, project_file)
@@ -634,11 +709,32 @@ def test_mirror_expand_project_and_toplevel_root(cli, tmpdir):
         "name": "test",
         "min-version": "2.0",
         "element-path": "elements",
-        "aliases": {"foo": "FOO/", "bar": "BAR/",},
+        "aliases": {
+            "foo": "FOO/",
+            "bar": "BAR/",
+        },
         "mirrors": [
-            {"name": "middle-earth", "aliases": {"foo": ["OOF/"], "bar": ["RAB/"],},},
-            {"name": "arrakis", "aliases": {"foo": ["%{project-root}/OFO/"], "bar": ["%{project-root}/RBA/"],},},
-            {"name": "oz", "aliases": {"foo": ["ooF/"], "bar": ["raB/"],}},
+            {
+                "name": "middle-earth",
+                "aliases": {
+                    "foo": ["OOF/"],
+                    "bar": ["RAB/"],
+                },
+            },
+            {
+                "name": "arrakis",
+                "aliases": {
+                    "foo": ["%{project-root}/OFO/"],
+                    "bar": ["%{project-root}/RBA/"],
+                },
+            },
+            {
+                "name": "oz",
+                "aliases": {
+                    "foo": ["ooF/"],
+                    "bar": ["raB/"],
+                },
+            },
         ],
         "plugins": [{"origin": "local", "path": "sources", "sources": ["fetch_source"]}],
     }

--- a/tests/frontend/order.py
+++ b/tests/frontend/order.py
@@ -9,7 +9,10 @@ from buildstream._testing import cli  # pylint: disable=unused-import
 from buildstream import _yaml
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 # create_element()

--- a/tests/frontend/progress.py
+++ b/tests/frontend/progress.py
@@ -11,7 +11,9 @@ from buildstream.exceptions import ErrorDomain, LoadErrorReason
 from tests.testutils import generate_junction
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+)
 
 
 @pytest.mark.datafiles(os.path.join(DATA_DIR, "project"))

--- a/tests/frontend/pull.py
+++ b/tests/frontend/pull.py
@@ -18,7 +18,10 @@ from tests.testutils import (
 
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 # Tests that:
@@ -91,7 +94,14 @@ def test_pull_secondary_cache(cli, tmpdir, datafiles):
 
         # Build the target and push it to share2 only.
         cli.configure(
-            {"artifacts": {"servers": [{"url": share1.repo, "push": False}, {"url": share2.repo, "push": True},]}}
+            {
+                "artifacts": {
+                    "servers": [
+                        {"url": share1.repo, "push": False},
+                        {"url": share2.repo, "push": True},
+                    ]
+                }
+            }
         )
         result = cli.run(project=project, args=["build", "target.bst"])
         result.assert_success()
@@ -139,7 +149,15 @@ def test_push_pull_specific_remote(cli, tmpdir, datafiles):
 
         # Configure the default push location to be bad_share; we will assert that
         # nothing actually gets pushed there.
-        cli.configure({"artifacts": {"servers": [{"url": bad_share.repo, "push": True},]}})
+        cli.configure(
+            {
+                "artifacts": {
+                    "servers": [
+                        {"url": bad_share.repo, "push": True},
+                    ]
+                }
+            }
+        )
 
         # Now try `bst artifact push` to the good_share.
         result = cli.run(

--- a/tests/frontend/push.py
+++ b/tests/frontend/push.py
@@ -40,7 +40,10 @@ from tests.testutils import (
 
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 # Tests that:
@@ -76,7 +79,14 @@ def test_push(cli, tmpdir, datafiles):
 
             # Configure bst to push to one of the caches and run `bst artifact push`. This works.
             cli.configure(
-                {"artifacts": {"servers": [{"url": share1.repo, "push": False}, {"url": share2.repo, "push": True},]}}
+                {
+                    "artifacts": {
+                        "servers": [
+                            {"url": share1.repo, "push": False},
+                            {"url": share2.repo, "push": True},
+                        ]
+                    }
+                }
             )
             cli.run(project=project, args=["artifact", "push", "target.bst"])
 
@@ -87,7 +97,14 @@ def test_push(cli, tmpdir, datafiles):
 
         with create_artifact_share(os.path.join(str(tmpdir), "artifactshare2")) as share2:
             cli.configure(
-                {"artifacts": {"servers": [{"url": share1.repo, "push": True}, {"url": share2.repo, "push": True},]}}
+                {
+                    "artifacts": {
+                        "servers": [
+                            {"url": share1.repo, "push": True},
+                            {"url": share2.repo, "push": True},
+                        ]
+                    }
+                }
             )
             cli.run(project=project, args=["artifact", "push", "target.bst"])
 
@@ -128,7 +145,14 @@ def test_push_artifact(cli, tmpdir, datafiles):
                 #        only, but it should probably be fixed.
                 #
                 "scheduler": {"pushers": 1},
-                "artifacts": {"servers": [{"url": share.repo, "push": True,}]},
+                "artifacts": {
+                    "servers": [
+                        {
+                            "url": share.repo,
+                            "push": True,
+                        }
+                    ]
+                },
             }
         )
 
@@ -187,7 +211,15 @@ def test_push_fails(cli, tmpdir, datafiles):
     # Set up the share
     with create_artifact_share(os.path.join(str(tmpdir), "artifactshare")) as share:
         # Configure bst to be able to push to the share
-        cli.configure({"artifacts": {"servers": [{"url": share.repo, "push": True},]}})
+        cli.configure(
+            {
+                "artifacts": {
+                    "servers": [
+                        {"url": share.repo, "push": True},
+                    ]
+                }
+            }
+        )
 
         # First ensure that the target is *NOT* cache
         assert cli.get_element_state(project, "target.bst") != "cached"
@@ -225,7 +257,15 @@ def test_push_fails_with_on_error_continue(cli, tmpdir, datafiles):
         assert cli.get_element_state(project, "import-dev.bst") != "cached"
 
         # Configure bst to be able to push to the share
-        cli.configure({"artifacts": {"servers": [{"url": share.repo, "push": True},]}})
+        cli.configure(
+            {
+                "artifacts": {
+                    "servers": [
+                        {"url": share.repo, "push": True},
+                    ]
+                }
+            }
+        )
 
         # Now try and push the target with its deps using --on-error continue
         # and assert that push failed, but what could be pushed was pushed
@@ -283,7 +323,14 @@ def test_push_deps(cli, tmpdir, datafiles, deps, expected_states):
                 #        only, but it should probably be fixed.
                 #
                 "scheduler": {"pushers": 1},
-                "artifacts": {"servers": [{"url": share.repo, "push": True,}]},
+                "artifacts": {
+                    "servers": [
+                        {
+                            "url": share.repo,
+                            "push": True,
+                        }
+                    ]
+                },
             }
         )
 
@@ -332,7 +379,14 @@ def test_push_artifacts_all_deps_fails(cli, tmpdir, datafiles):
                 #        only, but it should probably be fixed.
                 #
                 "scheduler": {"pushers": 1},
-                "artifacts": {"servers": [{"url": share.repo, "push": True,}]},
+                "artifacts": {
+                    "servers": [
+                        {
+                            "url": share.repo,
+                            "push": True,
+                        }
+                    ]
+                },
             }
         )
 
@@ -355,7 +409,15 @@ def test_push_after_pull(cli, tmpdir, datafiles):
 
         # Set the scene: share1 has the artifact, share2 does not.
         #
-        cli.configure({"artifacts": {"servers": [{"url": share1.repo, "push": True},]}})
+        cli.configure(
+            {
+                "artifacts": {
+                    "servers": [
+                        {"url": share1.repo, "push": True},
+                    ]
+                }
+            }
+        )
 
         result = cli.run(project=project, args=["build", "target.bst"])
         result.assert_success()
@@ -380,7 +442,14 @@ def test_push_after_pull(cli, tmpdir, datafiles):
         # Now we add share2 into the mix as a second push remote. This time,
         # `bst build` should push to share2 after pulling from share1.
         cli.configure(
-            {"artifacts": {"servers": [{"url": share1.repo, "push": True}, {"url": share2.repo, "push": True},]}}
+            {
+                "artifacts": {
+                    "servers": [
+                        {"url": share1.repo, "push": True},
+                        {"url": share2.repo, "push": True},
+                    ]
+                }
+            }
         )
         result = cli.run(project=project, args=["build", "target.bst"])
         result.assert_success()
@@ -401,7 +470,15 @@ def test_artifact_expires(cli, datafiles, tmpdir):
     with create_artifact_share(os.path.join(str(tmpdir), "artifactshare"), quota=int(22e6)) as share:
 
         # Configure bst to push to the cache
-        cli.configure({"artifacts": {"servers": [{"url": share.repo, "push": True},]}})
+        cli.configure(
+            {
+                "artifacts": {
+                    "servers": [
+                        {"url": share.repo, "push": True},
+                    ]
+                }
+            }
+        )
 
         # Create and build an element of 15 MB
         create_element_size("element1.bst", project, element_path, [], int(15e6))
@@ -451,7 +528,13 @@ def test_artifact_too_large(cli, datafiles, tmpdir):
     with create_artifact_share(os.path.join(str(tmpdir), "artifactshare"), quota=int(5e6)) as share:
 
         # Configure bst to push to the remote cache
-        cli.configure({"artifacts": {"servers": [{"url": share.repo, "push": True}],}})
+        cli.configure(
+            {
+                "artifacts": {
+                    "servers": [{"url": share.repo, "push": True}],
+                }
+            }
+        )
 
         # Create and push a 3MB element
         create_element_size("small_element.bst", project, element_path, [], int(3e6))
@@ -502,7 +585,13 @@ def test_recently_pulled_artifact_does_not_expire(cli, datafiles, tmpdir):
     with create_artifact_share(os.path.join(str(tmpdir), "artifactshare"), quota=int(22e6)) as share:
 
         # Configure bst to push to the cache
-        cli.configure({"artifacts": {"servers": [{"url": share.repo, "push": True}],}})
+        cli.configure(
+            {
+                "artifacts": {
+                    "servers": [{"url": share.repo, "push": True}],
+                }
+            }
+        )
 
         # Create and build 2 elements, one 5 MB and one 15 MB.
         create_element_size("element1.bst", project, element_path, [], int(5e6))
@@ -564,7 +653,13 @@ def test_push_cross_junction(cli, tmpdir, datafiles):
     assert cli.get_element_state(project, "junction.bst:import-etc.bst") == "cached"
 
     with create_artifact_share(os.path.join(str(tmpdir), "artifactshare")) as share:
-        cli.configure({"artifacts": {"servers": [{"url": share.repo, "push": True}],}})
+        cli.configure(
+            {
+                "artifacts": {
+                    "servers": [{"url": share.repo, "push": True}],
+                }
+            }
+        )
         cli.run(project=project, args=["artifact", "push", "junction.bst:import-etc.bst"])
 
         cache_key = cli.get_element_key(project, "junction.bst:import-etc.bst")

--- a/tests/frontend/rebuild.py
+++ b/tests/frontend/rebuild.py
@@ -6,7 +6,10 @@ import pytest
 from buildstream._testing import cli  # pylint: disable=unused-import
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 def strict_args(args, strict):

--- a/tests/frontend/remote-caches.py
+++ b/tests/frontend/remote-caches.py
@@ -74,8 +74,22 @@ def test_source_artifact_caches(cli, tmpdir, datafiles):
         user_config_file = str(tmpdir.join("buildstream.conf"))
         user_config = {
             "scheduler": {"pushers": 1},
-            "source-caches": {"servers": [{"url": share.repo, "push": True,}]},
-            "artifacts": {"servers": [{"url": share.repo, "push": True,}]},
+            "source-caches": {
+                "servers": [
+                    {
+                        "url": share.repo,
+                        "push": True,
+                    }
+                ]
+            },
+            "artifacts": {
+                "servers": [
+                    {
+                        "url": share.repo,
+                        "push": True,
+                    }
+                ]
+            },
             "cachedir": cachedir,
         }
         _yaml.roundtrip_dump(user_config, file=user_config_file)
@@ -109,8 +123,22 @@ def test_source_cache_empty_artifact_cache(cli, tmpdir, datafiles):
         user_config_file = str(tmpdir.join("buildstream.conf"))
         user_config = {
             "scheduler": {"pushers": 1},
-            "source-caches": {"servers": [{"url": share.repo, "push": True,}]},
-            "artifacts": {"servers": [{"url": share.repo, "push": True,}]},
+            "source-caches": {
+                "servers": [
+                    {
+                        "url": share.repo,
+                        "push": True,
+                    }
+                ]
+            },
+            "artifacts": {
+                "servers": [
+                    {
+                        "url": share.repo,
+                        "push": True,
+                    }
+                ]
+            },
             "cachedir": cachedir,
         }
         _yaml.roundtrip_dump(user_config, file=user_config_file)

--- a/tests/frontend/show.py
+++ b/tests/frontend/show.py
@@ -15,7 +15,9 @@ from tests.testutils import generate_junction
 from . import configure_project
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+)
 
 
 @pytest.mark.datafiles(os.path.join(DATA_DIR, "project"))
@@ -36,7 +38,12 @@ def test_show(cli, datafiles, target, fmt, expected):
         raise AssertionError("Expected output:\n{}\nInstead received output:\n{}".format(expected, result.output))
 
 
-@pytest.mark.datafiles(os.path.join(os.path.dirname(os.path.realpath(__file__)), "invalid_element_path",))
+@pytest.mark.datafiles(
+    os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "invalid_element_path",
+    )
+)
 def test_show_invalid_element_path(cli, datafiles):
     project = str(datafiles)
     cli.run(project=project, silent=True, args=["show", "foo.bst"])
@@ -196,7 +203,14 @@ def test_show_except_simple(cli, datafiles, target, except_, expected):
             ],
         ),
         # Test one target and excepting two elements
-        (["build.bst"], ["unrelated-1.bst", "unrelated-2.bst"], ["first-level-1.bst", "build.bst",]),
+        (
+            ["build.bst"],
+            ["unrelated-1.bst", "unrelated-2.bst"],
+            [
+                "first-level-1.bst",
+                "build.bst",
+            ],
+        ),
     ],
 )
 def test_show_except(cli, datafiles, targets, exceptions, expected):
@@ -432,7 +446,15 @@ def test_format_deps(cli, datafiles, dep_kind, expected_deps):
 #
 @pytest.mark.datafiles(os.path.join(DATA_DIR, "project"))
 @pytest.mark.parametrize(
-    "cli_value, config_value", [(None, None), (None, "16"), ("16", None), ("5", "16"), ("0", "16"), ("16", "0"),]
+    "cli_value, config_value",
+    [
+        (None, None),
+        (None, "16"),
+        ("16", None),
+        ("5", "16"),
+        ("0", "16"),
+        ("16", "0"),
+    ],
 )
 def test_max_jobs(cli, datafiles, cli_value, config_value):
     project = str(datafiles)
@@ -486,7 +508,11 @@ def test_max_jobs(cli, datafiles, cli_value, config_value):
 #
 @pytest.mark.datafiles(os.path.join(DATA_DIR, "strict-depends"))
 @pytest.mark.parametrize(
-    "target, expected_state", [("non-strict-depends.bst", "cached"), ("strict-depends.bst", "waiting"),]
+    "target, expected_state",
+    [
+        ("non-strict-depends.bst", "cached"),
+        ("strict-depends.bst", "waiting"),
+    ],
 )
 def test_strict_dependencies(cli, datafiles, target, expected_state):
     project = str(datafiles)

--- a/tests/frontend/source_checkout.py
+++ b/tests/frontend/source_checkout.py
@@ -11,7 +11,10 @@ from buildstream._testing import cli  # pylint: disable=unused-import
 from buildstream import utils, _yaml
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 def generate_remote_import_element(input_path, output_path):

--- a/tests/frontend/workspace.py
+++ b/tests/frontend/workspace.py
@@ -44,7 +44,10 @@ from tests.testutils import create_artifact_share, create_element_size, wait_for
 repo_kinds = ALL_REPO_KINDS
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 BASE_FILENAME = os.path.basename(__file__)
 
 
@@ -100,7 +103,9 @@ class WorkspaceCreator:
         element_tuples = []
 
         if suffixs is None:
-            suffixs = ["",] * len(kinds)
+            suffixs = [
+                "",
+            ] * len(kinds)
         else:
             assert len(suffixs) == len(kinds)
 
@@ -590,7 +595,15 @@ def test_reset_multiple(cli, tmpdir, datafiles):
 
     # Now reset the open workspaces, this should have the
     # effect of reverting our changes.
-    result = cli.run(project=project, args=["workspace", "reset", alpha, beta,])
+    result = cli.run(
+        project=project,
+        args=[
+            "workspace",
+            "reset",
+            alpha,
+            beta,
+        ],
+    )
     result.assert_success()
     assert os.path.exists(os.path.join(workspace_alpha, "usr", "bin", "hello"))
     assert not os.path.exists(os.path.join(workspace_beta, "etc", "pony.conf"))
@@ -804,7 +817,13 @@ def test_detect_modifications(cli, tmpdir, datafiles, modification, strict):
         # Test loading a negative workspace version
         {"format-version": -1},
         # Test loading version 0 with two sources
-        {"format-version": 0, "alpha.bst": {0: "/workspaces/bravo", 1: "/workspaces/charlie",}},
+        {
+            "format-version": 0,
+            "alpha.bst": {
+                0: "/workspaces/bravo",
+                1: "/workspaces/charlie",
+            },
+        },
         # Test loading a version with decimals
         {"format-version": 0.5},
         # Test loading an unsupported old version
@@ -832,7 +851,10 @@ def test_list_unsupported_workspace(cli, datafiles, workspace_cfg):
     [
         # Test loading version 4
         (
-            {"format-version": 4, "workspaces": {"alpha.bst": {"path": "/workspaces/bravo"}},},
+            {
+                "format-version": 4,
+                "workspaces": {"alpha.bst": {"path": "/workspaces/bravo"}},
+            },
             {
                 "format-version": BST_WORKSPACE_FORMAT_VERSION,
                 "workspaces": {"alpha.bst": {"path": "/workspaces/bravo"}},

--- a/tests/integration/artifact.py
+++ b/tests/integration/artifact.py
@@ -35,7 +35,10 @@ pytestmark = pytest.mark.integration
 
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 # A test to capture the integration of the cachebuildtrees

--- a/tests/integration/cachedfail.py
+++ b/tests/integration/cachedfail.py
@@ -43,8 +43,18 @@ def test_build_checkout_cached_fail(cli, datafiles):
     # Write out our test target
     element = {
         "kind": "script",
-        "depends": [{"filename": "base.bst", "type": "build",},],
-        "config": {"commands": ["touch %{install-root}/foo", "false",],},
+        "depends": [
+            {
+                "filename": "base.bst",
+                "type": "build",
+            },
+        ],
+        "config": {
+            "commands": [
+                "touch %{install-root}/foo",
+                "false",
+            ],
+        },
     }
     _yaml.roundtrip_dump(element, element_path)
 
@@ -73,14 +83,37 @@ def test_build_depend_on_cached_fail(cli, datafiles):
 
     dep = {
         "kind": "script",
-        "depends": [{"filename": "base.bst", "type": "build",},],
-        "config": {"commands": ["touch %{install-root}/foo", "false",],},
+        "depends": [
+            {
+                "filename": "base.bst",
+                "type": "build",
+            },
+        ],
+        "config": {
+            "commands": [
+                "touch %{install-root}/foo",
+                "false",
+            ],
+        },
     }
     _yaml.roundtrip_dump(dep, dep_path)
     target = {
         "kind": "script",
-        "depends": [{"filename": "base.bst", "type": "build",}, {"filename": "dep.bst", "type": "build",},],
-        "config": {"commands": ["test -e /foo",],},
+        "depends": [
+            {
+                "filename": "base.bst",
+                "type": "build",
+            },
+            {
+                "filename": "dep.bst",
+                "type": "build",
+            },
+        ],
+        "config": {
+            "commands": [
+                "test -e /foo",
+            ],
+        },
     }
     _yaml.roundtrip_dump(target, target_path)
 
@@ -112,7 +145,12 @@ def test_push_cached_fail(cli, tmpdir, datafiles, on_error):
     # Write out our test target
     element = {
         "kind": "script",
-        "depends": [{"filename": "base.bst", "type": "build",},],
+        "depends": [
+            {
+                "filename": "base.bst",
+                "type": "build",
+            },
+        ],
         "config": {
             "commands": [
                 "false",
@@ -191,13 +229,26 @@ def test_host_tools_errors_are_not_cached(cli, datafiles, tmp_path):
     # Write out our test target
     element = {
         "kind": "script",
-        "depends": [{"filename": "base.bst", "type": "build",},],
-        "config": {"commands": ["true",],},
+        "depends": [
+            {
+                "filename": "base.bst",
+                "type": "build",
+            },
+        ],
+        "config": {
+            "commands": [
+                "true",
+            ],
+        },
     }
     _yaml.roundtrip_dump(element, element_path)
 
     # Build without access to host tools, this will fail
-    result1 = cli.run(project=project, args=["build", "element.bst"], env={"PATH": str(tmp_path.joinpath("bin"))},)
+    result1 = cli.run(
+        project=project,
+        args=["build", "element.bst"],
+        env={"PATH": str(tmp_path.joinpath("bin"))},
+    )
     result1.assert_task_error(ErrorDomain.SANDBOX, "unavailable-local-sandbox")
     assert cli.get_element_state(project, "element.bst") == "buildable"
 

--- a/tests/integration/interactive_build.py
+++ b/tests/integration/interactive_build.py
@@ -27,7 +27,15 @@ def build_session(datafiles, element_name):
     with runcli.configured(project) as config_file:
         session = pexpect.spawn(
             "bst",
-            ["--directory", project, "--config", config_file, "--no-colors", "build", element_name,],
+            [
+                "--directory",
+                project,
+                "--config",
+                config_file,
+                "--no-colors",
+                "build",
+                element_name,
+            ],
             timeout=PEXPECT_TIMEOUT_SHORT,
         )
         yield session

--- a/tests/integration/manual.py
+++ b/tests/integration/manual.py
@@ -171,7 +171,12 @@ def test_manual_command_subdir(cli, datafiles):
     sources = [{"kind": "local", "path": "files/manual-element/root"}]
 
     create_manual_element(
-        element_name, element_path, {"install-commands": ["cp hello %{install-root}"]}, {}, {}, sources=sources,
+        element_name,
+        element_path,
+        {"install-commands": ["cp hello %{install-root}"]},
+        {},
+        {},
+        sources=sources,
     )
 
     # First, verify that element builds, and has the correct expected output.

--- a/tests/integration/messages.py
+++ b/tests/integration/messages.py
@@ -32,7 +32,10 @@ pytestmark = pytest.mark.integration
 
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 @pytest.mark.datafiles(DATA_DIR)

--- a/tests/integration/pullbuildtrees.py
+++ b/tests/integration/pullbuildtrees.py
@@ -170,7 +170,13 @@ def test_pullbuildtrees(cli2, tmpdir, datafiles):
 def test_invalid_cache_pullbuildtrees(cli, datafiles, value, success):
     project = str(datafiles)
 
-    cli.configure({"cache": {"pull-buildtrees": value,}})
+    cli.configure(
+        {
+            "cache": {
+                "pull-buildtrees": value,
+            }
+        }
+    )
 
     res = cli.run(project=project, args=["workspace", "list"])
     if success:

--- a/tests/integration/script.py
+++ b/tests/integration/script.py
@@ -43,7 +43,9 @@ def test_script(cli, datafiles):
     create_script_element(
         element_name,
         element_path,
-        config={"commands": ["mkdir -p %{install-root}", "echo 'Hi' > %{install-root}/test"],},
+        config={
+            "commands": ["mkdir -p %{install-root}", "echo 'Hi' > %{install-root}/test"],
+        },
     )
 
     res = cli.run(project=project, args=["build", element_name])
@@ -130,7 +132,9 @@ def test_script_cwd(cli, datafiles):
     create_script_element(
         element_name,
         element_path,
-        config={"commands": ["echo 'test' > test", "cp /buildstream/test %{install-root}"],},
+        config={
+            "commands": ["echo 'test' > test", "cp /buildstream/test %{install-root}"],
+        },
         variables={"cwd": "/buildstream"},
     )
 

--- a/tests/integration/shellbuildtrees.py
+++ b/tests/integration/shellbuildtrees.py
@@ -296,7 +296,16 @@ def test_shell_pull_cached_buildtree(share_with_buildtrees, datafiles, cli, pull
     # Run the shell and request that required artifacts and buildtrees should be pulled
     result = cli.run(
         project=project,
-        args=["--pull-buildtrees", "shell", "--build", element_name, "--use-buildtree", "--", "cat", "test",],
+        args=[
+            "--pull-buildtrees",
+            "shell",
+            "--build",
+            element_name,
+            "--use-buildtree",
+            "--",
+            "cat",
+            "test",
+        ],
     )
 
     # In this case, we should succeed every time, regardless of what was

--- a/tests/integration/source-determinism.py
+++ b/tests/integration/source-determinism.py
@@ -30,8 +30,7 @@ def create_test_directory(*path, mode=0o644):
 @pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.skipif(not HAVE_SANDBOX, reason="Only available with a functioning sandbox")
 def test_deterministic_source_local(cli, tmpdir, datafiles):
-    """Only user rights should be considered for local source.
-    """
+    """Only user rights should be considered for local source."""
     project = str(datafiles)
     element_name = "test.bst"
     element_path = os.path.join(project, "elements", element_name)

--- a/tests/integration/workspace.py
+++ b/tests/integration/workspace.py
@@ -80,7 +80,17 @@ def test_workspace_commanddir(cli, datafiles):
     # using the cached buildtree.
     res = cli.run(
         project=project,
-        args=["shell", "--build", element_name, "--use-buildtree", "--", "find", "..", "-mindepth", "1",],
+        args=[
+            "shell",
+            "--build",
+            element_name,
+            "--use-buildtree",
+            "--",
+            "find",
+            "..",
+            "-mindepth",
+            "1",
+        ],
     )
     res.assert_success()
 
@@ -290,7 +300,17 @@ def test_incremental_configure_commands_run_only_once(cli, datafiles):
     # the configure should have been run in the sandbox, so check the buildtree
     res = cli.run(
         project=project,
-        args=["shell", "--build", element_name, "--use-buildtree", "--", "find", ".", "-mindepth", "1",],
+        args=[
+            "shell",
+            "--build",
+            element_name,
+            "--use-buildtree",
+            "--",
+            "find",
+            ".",
+            "-mindepth",
+            "1",
+        ],
     )
     res.assert_success()
 
@@ -311,7 +331,17 @@ def test_incremental_configure_commands_run_only_once(cli, datafiles):
     assert not os.path.exists(os.path.join(workspace, "prepared-again"))
     res = cli.run(
         project=project,
-        args=["shell", "--build", element_name, "--use-buildtree", "--", "find", ".", "-mindepth", "1",],
+        args=[
+            "shell",
+            "--build",
+            element_name,
+            "--use-buildtree",
+            "--",
+            "find",
+            ".",
+            "-mindepth",
+            "1",
+        ],
     )
     res.assert_success()
 
@@ -382,7 +412,18 @@ def test_workspace_failed_logs(cli, datafiles):
 
 
 def get_buildtree_file_contents(cli, project, element_name, filename):
-    res = cli.run(project=project, args=["shell", "--build", element_name, "--use-buildtree", "--", "cat", filename,],)
+    res = cli.run(
+        project=project,
+        args=[
+            "shell",
+            "--build",
+            element_name,
+            "--use-buildtree",
+            "--",
+            "cat",
+            filename,
+        ],
+    )
     res.assert_success()
     return res.output
 

--- a/tests/internals/context.py
+++ b/tests/internals/context.py
@@ -9,7 +9,10 @@ from buildstream import _yaml, utils
 from buildstream._exceptions import LoadError
 from buildstream.exceptions import LoadErrorReason
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "context",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "context",
+)
 
 
 # Simple fixture to create a Context object.

--- a/tests/internals/loader.py
+++ b/tests/internals/loader.py
@@ -10,7 +10,10 @@ from buildstream._loader import LoadElement
 from tests.testutils import dummy_context
 
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "loader",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "loader",
+)
 
 
 @contextmanager

--- a/tests/internals/storage.py
+++ b/tests/internals/storage.py
@@ -44,7 +44,11 @@ def test_import(tmpdir, datafiles, backend):
 
 
 @pytest.mark.parametrize(
-    "directories", [("merge-base", "merge-base"), ("empty", "empty"),],
+    "directories",
+    [
+        ("merge-base", "merge-base"),
+        ("empty", "empty"),
+    ],
 )
 @pytest.mark.datafiles(DATA_DIR)
 def test_merge_same_casdirs(tmpdir, datafiles, directories):

--- a/tests/internals/storage_vdir_import.py
+++ b/tests/internals/storage_vdir_import.py
@@ -152,11 +152,11 @@ def combinations(integer_range):
 
 
 def resolve_symlinks(path, root):
-    """ A function to resolve symlinks inside 'path' components apart from the last one.
-        For example, resolve_symlinks('/a/b/c/d', '/a/b')
-        will return '/a/b/f/d' if /a/b/c is a symlink to /a/b/f. The final component of
-        'path' is not resolved, because we typically want to inspect the symlink found
-        at that path, not its target.
+    """A function to resolve symlinks inside 'path' components apart from the last one.
+    For example, resolve_symlinks('/a/b/c/d', '/a/b')
+    will return '/a/b/f/d' if /a/b/c is a symlink to /a/b/f. The final component of
+    'path' is not resolved, because we typically want to inspect the symlink found
+    at that path, not its target.
 
     """
     components = path.split(os.path.sep)

--- a/tests/internals/yaml.py
+++ b/tests/internals/yaml.py
@@ -8,7 +8,10 @@ from buildstream.exceptions import LoadErrorReason
 from buildstream._exceptions import LoadError
 
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "yaml",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "yaml",
+)
 
 
 @pytest.mark.datafiles(os.path.join(DATA_DIR))
@@ -437,7 +440,15 @@ def test_roundtrip_dump(datafiles):
 
 
 @pytest.mark.datafiles(os.path.join(DATA_DIR))
-@pytest.mark.parametrize("case", [["a", "b", "c"], ["foo", 1], ["stuff", 0, "colour"], ["bird", 0, 1],])
+@pytest.mark.parametrize(
+    "case",
+    [
+        ["a", "b", "c"],
+        ["foo", 1],
+        ["stuff", 0, "colour"],
+        ["bird", 0, 1],
+    ],
+)
 def test_node_find_target(datafiles, case):
     filename = os.path.join(datafiles.dirname, datafiles.basename, "traversal.yaml")
     # We set copy_tree in order to ensure that the nodes in `loaded`

--- a/tests/plugins/loading.py
+++ b/tests/plugins/loading.py
@@ -255,7 +255,11 @@ def test_plugin_found(cli, datafiles, plugin_type):
         project,
         {
             "plugins": [
-                {"origin": "local", "path": os.path.join("plugins", plugin_type, "found"), plugin_type: ["found"],}
+                {
+                    "origin": "local",
+                    "path": os.path.join("plugins", plugin_type, "found"),
+                    plugin_type: ["found"],
+                }
             ]
         },
     )
@@ -345,7 +349,16 @@ def test_pip_origin_load_success(cli, datafiles, plugin_type):
     project = str(datafiles)
 
     update_project(
-        project, {"plugins": [{"origin": "pip", "package-name": "sample-plugins", plugin_type: ["sample"],}]},
+        project,
+        {
+            "plugins": [
+                {
+                    "origin": "pip",
+                    "package-name": "sample-plugins",
+                    plugin_type: ["sample"],
+                }
+            ]
+        },
     )
     setup_element(project, plugin_type, "sample")
 
@@ -363,7 +376,11 @@ def test_pip_origin_with_constraints(cli, datafiles, plugin_type):
         project,
         {
             "plugins": [
-                {"origin": "pip", "package-name": "sample-plugins>=1.0,<1.2.5,!=1.1.3", plugin_type: ["sample"],}
+                {
+                    "origin": "pip",
+                    "package-name": "sample-plugins>=1.0,<1.2.5,!=1.1.3",
+                    plugin_type: ["sample"],
+                }
             ]
         },
     )
@@ -379,7 +396,16 @@ def test_pip_origin_package_not_found(cli, datafiles, plugin_type):
     project = str(datafiles)
 
     update_project(
-        project, {"plugins": [{"origin": "pip", "package-name": "not-a-package", plugin_type: ["sample"],}]},
+        project,
+        {
+            "plugins": [
+                {
+                    "origin": "pip",
+                    "package-name": "not-a-package",
+                    plugin_type: ["sample"],
+                }
+            ]
+        },
     )
     setup_element(project, plugin_type, "sample")
 
@@ -394,7 +420,16 @@ def test_pip_origin_plugin_not_found(cli, datafiles, plugin_type):
     project = str(datafiles)
 
     update_project(
-        project, {"plugins": [{"origin": "pip", "package-name": "sample-plugins", plugin_type: ["notfound"],}]},
+        project,
+        {
+            "plugins": [
+                {
+                    "origin": "pip",
+                    "package-name": "sample-plugins",
+                    plugin_type: ["notfound"],
+                }
+            ]
+        },
     )
     setup_element(project, plugin_type, "notfound")
 
@@ -409,7 +444,16 @@ def test_pip_origin_version_conflict(cli, datafiles, plugin_type):
     project = str(datafiles)
 
     update_project(
-        project, {"plugins": [{"origin": "pip", "package-name": "sample-plugins>=1.4", plugin_type: ["sample"],}]},
+        project,
+        {
+            "plugins": [
+                {
+                    "origin": "pip",
+                    "package-name": "sample-plugins>=1.4",
+                    plugin_type: ["sample"],
+                }
+            ]
+        },
     )
     setup_element(project, plugin_type, "sample")
 
@@ -424,7 +468,16 @@ def test_pip_origin_malformed_constraints(cli, datafiles, plugin_type):
     project = str(datafiles)
 
     update_project(
-        project, {"plugins": [{"origin": "pip", "package-name": "sample-plugins>1.4,A", plugin_type: ["sample"],}]},
+        project,
+        {
+            "plugins": [
+                {
+                    "origin": "pip",
+                    "package-name": "sample-plugins>1.4,A",
+                    plugin_type: ["sample"],
+                }
+            ]
+        },
     )
     setup_element(project, plugin_type, "sample")
 
@@ -441,13 +494,26 @@ def test_junction_plugin_found(cli, datafiles, plugin_type):
     shutil.copytree(os.path.join(project, "plugins"), os.path.join(subproject, "plugins"))
 
     update_project(
-        project, {"plugins": [{"origin": "junction", "junction": "subproject-junction.bst", plugin_type: ["found"],}]},
+        project,
+        {
+            "plugins": [
+                {
+                    "origin": "junction",
+                    "junction": "subproject-junction.bst",
+                    plugin_type: ["found"],
+                }
+            ]
+        },
     )
     update_project(
         subproject,
         {
             "plugins": [
-                {"origin": "local", "path": os.path.join("plugins", plugin_type, "found"), plugin_type: ["found"],}
+                {
+                    "origin": "local",
+                    "path": os.path.join("plugins", plugin_type, "found"),
+                    plugin_type: ["found"],
+                }
             ]
         },
     )
@@ -469,7 +535,15 @@ def test_junction_plugin_not_found(cli, datafiles, plugin_type):
     #
     update_project(
         project,
-        {"plugins": [{"origin": "junction", "junction": "subproject-junction.bst", plugin_type: ["notfound"],}]},
+        {
+            "plugins": [
+                {
+                    "origin": "junction",
+                    "junction": "subproject-junction.bst",
+                    plugin_type: ["notfound"],
+                }
+            ]
+        },
     )
 
     # The subproject only configures the "found" plugin
@@ -478,7 +552,11 @@ def test_junction_plugin_not_found(cli, datafiles, plugin_type):
         subproject,
         {
             "plugins": [
-                {"origin": "local", "path": os.path.join("plugins", plugin_type, "found"), plugin_type: ["found"],}
+                {
+                    "origin": "local",
+                    "path": os.path.join("plugins", plugin_type, "found"),
+                    plugin_type: ["found"],
+                }
             ]
         },
     )
@@ -498,17 +576,38 @@ def test_junction_deep_plugin_found(cli, datafiles, plugin_type):
     shutil.copytree(os.path.join(project, "plugins"), os.path.join(subsubproject, "plugins"))
 
     update_project(
-        project, {"plugins": [{"origin": "junction", "junction": "subproject-junction.bst", plugin_type: ["found"],}]},
+        project,
+        {
+            "plugins": [
+                {
+                    "origin": "junction",
+                    "junction": "subproject-junction.bst",
+                    plugin_type: ["found"],
+                }
+            ]
+        },
     )
     update_project(
         subproject,
-        {"plugins": [{"origin": "junction", "junction": "subsubproject-junction.bst", plugin_type: ["found"],}]},
+        {
+            "plugins": [
+                {
+                    "origin": "junction",
+                    "junction": "subsubproject-junction.bst",
+                    plugin_type: ["found"],
+                }
+            ]
+        },
     )
     update_project(
         subsubproject,
         {
             "plugins": [
-                {"origin": "local", "path": os.path.join("plugins", plugin_type, "found"), plugin_type: ["found"],}
+                {
+                    "origin": "local",
+                    "path": os.path.join("plugins", plugin_type, "found"),
+                    plugin_type: ["found"],
+                }
             ]
         },
     )
@@ -531,14 +630,30 @@ def test_junction_deep_plugin_not_found(cli, datafiles, plugin_type):
     #
     update_project(
         project,
-        {"plugins": [{"origin": "junction", "junction": "subproject-junction.bst", plugin_type: ["notfound"],}]},
+        {
+            "plugins": [
+                {
+                    "origin": "junction",
+                    "junction": "subproject-junction.bst",
+                    plugin_type: ["notfound"],
+                }
+            ]
+        },
     )
 
     # The subproject says to search for the "notfound" plugin in the subproject
     #
     update_project(
         subproject,
-        {"plugins": [{"origin": "junction", "junction": "subsubproject-junction.bst", plugin_type: ["notfound"],}]},
+        {
+            "plugins": [
+                {
+                    "origin": "junction",
+                    "junction": "subsubproject-junction.bst",
+                    plugin_type: ["notfound"],
+                }
+            ]
+        },
     )
 
     # The subsubproject only configures the "found" plugin
@@ -547,7 +662,11 @@ def test_junction_deep_plugin_not_found(cli, datafiles, plugin_type):
         subsubproject,
         {
             "plugins": [
-                {"origin": "local", "path": os.path.join("plugins", plugin_type, "found"), plugin_type: ["found"],}
+                {
+                    "origin": "local",
+                    "path": os.path.join("plugins", plugin_type, "found"),
+                    plugin_type: ["found"],
+                }
             ]
         },
     )
@@ -568,10 +687,27 @@ def test_junction_pip_plugin_found(cli, datafiles, plugin_type):
 
     update_project(
         project,
-        {"plugins": [{"origin": "junction", "junction": "subproject-junction.bst", plugin_type: ["sample"],}]},
+        {
+            "plugins": [
+                {
+                    "origin": "junction",
+                    "junction": "subproject-junction.bst",
+                    plugin_type: ["sample"],
+                }
+            ]
+        },
     )
     update_project(
-        subproject, {"plugins": [{"origin": "pip", "package-name": "sample-plugins", plugin_type: ["sample"],}]},
+        subproject,
+        {
+            "plugins": [
+                {
+                    "origin": "pip",
+                    "package-name": "sample-plugins",
+                    plugin_type: ["sample"],
+                }
+            ]
+        },
     )
     setup_element(project, plugin_type, "sample")
 
@@ -590,10 +726,27 @@ def test_junction_pip_plugin_version_conflict(cli, datafiles, plugin_type):
 
     update_project(
         project,
-        {"plugins": [{"origin": "junction", "junction": "subproject-junction.bst", plugin_type: ["sample"],}]},
+        {
+            "plugins": [
+                {
+                    "origin": "junction",
+                    "junction": "subproject-junction.bst",
+                    plugin_type: ["sample"],
+                }
+            ]
+        },
     )
     update_project(
-        subproject, {"plugins": [{"origin": "pip", "package-name": "sample-plugins>=1.4", plugin_type: ["sample"],}]},
+        subproject,
+        {
+            "plugins": [
+                {
+                    "origin": "pip",
+                    "package-name": "sample-plugins>=1.4",
+                    plugin_type: ["sample"],
+                }
+            ]
+        },
     )
     setup_element(project, plugin_type, "sample")
 
@@ -626,7 +779,11 @@ def test_junction_full_path_found(cli, datafiles, plugin_type):
         subsubproject,
         {
             "plugins": [
-                {"origin": "local", "path": os.path.join("plugins", plugin_type, "found"), plugin_type: ["found"],}
+                {
+                    "origin": "local",
+                    "path": os.path.join("plugins", plugin_type, "found"),
+                    plugin_type: ["found"],
+                }
             ]
         },
     )
@@ -666,7 +823,11 @@ def test_junction_full_path_not_found(cli, datafiles, plugin_type):
         subsubproject,
         {
             "plugins": [
-                {"origin": "local", "path": os.path.join("plugins", plugin_type, "found"), plugin_type: ["found"],}
+                {
+                    "origin": "local",
+                    "path": os.path.join("plugins", plugin_type, "found"),
+                    plugin_type: ["found"],
+                }
             ]
         },
     )

--- a/tests/plugins/sample-plugins/setup.py
+++ b/tests/plugins/sample-plugins/setup.py
@@ -27,8 +27,12 @@ setup(
     packages=find_packages(where="src"),
     include_package_data=True,
     entry_points={
-        "buildstream.plugins.elements": ["sample = sample_plugins.elements.sample",],
-        "buildstream.plugins.sources": ["sample = sample_plugins.sources.sample",],
+        "buildstream.plugins.elements": [
+            "sample = sample_plugins.elements.sample",
+        ],
+        "buildstream.plugins.sources": [
+            "sample = sample_plugins.sources.sample",
+        ],
     },
     zip_safe=False,
 )

--- a/tests/remoteexecution/buildfail.py
+++ b/tests/remoteexecution/buildfail.py
@@ -27,7 +27,10 @@ from buildstream._testing import cli_remote_execution as cli  # pylint: disable=
 pytestmark = pytest.mark.remoteexecution
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 @pytest.mark.datafiles(DATA_DIR)
@@ -39,8 +42,18 @@ def test_build_remote_failure(cli, datafiles):
     # Write out our test target
     element = {
         "kind": "script",
-        "depends": [{"filename": "base.bst", "type": "build",},],
-        "config": {"commands": ["touch %{install-root}/foo", "false",],},
+        "depends": [
+            {
+                "filename": "base.bst",
+                "type": "build",
+            },
+        ],
+        "config": {
+            "commands": [
+                "touch %{install-root}/foo",
+                "false",
+            ],
+        },
     }
     _yaml.roundtrip_dump(element, element_path)
 

--- a/tests/remoteexecution/buildtree.py
+++ b/tests/remoteexecution/buildtree.py
@@ -27,7 +27,10 @@ from tests.testutils import create_artifact_share
 pytestmark = pytest.mark.remoteexecution
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 @pytest.mark.datafiles(DATA_DIR)

--- a/tests/remoteexecution/junction.py
+++ b/tests/remoteexecution/junction.py
@@ -27,7 +27,10 @@ from tests.testutils import generate_junction
 pytestmark = pytest.mark.remoteexecution
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 def configure_project(path, config):

--- a/tests/remoteexecution/workspace.py
+++ b/tests/remoteexecution/workspace.py
@@ -98,7 +98,12 @@ def get_mtimes(root):
 
 
 def check_buildtree(
-    cli, project, element_name, input_files, generated_files, incremental=False,
+    cli,
+    project,
+    element_name,
+    input_files,
+    generated_files,
+    incremental=False,
 ):
     # check modified workspace dir was cached
     #   - generated files are present
@@ -175,7 +180,8 @@ def check_buildtree(
 
 def get_timemark(cli, project, element_name, marker):
     result = cli.run(
-        project=project, args=["shell", "--build", element_name, "--use-buildtree", "--", "cat", marker[1:]],
+        project=project,
+        args=["shell", "--build", element_name, "--use-buildtree", "--", "cat", marker[1:]],
     )
     result.assert_success()
     marker_time = int(result.output)
@@ -184,7 +190,11 @@ def get_timemark(cli, project, element_name, marker):
 
 @pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.parametrize(
-    "modification", [pytest.param("content"), pytest.param("time"),],
+    "modification",
+    [
+        pytest.param("content"),
+        pytest.param("time"),
+    ],
 )
 def test_workspace_build(cli, tmpdir, datafiles, modification):
     project = str(datafiles)

--- a/tests/sandboxes/missing_dependencies.py
+++ b/tests/sandboxes/missing_dependencies.py
@@ -12,7 +12,10 @@ from buildstream._testing import cli  # pylint: disable=unused-import
 
 
 # Project directory
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "missing-dependencies",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "missing-dependencies",
+)
 
 
 def _symlink_host_tools_to_dir(host_tools, dir_):
@@ -35,8 +38,17 @@ def test_missing_buildbox_run_has_nice_error_message(cli, datafiles, tmp_path):
     # Write out our test target
     element = {
         "kind": "script",
-        "depends": [{"filename": "base.bst", "type": "build",},],
-        "config": {"commands": ["false",],},
+        "depends": [
+            {
+                "filename": "base.bst",
+                "type": "build",
+            },
+        ],
+        "config": {
+            "commands": [
+                "false",
+            ],
+        },
     }
     _yaml.roundtrip_dump(element, element_path)
 

--- a/tests/sandboxes/remote-exec-config.py
+++ b/tests/sandboxes/remote-exec-config.py
@@ -23,7 +23,10 @@ def test_missing_certs(cli, datafiles, config_key, config_value):
         {
             "remote-execution": {
                 "execution-service": {"url": "http://localhost:8088"},
-                "storage-service": {"url": "http://charactron:11001", config_key: config_value,},
+                "storage-service": {
+                    "url": "http://charactron:11001",
+                    config_key: config_value,
+                },
             },
         }
     )

--- a/tests/sandboxes/selection.py
+++ b/tests/sandboxes/selection.py
@@ -41,13 +41,26 @@ def test_dummy_sandbox_fallback(cli, datafiles, tmp_path):
     # Write out our test target
     element = {
         "kind": "script",
-        "depends": [{"filename": "base.bst", "type": "build",},],
-        "config": {"commands": ["true",],},
+        "depends": [
+            {
+                "filename": "base.bst",
+                "type": "build",
+            },
+        ],
+        "config": {
+            "commands": [
+                "true",
+            ],
+        },
     }
     _yaml.roundtrip_dump(element, element_path)
 
     # Build without access to host tools, this will fail
-    result = cli.run(project=project, args=["build", "element.bst"], env={"PATH": str(tmp_path.joinpath("bin"))},)
+    result = cli.run(
+        project=project,
+        args=["build", "element.bst"],
+        env={"PATH": str(tmp_path.joinpath("bin"))},
+    )
     # But if we dont spesify a sandbox then we fall back to dummy, we still
     # fail early but only once we know we need a facny sandbox and that
     # dumy is not enough, there for element gets fetched and so is buildable

--- a/tests/sourcecache/capabilities.py
+++ b/tests/sourcecache/capabilities.py
@@ -13,7 +13,10 @@ from tests.testutils import dummy_context
 from tests.testutils.artifactshare import create_dummy_artifact_share
 
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "project",
+)
 
 
 @pytest.mark.datafiles(DATA_DIR)
@@ -27,7 +30,13 @@ def test_artifact_cache_with_missing_capabilities_is_skipped(cli, tmpdir, datafi
         user_config_file = str(tmpdir.join("buildstream.conf"))
         user_config = {
             "scheduler": {"pushers": 1},
-            "source-caches": {"servers": [{"url": share.repo,}]},
+            "source-caches": {
+                "servers": [
+                    {
+                        "url": share.repo,
+                    }
+                ]
+            },
             "cachedir": cache_dir,
         }
         _yaml.roundtrip_dump(user_config, file=user_config_file)

--- a/tests/sourcecache/fetch.py
+++ b/tests/sourcecache/fetch.py
@@ -50,7 +50,13 @@ def context_with_source_cache(cli, cache, share, tmpdir):
     user_config_file = str(tmpdir.join("buildstream.conf"))
     user_config = {
         "scheduler": {"pushers": 1},
-        "source-caches": {"servers": [{"url": share.repo,}]},
+        "source-caches": {
+            "servers": [
+                {
+                    "url": share.repo,
+                }
+            ]
+        },
         "cachedir": cache,
     }
     _yaml.roundtrip_dump(user_config, file=user_config_file)

--- a/tests/sourcecache/push.py
+++ b/tests/sourcecache/push.py
@@ -116,7 +116,14 @@ def test_source_push(cli, tmpdir, datafiles):
         user_config_file = str(tmpdir.join("buildstream.conf"))
         user_config = {
             "scheduler": {"pushers": 1},
-            "source-caches": {"servers": [{"url": share.repo, "push": True,}]},
+            "source-caches": {
+                "servers": [
+                    {
+                        "url": share.repo,
+                        "push": True,
+                    }
+                ]
+            },
             "cachedir": cache_dir,
         }
         _yaml.roundtrip_dump(user_config, file=user_config_file)
@@ -166,7 +173,14 @@ def test_push_pull(cli, datafiles, tmpdir):
         user_config_file = str(tmpdir.join("buildstream.conf"))
         user_config = {
             "scheduler": {"pushers": 1},
-            "source-caches": {"servers": [{"url": share.repo, "push": True,}]},
+            "source-caches": {
+                "servers": [
+                    {
+                        "url": share.repo,
+                        "push": True,
+                    }
+                ]
+            },
             "cachedir": cache_dir,
         }
         _yaml.roundtrip_dump(user_config, file=user_config_file)
@@ -204,7 +218,14 @@ def test_push_fail(cli, tmpdir, datafiles):
         user_config_file = str(tmpdir.join("buildstream.conf"))
         user_config = {
             "scheduler": {"pushers": 1},
-            "source-caches": {"servers": [{"url": share.repo, "push": True,}]},
+            "source-caches": {
+                "servers": [
+                    {
+                        "url": share.repo,
+                        "push": True,
+                    }
+                ]
+            },
             "cachedir": cache_dir,
         }
         _yaml.roundtrip_dump(user_config, file=user_config_file)
@@ -235,7 +256,14 @@ def test_source_push_build_fail(cli, tmpdir, datafiles):
     with create_artifact_share(os.path.join(str(tmpdir), "share")) as share:
         user_config = {
             "scheduler": {"pushers": 1},
-            "source-caches": {"servers": [{"url": share.repo, "push": True,}]},
+            "source-caches": {
+                "servers": [
+                    {
+                        "url": share.repo,
+                        "push": True,
+                    }
+                ]
+            },
             "cachedir": cache_dir,
         }
         cli.configure(user_config)
@@ -276,7 +304,14 @@ def test_push_missing_source_after_build(cli, tmpdir, datafiles):
         user_config_file = str(tmpdir.join("buildstream.conf"))
         user_config = {
             "scheduler": {"pushers": 1},
-            "source-caches": {"servers": [{"url": share.repo, "push": True,}]},
+            "source-caches": {
+                "servers": [
+                    {
+                        "url": share.repo,
+                        "push": True,
+                    }
+                ]
+            },
             "cachedir": cache_dir,
         }
         _yaml.roundtrip_dump(user_config, file=user_config_file)
@@ -301,7 +336,14 @@ def test_build_push_source_twice(cli, tmpdir, datafiles):
         user_config_file = str(tmpdir.join("buildstream.conf"))
         user_config = {
             "scheduler": {"pushers": 1},
-            "source-caches": {"servers": [{"url": share.repo, "push": True,}]},
+            "source-caches": {
+                "servers": [
+                    {
+                        "url": share.repo,
+                        "push": True,
+                    }
+                ]
+            },
             "cachedir": cache_dir,
         }
         _yaml.roundtrip_dump(user_config, file=user_config_file)

--- a/tests/sourcecache/source-checkout.py
+++ b/tests/sourcecache/source-checkout.py
@@ -41,7 +41,9 @@ def test_source_checkout(tmpdir, datafiles, cli):
     source_dir = os.path.join(cache_dir, "sources")
 
     cli.configure(
-        {"cachedir": cache_dir,}
+        {
+            "cachedir": cache_dir,
+        }
     )
     target_dir = os.path.join(str(tmpdir), "target")
 

--- a/tests/sourcecache/workspace.py
+++ b/tests/sourcecache/workspace.py
@@ -74,7 +74,14 @@ def test_workspace_open_no_source_push(tmpdir, datafiles, cli):
             {
                 "cachedir": cache_dir,
                 "scheduler": {"pushers": 1},
-                "source-caches": {"servers": [{"url": share.repo, "push": True,}]},
+                "source-caches": {
+                    "servers": [
+                        {
+                            "url": share.repo,
+                            "push": True,
+                        }
+                    ]
+                },
             }
         )
 

--- a/tests/sources/git.py
+++ b/tests/sources/git.py
@@ -36,7 +36,10 @@ from buildstream._testing import generate_project, generate_element, load_yaml
 from buildstream._testing import create_repo
 from buildstream._testing._utils.site import HAVE_GIT, HAVE_OLD_GIT
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "git",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "git",
+)
 
 
 @pytest.mark.skipif(HAVE_GIT is False, reason="git is not available")

--- a/tests/sources/local.py
+++ b/tests/sources/local.py
@@ -10,7 +10,10 @@ from buildstream._testing import cli  # pylint: disable=unused-import
 from buildstream._testing._utils.site import HAVE_SANDBOX
 from tests.testutils import filetypegenerator
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "local",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "local",
+)
 
 
 @pytest.mark.datafiles(os.path.join(DATA_DIR, "basic"))

--- a/tests/sources/patch.py
+++ b/tests/sources/patch.py
@@ -8,7 +8,10 @@ from buildstream.exceptions import ErrorDomain, LoadErrorReason
 from buildstream._testing import cli  # pylint: disable=unused-import
 from tests.testutils import filetypegenerator
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "patch",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "patch",
+)
 
 
 @pytest.mark.datafiles(os.path.join(DATA_DIR, "basic"))

--- a/tests/sources/pip.py
+++ b/tests/sources/pip.py
@@ -8,7 +8,10 @@ from buildstream.exceptions import ErrorDomain
 from buildstream.plugins.sources.pip import _match_package_name
 from buildstream._testing import cli, generate_project  # pylint: disable=unused-import
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "pip",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "pip",
+)
 
 
 # Test that without ref, consistency is set appropriately.

--- a/tests/sources/previous_source_access/plugins/sources/foo_transform.py
+++ b/tests/sources/previous_source_access/plugins/sources/foo_transform.py
@@ -23,9 +23,7 @@ class FooTransformSource(Source):
 
     @property
     def mirror(self):
-        """Directory where this source should stage its files
-
-        """
+        """Directory where this source should stage its files"""
         path = os.path.join(self.get_mirror_directory(), self.name, self.ref.strip())
         os.makedirs(path, exist_ok=True)
         return path

--- a/tests/sources/project_key_test/plugins/sources/key-test.py
+++ b/tests/sources/project_key_test/plugins/sources/key-test.py
@@ -4,8 +4,7 @@ from buildstream import Source
 
 
 class KeyTest(Source):
-    """ This plugin should fail if get_unique_key is called before track
-    """
+    """This plugin should fail if get_unique_key is called before track"""
 
     BST_MIN_VERSION = "2.0"
 

--- a/tests/sources/remote.py
+++ b/tests/sources/remote.py
@@ -11,7 +11,10 @@ from buildstream._testing import generate_project
 from buildstream._testing import cli  # pylint: disable=unused-import
 from tests.testutils.file_server import create_file_server
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "remote",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "remote",
+)
 
 
 # Test that without ref, consistency is set appropriately.
@@ -132,8 +135,7 @@ def test_unique_key(cli, tmpdir, datafiles):
 
 @pytest.mark.datafiles(os.path.join(DATA_DIR, "unique-keys"))
 def test_executable(cli, tmpdir, datafiles):
-    """This test confirms that the 'ecxecutable' parameter is honoured.
-    """
+    """This test confirms that the 'ecxecutable' parameter is honoured."""
     project = str(datafiles)
     generate_project(project, {"aliases": {"tmpdir": "file:///" + str(tmpdir)}})
 

--- a/tests/sources/tar.py
+++ b/tests/sources/tar.py
@@ -18,7 +18,10 @@ from buildstream._testing._utils.site import HAVE_LZIP
 from tests.testutils.file_server import create_file_server
 from . import list_dir_contents
 
-DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tar",)
+DATA_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "tar",
+)
 
 
 def _assemble_tar(workingdir, srcdir, dstfile):

--- a/tests/testutils/artifactshare.py
+++ b/tests/testutils/artifactshare.py
@@ -133,7 +133,12 @@ class ArtifactShare(BaseArtifactShare):
         super().__init__()
 
     def _create_server(self):
-        return create_server(self.repodir, quota=self.quota, enable_push=True, index_only=self.index_only,)
+        return create_server(
+            self.repodir,
+            quota=self.quota,
+            enable_push=True,
+            index_only=self.index_only,
+        )
 
     # has_object():
     #

--- a/tests/testutils/repo/git.py
+++ b/tests/testutils/repo/git.py
@@ -90,7 +90,12 @@ class Git(Repo):
         return config
 
     def latest_commit(self):
-        return self._run_git("rev-parse", "HEAD", stdout=subprocess.PIPE, universal_newlines=True,).stdout.strip()
+        return self._run_git(
+            "rev-parse",
+            "HEAD",
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
+        ).stdout.strip()
 
     def branch(self, branch_name):
         self._run_git("checkout", "-b", branch_name)
@@ -106,4 +111,9 @@ class Git(Repo):
         return self.latest_commit()
 
     def rev_parse(self, rev):
-        return self._run_git("rev-parse", rev, stdout=subprocess.PIPE, universal_newlines=True,).stdout.strip()
+        return self._run_git(
+            "rev-parse",
+            rev,
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
+        ).stdout.strip()

--- a/tox.ini
+++ b/tox.ini
@@ -123,7 +123,7 @@ setenv =
 [testenv:format]
 skip_install = True
 deps =
-    black==19.10b0
+    black==22.3.0
 commands =
     black {posargs: src tests doc/source/conf.py setup.py}
 
@@ -133,7 +133,7 @@ commands =
 [testenv:format-check]
 skip_install = True
 deps =
-    black==19.10b0
+    black==22.3.0
 commands =
     black --check --diff {posargs: src tests doc/source/conf.py setup.py}
 


### PR DESCRIPTION
This is required to avoid a recently occurring exception when running black, as outlined here: https://github.com/psf/black/issues/2964
