### PR TITLE
Resolve variables in included files in the appropriate project context

### DIFF
--- a/tests/format/junctions.py
+++ b/tests/format/junctions.py
@@ -817,3 +817,18 @@ def test_internal(cli, tmpdir, datafiles, project_dir, expected_files):
     # Check that the checkout contains the expected file
     for expected in expected_files:
         assert os.path.exists(os.path.join(checkoutdir, expected))
+
+
+# This test verifies that variables declared in subproject include files
+# are resolved in their respective subproject, rather than being imported
+# literally and resolved in the including project.
+#
+@pytest.mark.datafiles(DATA_DIR)
+def test_include_vars(cli, datafiles):
+    project = os.path.join(str(datafiles), "include-vars")
+    result = cli.run(
+        project=project, silent=True, args=["show", "--deps", "none", "--format", "%{vars}", "target.bst"]
+    )
+    result.assert_success()
+    result_vars = _yaml.load_data(result.output)
+    assert result_vars.get_str("resolved") == "The animal is a horsy"

--- a/tests/format/junctions.py
+++ b/tests/format/junctions.py
@@ -832,3 +832,28 @@ def test_include_vars(cli, datafiles):
     result.assert_success()
     result_vars = _yaml.load_data(result.output)
     assert result_vars.get_str("resolved") == "The animal is a horsy"
+
+
+# This test verifies that project option conditional statements made
+# in an include file are resolved in the context of the project where
+# the include file originates.
+#
+@pytest.mark.datafiles(DATA_DIR)
+@pytest.mark.parametrize(
+    "use_species,expected_result",
+    [
+        ("True", "The species is a horsy"),
+        ("False", "The animal is a horsy"),
+    ],
+    ids=["branch1", "branch2"],
+)
+def test_include_vars_optional(cli, datafiles, use_species, expected_result):
+    project = os.path.join(str(datafiles), "include-vars-optional")
+    result = cli.run(
+        project=project,
+        silent=True,
+        args=["--option", "use_species", use_species, "show", "--deps", "none", "--format", "%{vars}", "target.bst"],
+    )
+    result.assert_success()
+    result_vars = _yaml.load_data(result.output)
+    assert result_vars.get_str("resolved") == expected_result

--- a/tests/format/junctions/include-vars-optional/project.conf
+++ b/tests/format/junctions/include-vars-optional/project.conf
@@ -1,0 +1,11 @@
+name: test
+min-version: 2.0
+
+variables:
+  animal: pony
+
+options:
+  use_species:
+    type: bool
+    description: Whether to use the species classifier in the subproject
+    default: True

--- a/tests/format/junctions/include-vars-optional/subproject.bst
+++ b/tests/format/junctions/include-vars-optional/subproject.bst
@@ -1,0 +1,13 @@
+kind: junction
+sources:
+- kind: local
+  path: subproject
+
+
+config:
+  options:
+    (?):
+    - use_species:
+        classifier: species
+    - not use_species:
+        classifier: animal

--- a/tests/format/junctions/include-vars-optional/subproject/include.yml
+++ b/tests/format/junctions/include-vars-optional/subproject/include.yml
@@ -1,0 +1,12 @@
+
+
+#
+# Test that conditional statements are resolved in the context
+# of the project from where the include originated.
+#
+variables:
+  (?):
+  - classifier == "species":
+      resolved: The species is a %{animal}
+  - classifier == "animal":
+      resolved: The animal is a %{animal}

--- a/tests/format/junctions/include-vars-optional/subproject/project.conf
+++ b/tests/format/junctions/include-vars-optional/subproject/project.conf
@@ -1,0 +1,14 @@
+name: subtest
+min-version: 2.0
+
+variables:
+  animal: horsy
+
+options:
+  classifier:
+    type: enum
+    description: how to classify the horsy or pony
+    values:
+    - animal
+    - species
+    default: animal

--- a/tests/format/junctions/include-vars-optional/target.bst
+++ b/tests/format/junctions/include-vars-optional/target.bst
@@ -1,0 +1,3 @@
+kind: stack
+
+(@): subproject.bst:include.yml

--- a/tests/format/junctions/include-vars/project.conf
+++ b/tests/format/junctions/include-vars/project.conf
@@ -1,0 +1,5 @@
+name: test
+min-version: 2.0
+
+variables:
+  animal: pony

--- a/tests/format/junctions/include-vars/subproject.bst
+++ b/tests/format/junctions/include-vars/subproject.bst
@@ -1,0 +1,4 @@
+kind: junction
+sources:
+- kind: local
+  path: subproject

--- a/tests/format/junctions/include-vars/subproject/include.yml
+++ b/tests/format/junctions/include-vars/subproject/include.yml
@@ -1,0 +1,3 @@
+
+variables:
+  resolved: The animal is a %{animal}

--- a/tests/format/junctions/include-vars/subproject/project.conf
+++ b/tests/format/junctions/include-vars/subproject/project.conf
@@ -1,0 +1,5 @@
+name: subtest
+min-version: 2.0
+
+variables:
+  animal: horsy

--- a/tests/format/junctions/include-vars/target.bst
+++ b/tests/format/junctions/include-vars/target.bst
@@ -1,0 +1,3 @@
+kind: stack
+
+(@): subproject.bst:include.yml


### PR DESCRIPTION
This branch fixes the issue of variable resolution, and adds a test case for this.

In addition, this branch also adds a test case which ensures that project option conditional statements present in include
files are resolved in the context of the project from where the include file originates.

Fixes #1485 
