### PR TITLE
Clean the build directory after a successful build

### DIFF
--- a/src/buildstream/buildelement.py
+++ b/src/buildstream/buildelement.py
@@ -334,6 +334,10 @@ class BuildElement(Element):
                 for cmd in commands:
                     self.__run_command(sandbox, cmd)
 
+            # Empty the build directory after a successful build to avoid the
+            # overhead of capturing the build directory.
+            self.run_cleanup_commands(sandbox)
+
             # Return the payload, this is configurable but is generally
             # always the /buildstream-install directory
             return self.get_variable("install-root")

--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -1646,15 +1646,6 @@ class Element(Plugin):
                 rootdir, output_file, output_file, self.__sandbox_config
             ) as sandbox:  # noqa
 
-                # Let the sandbox know whether the buildtree will be required.
-                # This allows the remote execution sandbox to skip buildtree
-                # download when it's not needed.
-                buildroot = self.get_variable("build-root")
-                cache_buildtrees = context.cache_buildtrees
-                if cache_buildtrees != _CacheBuildTrees.NEVER:
-                    always_cache_buildtrees = cache_buildtrees == _CacheBuildTrees.ALWAYS
-                    sandbox._set_build_directory(buildroot, always=always_cache_buildtrees)
-
                 if not self.BST_RUN_COMMANDS:
                     # Element doesn't need to run any commands in the sandbox.
                     #

--- a/src/buildstream/sandbox/_sandboxreapi.py
+++ b/src/buildstream/sandbox/_sandboxreapi.py
@@ -278,3 +278,11 @@ class _SandboxREAPIBatch(_SandboxBatch):
 
     def create_empty_file(self, name):
         self.script += "touch -- {}\n".format(shlex.quote(name))
+
+    def clean_directory(self, name):
+        # Do not treat error during cleanup as a fatal build error
+        self.script += "rm -rf -- {} || true\n".format(shlex.quote(name))
+        if self.first_command:
+            # Working directory may be a subdirectory of the build directory.
+            # Recreate it if necessary as output capture requires the working directory to exist.
+            self.script += "mkdir -p {} || true\n".format(shlex.quote(self.first_command.cwd))

--- a/src/buildstream/sandbox/sandbox.py
+++ b/src/buildstream/sandbox/sandbox.py
@@ -94,8 +94,6 @@ class Sandbox:
         self.__stdout = kwargs["stdout"]
         self.__stderr = kwargs["stderr"]
 
-        self._build_directory = None
-        self._build_directory_always = None
         self._vdir = None  # type: Optional[Directory]
         self._usebuildtree = False
 
@@ -541,20 +539,6 @@ class Sandbox:
     #
     def _disable_run(self):
         self.__allow_run = False
-
-    # _set_build_directory()
-    #
-    # Sets the build directory - the directory which may be preserved as
-    # buildtree in the artifact.
-    #
-    # Args:
-    #    directory (str): An absolute path within the sandbox
-    #    always (bool): True if the build directory should always be downloaded,
-    #                   False if it should be downloaded only on failure
-    #
-    def _set_build_directory(self, directory, *, always):
-        self._build_directory = directory
-        self._build_directory_always = always
 
 
 # SandboxFlags()

--- a/src/buildstream/sandbox/sandbox.py
+++ b/src/buildstream/sandbox/sandbox.py
@@ -524,6 +524,26 @@ class Sandbox:
             cwd_vdir = vdir.open_directory(cwd.lstrip(os.sep), create=True)
             cwd_vdir._create_empty_file(name)
 
+    # _clean_directory()
+    #
+    # Remove the contents of the specified directory.
+    #
+    # Args:
+    #    path (str): The path of the directory to be cleaned
+    #
+    def _clean_directory(self, path):
+        if self.__batch:
+            batch_clean = _SandboxBatchCleanDirectory(path)
+
+            current_group = self.__batch.current_group
+            current_group.append(batch_clean)
+        else:
+            vdir = self.get_virtual_directory()
+            relative_path = path.lstrip(os.sep)
+            if vdir.exists(relative_path):
+                vdir.remove(relative_path, recursive=True)
+                vdir.open_directory(relative_path, create=True)
+
     # _get_element_name()
     #
     # Get the plugin's element full name
@@ -626,6 +646,13 @@ class _SandboxBatch:
         cwd_vdir = vdir.open_directory(cwd.lstrip(os.sep), create=True)
         cwd_vdir._create_empty_file(name)
 
+    def clean_directory(self, name):
+        vdir = self.sandbox.get_virtual_directory()
+        relative_path = name.lstrip(os.sep)
+        if vdir.exists(relative_path):
+            vdir.remove(relative_path, recursive=True)
+            vdir.open_directory(relative_path, create=True)
+
 
 # _SandboxBatchItem()
 #
@@ -691,3 +718,17 @@ class _SandboxBatchFile(_SandboxBatchItem):
 
     def execute(self, batch):
         batch.create_empty_file(self.name)
+
+
+# _SandboxBatchCleanDirectory()
+#
+# A directory cleaning item in a command batch.
+#
+class _SandboxBatchCleanDirectory(_SandboxBatchItem):
+    def __init__(self, name):
+        super().__init__()
+
+        self.name = name
+
+    def execute(self, batch):
+        batch.clean_directory(self.name)

--- a/src/buildstream/scriptelement.py
+++ b/src/buildstream/scriptelement.py
@@ -252,6 +252,10 @@ class ScriptElement(Element):
                         # if any untested command fails.
                         sandbox.run(["sh", "-c", "-e", cmd + "\n"], root_read_only=self.__root_read_only, label=cmd)
 
+            # Empty the build directory after a successful build to avoid the
+            # overhead of capturing the build directory.
+            self.run_cleanup_commands(sandbox)
+
         # Return where the result can be collected from
         return self.__install_root
 


### PR DESCRIPTION
Capturing the build directory takes time and uses disk space of the CAS cache. If the `cache-buildtrees` option is set to `auto` (the default) or `never`, the contents of the build directory can be removed after a successful build as the build tree is no longer needed, avoiding the capture costs.