### PR TITLE
Avoid prematurely resolving projects when loading plugins across junctions

### DIFF
--- a/src/buildstream/_pluginfactory/pluginoriginjunction.py
+++ b/src/buildstream/_pluginfactory/pluginoriginjunction.py
@@ -36,7 +36,6 @@ class PluginOriginJunction(PluginOrigin):
         #
         loader = self.project.loader.get_loader(self._junction, self.provenance_node)
         project = loader.project
-        project.ensure_fully_loaded()
 
         # Now get the appropriate PluginFactory object
         #

--- a/tests/plugins/junction-with-junction/element.bst
+++ b/tests/plugins/junction-with-junction/element.bst
@@ -1,0 +1,1 @@
+kind: manual

--- a/tests/plugins/junction-with-junction/project.conf
+++ b/tests/plugins/junction-with-junction/project.conf
@@ -1,0 +1,11 @@
+name: test
+min-version: 2.0
+
+plugins:
+- origin: junction
+  junction: sample-plugins.bst
+  sources:
+  - git
+
+(@):
+- subproject.bst:variables.yml

--- a/tests/plugins/junction-with-junction/subproject/project.conf
+++ b/tests/plugins/junction-with-junction/subproject/project.conf
@@ -1,0 +1,2 @@
+name: subproject-test
+min-version: 2.0

--- a/tests/plugins/junction-with-junction/subproject/variables.yml
+++ b/tests/plugins/junction-with-junction/subproject/variables.yml
@@ -1,0 +1,4 @@
+
+
+variables:
+  animal: pony

--- a/tests/plugins/sample-plugins/project.conf
+++ b/tests/plugins/sample-plugins/project.conf
@@ -1,0 +1,15 @@
+name: sample-plugins
+min-version: 2.0
+
+plugins:
+- origin: local
+  path: src/sample_plugins/elements
+  elements:
+  - autotools
+  - sample
+
+- origin: local
+  path: src/sample_plugins/sources
+  sources:
+  - git
+  - sample


### PR DESCRIPTION
This fixes #1686 
