### PR TITLE
Update gitlab link to github

### DIFF
--- a/doc/source/install_linux_distro.rst
+++ b/doc/source/install_linux_distro.rst
@@ -72,7 +72,7 @@ Arch Linux
 Install the dependencies with::
 
   sudo pacman -S fuse2 ostree bubblewrap git \
-                 python python-pip python-gobject python-psutil
+                 python python-pip python-gobject python-psutil lzip
 
 
 Debian
@@ -96,7 +96,7 @@ At this point you should be able to get the system requirements with::
 
   sudo apt-get install \
       fuse ostree gir1.2-ostree-1.0 bubblewrap git \
-      python3 python3-pip python3-gi python3-psutil
+      python3 python3-pip python3-gi python3-psutil lzip
   sudo apt-get install -t stretch-backports \
       gir1.2-ostree-1.0 ostree
 
@@ -108,7 +108,7 @@ to get the base system requirements installed::
 
   sudo apt-get install \
       fuse ostree gir1.2-ostree-1.0 bubblewrap git \
-      python3 python3-pip python3-gi python3-psutil
+      python3 python3-pip python3-gi python3-psutil lzip
 
 
 Fedora
@@ -117,7 +117,7 @@ For recent fedora systems, the following line should get you the system
 requirements you need::
 
   dnf install -y fuse ostree bubblewrap git \
-                 python3 python3-pip python3-gobject python3-psutil
+                 python3 python3-pip python3-gobject python3-psutil lzip
 
 
 Installing

--- a/doc/source/install_linux_distro.rst
+++ b/doc/source/install_linux_distro.rst
@@ -148,6 +148,7 @@ command is in your ``PATH`` and to enable bash completions for it.
    You can view available version tags `here <https://github.com/apache/buildstream/tags>`__
    for example to install version 1.6.6 ``git checkout 1.6.6``
 
+   You may require ``bst-external`` the install instructions can be found on the `bst-external gitlab <https://gitlab.com/BuildStream/bst-external>`__
 
 Adjust PATH
 ~~~~~~~~~~~

--- a/doc/source/install_linux_distro.rst
+++ b/doc/source/install_linux_distro.rst
@@ -125,7 +125,7 @@ Installing
 Once you have the base system dependencies, you can clone the BuildStream
 git repository and install it as a regular user::
 
-  git clone https://gitlab.com/BuildStream/buildstream.git
+  git clone https://github.com/apache/buildstream.git
   cd buildstream
   git checkout <VERSION_TAG>
   pip3 install --user -e .


### PR DESCRIPTION
The link given in the documentation is to the old gitlab repository and as such doesn't have the latest tags etc