### PR TITLE
bst-1: .github: Run tests in fedora 36

### DIFF
--- a/.github/common.env
+++ b/.github/common.env
@@ -1,5 +1,5 @@
 # Shared common variables
 
-CI_IMAGE_VERSION=master-443158932
+CI_IMAGE_VERSION=master-533491591
 CI_TOXENV_MAIN=py36-nocover,py37-nocover,py38-nocover,py39-nocover,py310-nocover
 CI_TOXENV_ALL="${CI_TOXENV_MAIN}"

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 
 x-tests-template: &tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:34-${CI_IMAGE_VERSION:-latest}
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:35-${CI_IMAGE_VERSION:-latest}
     command: tox -vvvvv -- --color=yes --integration
     environment:
       TOXENV: ${CI_TOXENV_ALL}
@@ -22,13 +22,13 @@ x-tests-template: &tests-template
 
 services:
 
-  fedora-34:
-    <<: *tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:34-${CI_IMAGE_VERSION:-latest}
-
   fedora-35:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:35-${CI_IMAGE_VERSION:-latest}
+
+  fedora-36:
+    <<: *tests-template
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:36-${CI_IMAGE_VERSION:-latest}
 
   debian-10:
     <<: *tests-template

--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -67,8 +67,8 @@ set -e
 if [ -z "${test_names}" ]; then
     runTest "lint"
     runTest "debian-10"
-    runTest "fedora-34"
     runTest "fedora-35"
+    runTest "fedora-36"
 else
     for test_name in "${test_names}"; do
 	runTest "${test_name}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
         # "../compose/ci.docker-compose.yml"
         test-name:
           - debian-10
-          - fedora-34
           - fedora-35
+          - fedora-36
           - lint
 
     steps:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -74,7 +74,7 @@ release = __version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ commands =
     make -C doc
 # sphinx_rtd_theme < 0.4.2 breaks search functionality for Sphinx >= 1.8
 deps =
-    sphinx == 1.8.5
+    sphinx >= 1.8.5
     sphinx-click
     sphinx_rtd_theme >= 0.4.2
     -rrequirements/requirements.txt


### PR DESCRIPTION
And remove soon to be deprecated fedora 34

Backport of https://github.com/apache/buildstream/pull/1647