### PR TITLE
Ensure the initial branch in git is master

### DIFF
--- a/tests/testutils/repo/git.py
+++ b/tests/testutils/repo/git.py
@@ -29,6 +29,11 @@ class Git(Repo):
     def create(self, directory):
         self.copy_directory(directory, self.repo)
         subprocess.call(['git', 'init', '.'], env=GIT_ENV, cwd=self.repo)
+        subprocess.call(
+            ['git', 'checkout', '-b', 'master'],
+            env=GIT_ENV,
+            cwd=self.repo
+        )
         subprocess.call(['git', 'add', '.'], env=GIT_ENV, cwd=self.repo)
         subprocess.call(['git', 'commit', '-m', 'Initial commit'], env=GIT_ENV, cwd=self.repo)
         return self.latest_commit()


### PR DESCRIPTION
There's many tests depending on this all around and default
branch is changing to main so it's better to be explicit.
Backport of https://github.com/apache/buildstream/pull/1648