### PR TITLE
storage: Add `collect_result` parameter to `import_files()`

### DIFF
--- a/src/buildstream/_artifact.py
+++ b/src/buildstream/_artifact.py
@@ -233,7 +233,7 @@ class Artifact:
         # Store files
         if collectvdir is not None:
             filesvdir = CasBasedDirectory(cas_cache=self._cas)
-            filesvdir._import_files_internal(collectvdir, properties=properties)
+            filesvdir._import_files_internal(collectvdir, properties=properties, collect_result=False)
             artifact.files.CopyFrom(filesvdir._get_digest())
             size += filesvdir._get_size()
 
@@ -292,7 +292,7 @@ class Artifact:
         # Store build tree
         if sandbox_build_dir is not None:
             buildtreevdir = CasBasedDirectory(cas_cache=self._cas)
-            buildtreevdir._import_files_internal(sandbox_build_dir, properties=properties)
+            buildtreevdir._import_files_internal(sandbox_build_dir, properties=properties, collect_result=False)
             artifact.buildtree.CopyFrom(buildtreevdir._get_digest())
             size += buildtreevdir._get_size()
 

--- a/src/buildstream/_elementsources.py
+++ b/src/buildstream/_elementsources.py
@@ -482,10 +482,10 @@ class ElementSources:
 
                         # Capture modified tree
                         vsubdir._clear()
-                        vsubdir.import_files(tmpdir)
+                        vsubdir.import_files(tmpdir, collect_result=False)
             else:
                 source_dir = self._sourcecache.export(source)
-                vsubdir.import_files(source_dir)
+                vsubdir.import_files(source_dir, collect_result=False)
 
         return vdir
 

--- a/src/buildstream/_sourcecache.py
+++ b/src/buildstream/_sourcecache.py
@@ -76,7 +76,7 @@ class SourceCache(AssetCache):
         if not source.BST_STAGE_VIRTUAL_DIRECTORY:
             with utils._tempdir(dir=self.context.tmpdir, prefix="staging-temp") as tmpdir:
                 source._stage(tmpdir)
-                vdir.import_files(tmpdir)
+                vdir.import_files(tmpdir, collect_result=False)
         else:
             source._stage(vdir)
 

--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -978,6 +978,7 @@ class Element(Plugin):
         split_filter = self.__split_filter_func(include, exclude, orphans)
 
         result = vstagedir._import_files_internal(files_vdir, filter_callback=split_filter)
+        assert result is not None
 
         owner._overlap_collector.collect_stage_result(self, result)
 
@@ -1488,7 +1489,7 @@ class Element(Plugin):
                     import_dir = staged_sources
 
             # Set update_mtime to ensure deterministic mtime of sources at build time
-            vdirectory._import_files_internal(import_dir, update_mtime=BST_ARBITRARY_TIMESTAMP)
+            vdirectory._import_files_internal(import_dir, update_mtime=BST_ARBITRARY_TIMESTAMP, collect_result=False)
 
         # Ensure deterministic owners of sources at build time
         vdirectory._set_deterministic_user()

--- a/src/buildstream/plugins/elements/compose.py
+++ b/src/buildstream/plugins/elements/compose.py
@@ -170,7 +170,7 @@ class ComposeElement(Element):
 
         with self.timed_activity("Creating composition", detail=detail, silent_nested=True):
             self.info("Composing {} files".format(len(manifest)))
-            installdir.import_files(vbasedir, filter_callback=import_filter)
+            installdir.import_files(vbasedir, filter_callback=import_filter, collect_result=False)
 
         # And we're done
         return os.path.join(os.sep, "buildstream", "install")

--- a/src/buildstream/plugins/elements/import.py
+++ b/src/buildstream/plugins/elements/import.py
@@ -83,7 +83,7 @@ class ImportElement(Element):
             raise ElementError("{}: No files were found inside directory '{}'".format(self, self.source))
 
         # Move it over
-        outputdir.import_files(inputdir)
+        outputdir.import_files(inputdir, collect_result=False)
 
         # And we're done
         return "/output"

--- a/src/buildstream/plugins/sources/local.py
+++ b/src/buildstream/plugins/sources/local.py
@@ -100,7 +100,7 @@ class LocalSource(Source):
         assert isinstance(directory, Directory)
         assert self.__digest is not None
         with self._cache_directory(digest=self.__digest) as cached_directory:
-            directory.import_files(cached_directory)
+            directory.import_files(cached_directory, collect_result=False)
 
     def init_workspace_directory(self, directory):
         #

--- a/src/buildstream/plugins/sources/workspace.py
+++ b/src/buildstream/plugins/sources/workspace.py
@@ -108,7 +108,7 @@ class WorkspaceSource(Source):
         assert isinstance(directory, Directory)
         assert self.__digest is not None
         with self._cache_directory(digest=self.__digest) as cached_directory:
-            directory._import_files_internal(cached_directory)
+            directory._import_files_internal(cached_directory, collect_result=False)
 
     # As a core element, we speed up some scenarios when this is used for
     # a junction, by providing the local path to this content directly.
@@ -124,6 +124,7 @@ class WorkspaceSource(Source):
         assert isinstance(directory, Directory)
         with self.timed_activity("Staging local files"):
             result = directory._import_files_internal(self.path, properties=["mtime"])
+            assert result is not None
 
             if result.overwritten or result.ignored:
                 raise SourceError(

--- a/src/buildstream/storage/_filebaseddirectory.py
+++ b/src/buildstream/storage/_filebaseddirectory.py
@@ -237,7 +237,8 @@ class FileBasedDirectory(Directory):
         *,
         filter_callback: Optional[Callable[[str], bool]] = None,
         update_mtime: Optional[float] = None,
-        properties: Optional[List[str]] = None
+        properties: Optional[List[str]] = None,
+        collect_result: bool = True
     ) -> FileListResult:
 
         # See if we can get a source directory to copy from

--- a/src/buildstream/storage/directory.py
+++ b/src/buildstream/storage/directory.py
@@ -171,7 +171,8 @@ class Directory:
         external_pathspec: Union["Directory", str],
         *,
         filter_callback: Optional[Callable[[str], bool]] = None,
-    ) -> FileListResult:
+        collect_result: bool = True
+    ) -> Optional[FileListResult]:
         """Imports some or all files from external_path into this directory.
 
         Args:
@@ -181,9 +182,11 @@ class Directory:
                             relative path as argument for every file in the source directory.
                             The file is imported only if the callable returns True.
                             If no filter callback is specified, all files will be imported.
+           collect_result: Whether to collect data for the :class:`.FileListResult`, defaults to True.
 
         Returns:
-           A :class:`.FileListResult` report of files imported and overwritten.
+           A :class:`.FileListResult` report of files imported and overwritten,
+           or `None` if `collect_result` is False.
 
         Raises:
            DirectoryError: if any system error occurs.
@@ -191,6 +194,7 @@ class Directory:
         return self._import_files_internal(
             external_pathspec,
             filter_callback=filter_callback,
+            collect_result=collect_result,
         )
 
     def import_single_file(self, external_pathspec: str) -> FileListResult:
@@ -390,9 +394,11 @@ class Directory:
     #                    If no filter callback is specified, all files will be imported.
     #                    update_mtime: Update the access and modification time of each file copied to the time specified in seconds.
     #   properties: Optional list of strings representing file properties to capture when importing.
+    #   collect_result: Whether to collect data for the :class:`.FileListResult`, defaults to True.
     #
     # Returns:
-    #    A :class:`.FileListResult` report of files imported and overwritten.
+    #    A :class:`.FileListResult` report of files imported and overwritten,
+    #    or `None` if `collect_result` is False.
     #
     # Raises:
     #    DirectoryError: if any system error occurs.
@@ -404,12 +410,14 @@ class Directory:
         filter_callback: Optional[Callable[[str], bool]] = None,
         update_mtime: Optional[float] = None,
         properties: Optional[List[str]] = None,
-    ) -> FileListResult:
+        collect_result: bool = True
+    ) -> Optional[FileListResult]:
         return self._import_files(
             external_pathspec,
             filter_callback=filter_callback,
             update_mtime=update_mtime,
             properties=properties,
+            collect_result=collect_result,
         )
 
     # _import_files()
@@ -425,9 +433,11 @@ class Directory:
     #                    If no filter callback is specified, all files will be imported.
     #                    update_mtime: Update the access and modification time of each file copied to the time specified in seconds.
     #   properties: Optional list of strings representing file properties to capture when importing.
+    #   collect_result: Whether to collect data for the :class:`.FileListResult`, defaults to True.
     #
     # Returns:
-    #    A :class:`.FileListResult` report of files imported and overwritten.
+    #    A :class:`.FileListResult` report of files imported and overwritten,
+    #    or `None` if `collect_result` is False.
     #
     # Raises:
     #    DirectoryError: if any system error occurs.
@@ -439,7 +449,8 @@ class Directory:
         filter_callback: Optional[Callable[[str], bool]] = None,
         update_mtime: Optional[float] = None,
         properties: Optional[List[str]] = None,
-    ) -> FileListResult:
+        collect_result: bool = True
+    ) -> Optional[FileListResult]:
         raise NotImplementedError()
 
     # _export_files()


### PR DESCRIPTION
Collecting data for `FileListResult` may incur significant overhead as it always requires iterating over all files in the directory, recursively, even if the whole directory can be imported as is.