### PR TITLE
tox.ini: Test against latest bst-plugins-experimental tag

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ isolated_build = true
 
 # Configuration variables to share across environments
 [config]
-BST_PLUGINS_EXPERIMENTAL_VERSION = 8d65392b50be975371b7efb36f36440f668b05a7
+BST_PLUGINS_EXPERIMENTAL_VERSION = 1.93.7
 
 #
 # Defaults for all environments


### PR DESCRIPTION
This has the fix to work with zip source removed from buildstream