### PR TITLE
setup.py, setup.cfg: Disable gRPC fork support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ norecursedirs = src tests/integration/project tests/plugins/loading tests/plugin
 python_files = tests/*/*.py
 env =
     D:BST_TEST_SUITE=True
+    D:GRPC_ENABLE_FORK_SUPPORT=0
 
 markers =
     datafiles: data files for tests

--- a/setup.py
+++ b/setup.py
@@ -112,13 +112,18 @@ def list_testing_datafiles():
 #
 # The patch was inspired from https://github.com/ninjaaron/fast-entry_points
 # which we believe was also inspired from the code from `setuptools` project.
+#
+# This also sets an environment variable to disable gRPC fork support as it
+# can cause problems in certain environments and BuildStream doesn't need it.
 TEMPLATE = """\
 # -*- coding: utf-8 -*-
+import os
 import sys
 
 from {0} import {1}
 
 if __name__ == '__main__':
+    os.environ['GRPC_ENABLE_FORK_SUPPORT'] = '0'
     sys.exit({2}())"""
 
 


### PR DESCRIPTION
gRPC fork support is not compatible with the default polling engine of
certain gRPC versions on modern Linux systems (epollex) and it also does
not work if another thread is calling into gRPC. It also causes Python
to segfault in the test suite in some environments.

As BuildStream, after gRPC initialization, uses `fork()` only to
`exec()` subprocesses, the gRPC fork support (`atfork` handler) is not
needed. Setting `GRPC_ENABLE_FORK_SUPPORT=0` disables gRPC fork support,
fixing Python segmentation faults and error messages caused by the
`atfork` handler.

https://github.com/grpc/grpc/issues/29044