### PR TITLE
.github/workflow: run tests using ubuntu 18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     continue-on-error: ${{ matrix.allow-failure || false }}
 
     strategy:
@@ -60,7 +60,7 @@ jobs:
 
   # Matrix of tests which run against remote services which we bring up adjacently
   service-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
 
     strategy:
       matrix:
@@ -84,7 +84,7 @@ jobs:
           ${GITHUB_WORKSPACE}/.github/run-ci.sh --service ${{ matrix.test-name }}
 
   docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Ubuntu 20.04 seems to have a kernel bug making tests that use buildbox-fuse
hang.