### PR TITLE
Fix artifact deletion in non-strict mode

### DIFF
--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -853,6 +853,8 @@ class Stream:
         # Return list of Element and/or ArtifactElement objects
         target_objects = self.load_selection(targets, selection=selection, load_artifacts=True)
 
+        self.query_cache(target_objects)
+
         # Some of the targets may refer to the same key, so first obtain a
         # set of the refs to be removed.
         remove_refs = set()


### PR DESCRIPTION
After constructing a sufficiently complex project state for the sake of implementing failed artifact build retries, I was able to reproduce a stack trace when trying to delete a failed artifact in non-strict mode with the same setup.

This failure mode is a different from what is reported in #1461, which I was not able to reproduce.

The stack trace I encountered looks like this:
```
Traceback (most recent call last):
  File "/home/tristan/work/buildstream/.tox/py39-nocover/lib/python3.9/site-packages/buildstream/_testing/runcli.py", line 387, in _invoke
    cli_object.main(args=args or (), prog_name=cli_object.name)
  File "/home/tristan/work/buildstream/.tox/py39-nocover/lib/python3.9/site-packages/buildstream/_frontend/cli.py", line 258, in override_main
    original_main(self, args=args, prog_name=prog_name, complete_var=None, standalone_mode=standalone_mode, **extra)
  File "/home/tristan/work/buildstream/.tox/py39-nocover/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/tristan/work/buildstream/.tox/py39-nocover/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/tristan/work/buildstream/.tox/py39-nocover/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/tristan/work/buildstream/.tox/py39-nocover/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/tristan/work/buildstream/.tox/py39-nocover/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/tristan/work/buildstream/.tox/py39-nocover/lib/python3.9/site-packages/click/decorators.py", line 38, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/home/tristan/work/buildstream/.tox/py39-nocover/lib/python3.9/site-packages/buildstream/_frontend/cli.py", line 1621, in artifact_delete
    app.stream.artifact_delete(artifacts, selection=deps)
  File "/home/tristan/work/buildstream/.tox/py39-nocover/lib/python3.9/site-packages/buildstream/_stream.py", line 862, in artifact_delete
    remove_refs.add(obj.get_artifact_name(key=key))
  File "/home/tristan/work/buildstream/.tox/py39-nocover/lib/python3.9/site-packages/buildstream/element.py", line 591, in get_artifact_name
    assert key is not None
AssertionError
```
