### PR TITLE
_cas/casdprocessmanager.py: Assert minimal required version of buildbox-casd

### DIFF
--- a/src/buildstream/_cas/cascache.py
+++ b/src/buildstream/_cas/cascache.py
@@ -71,7 +71,8 @@ class CASCache:
         remote_cache_spec=None,
         protect_session_blobs=True,
         log_level=CASLogLevel.WARNING,
-        log_directory=None
+        log_directory=None,
+        messenger=None
     ):
         self.casdir = os.path.join(path, "cas")
         self.tmpdir = os.path.join(path, "tmp")
@@ -88,7 +89,7 @@ class CASCache:
             assert log_directory is not None, "log_directory is required when casd is True"
             log_dir = os.path.join(log_directory, "_casd")
             self._casd_process_manager = CASDProcessManager(
-                path, log_dir, log_level, cache_quota, remote_cache_spec, protect_session_blobs
+                path, log_dir, log_level, cache_quota, remote_cache_spec, protect_session_blobs, messenger
             )
 
             self._casd_channel = self._casd_process_manager.create_channel()

--- a/src/buildstream/_cas/casserver.py
+++ b/src/buildstream/_cas/casserver.py
@@ -94,7 +94,7 @@ def create_server(repo, *, enable_push, quota, index_only, log_level=LogLevel.Le
     logger.addHandler(handler)
 
     casd_manager = CASDProcessManager(
-        os.path.abspath(repo), os.path.join(os.path.abspath(repo), "logs"), log_level, quota, None, False
+        os.path.abspath(repo), os.path.join(os.path.abspath(repo), "logs"), log_level, quota, None, False, None
     )
     casd_channel = casd_manager.create_channel()
 

--- a/src/buildstream/_context.py
+++ b/src/buildstream/_context.py
@@ -688,6 +688,7 @@ class Context:
                 remote_cache_spec=self.remote_cache_spec,
                 log_level=log_level,
                 log_directory=self.logdir,
+                messenger=self.messenger,
             )
         return self._cascache
 

--- a/tests/internals/cascache.py
+++ b/tests/internals/cascache.py
@@ -7,9 +7,24 @@ from buildstream._cas import casdprocessmanager
 from buildstream._messenger import Messenger
 
 
+#
+# A dummy CASD script placeholder which supports the --version argument
+#
+DUMMY_CASD_SCRIPT_FMT = (
+    "#!/usr/bin/env sh\n"
+    + "\n"
+    + 'if test "$1" = "--version"; then\n'
+    + '  echo "buildbox-casd 2.0.0"\n'
+    + "  exit 0\n"
+    + "fi\n"
+    + "{}\n"
+    + "exit 0\n"
+)
+
+
 def test_report_when_cascache_dies_before_asked_to(tmp_path, monkeypatch):
     dummy_buildbox_casd = tmp_path.joinpath("buildbox-casd")
-    dummy_buildbox_casd.write_text("#!/usr/bin/env sh\nexit 0")
+    dummy_buildbox_casd.write_text(DUMMY_CASD_SCRIPT_FMT.format(""))
     dummy_buildbox_casd.chmod(0o777)
     monkeypatch.setenv("PATH", str(tmp_path), prepend=os.pathsep)
 
@@ -27,7 +42,7 @@ def test_report_when_cascache_dies_before_asked_to(tmp_path, monkeypatch):
 
 def test_report_when_cascache_exits_not_cleanly(tmp_path, monkeypatch):
     dummy_buildbox_casd = tmp_path.joinpath("buildbox-casd")
-    dummy_buildbox_casd.write_text("#!/usr/bin/env sh\nwhile :\ndo\nsleep 60\ndone")
+    dummy_buildbox_casd.write_text(DUMMY_CASD_SCRIPT_FMT.format("while :\ndo\nsleep 60\ndone"))
     dummy_buildbox_casd.chmod(0o777)
     monkeypatch.setenv("PATH", str(tmp_path), prepend=os.pathsep)
     # FIXME: this is a hack, we should instead have a socket be created nicely
@@ -49,7 +64,7 @@ def test_report_when_cascache_exits_not_cleanly(tmp_path, monkeypatch):
 
 def test_report_when_cascache_is_forcefully_killed(tmp_path, monkeypatch):
     dummy_buildbox_casd = tmp_path.joinpath("buildbox-casd")
-    dummy_buildbox_casd.write_text("#!/usr/bin/env sh\ntrap 'echo hello' TERM\nwhile :\ndo\nsleep 60\ndone")
+    dummy_buildbox_casd.write_text(DUMMY_CASD_SCRIPT_FMT.format("trap 'echo hello' TERM\nwhile :\ndo\nsleep 60\ndone"))
     dummy_buildbox_casd.chmod(0o777)
     monkeypatch.setenv("PATH", str(tmp_path), prepend=os.pathsep)
     # FIXME: this is a hack, we should instead have a socket be created nicely
@@ -72,7 +87,7 @@ def test_casd_redirects_stderr_to_file_and_rotate(tmp_path, monkeypatch):
     n_max_log_files = 10
 
     dummy_buildbox_casd = tmp_path.joinpath("buildbox-casd")
-    dummy_buildbox_casd.write_text("#!/usr/bin/env sh\nprintf '%s\n' hello")
+    dummy_buildbox_casd.write_text(DUMMY_CASD_SCRIPT_FMT.format("printf '%s\n' hello"))
     dummy_buildbox_casd.chmod(0o777)
     monkeypatch.setenv("PATH", str(tmp_path), prepend=os.pathsep)
 


### PR DESCRIPTION
Here we pass along the Messenger object to the casdprocessmanager so that
we can issue a warning on startup in the case that we are unable to properly
determine the installed buildbox-casd version.

An error is raised if we successfully identify the installed version and
it is less than the required version.

Fixes #1189