### PR TITLE
doc/source/conf.py: Set language

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -69,7 +69,7 @@ release = __version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
This fixes the following CI failure with Sphinx 5:

    Warning, treated as error:
    Invalid configuration value found: 'language = None'. Update your configuration to a valid langauge code. Falling back to 'en' (English).