### PR TITLE
Ensure the initial branch in git is master

### DIFF
--- a/tests/testutils/repo/git.py
+++ b/tests/testutils/repo/git.py
@@ -32,6 +32,7 @@ class Git(Repo):
     def create(self, directory):
         self.copy_directory(directory, self.repo)
         self._run_git("init", ".")
+        self._run_git("checkout", "-b", "master")
         self._run_git("add", ".")
         self._run_git("commit", "-m", "Initial commit")
         return self.latest_commit()


### PR DESCRIPTION
There's many tests depending on this all around and default
branch is changing to main so it's better to be explicit.
Fixes https://github.com/apache/buildstream/issues/1649