### PR TITLE
Don't mark layout locations as read-write directories

### DIFF
--- a/src/buildstream/buildelement.py
+++ b/src/buildstream/buildelement.py
@@ -258,10 +258,6 @@ class BuildElement(Element):
         sandbox.mark_directory(build_root)
         sandbox.mark_directory(install_root)
 
-        # Mark the artifact directories in the layout
-        for location in self.__layout:
-            sandbox.mark_directory(location)
-
         # Allow running all commands in a specified subdirectory
         if self._command_subdir:
             command_dir = os.path.join(build_root, self._command_subdir)

--- a/src/buildstream/scriptelement.py
+++ b/src/buildstream/scriptelement.py
@@ -207,10 +207,6 @@ class ScriptElement(Element):
         # Mark the install root
         sandbox.mark_directory(self.__install_root)
 
-        # Mark the artifact directories in the layout
-        for location in self.__layout:
-            sandbox.mark_directory(location)
-
     def stage(self, sandbox):
 
         # If self.layout_add() was never called, do the default staging of


### PR DESCRIPTION
`mark_directory()` was originally called on layout locations to enable SafeHardlinks to protect the CAS cache from corruption. This is no longer relevant.

This prevents the root directory of the sandbox from accidentally being marked as REAPI output directory, and thus avoiding expensive capture operations.
