### PR TITLE
Specify access credentials in `stage_directory()`

### DIFF
--- a/src/buildstream/_protos/build/buildgrid/local_cas.proto
+++ b/src/buildstream/_protos/build/buildgrid/local_cas.proto
@@ -100,6 +100,12 @@ service LocalContentAddressableStorage {
   // If a CAS remote is configured, the blobs are uploaded.
   // The `bypass_local_cache` parameter is a hint to indicate whether the blobs
   // shall be uploaded without first storing them in the local cache.
+  //
+  // The `move_files` parameter is a hint to indicate that files could be
+  // moved into the storage. This can make capturing more efficient by
+  // avoiding copies when it is known that files will not be needed after they
+  // are imported. If a server chooses not to move them, the source files will
+  // still exist after this request.
   rpc CaptureTree(CaptureTreeRequest) returns (CaptureTreeResponse) {}
 
   // Capture files from the local filesystem.
@@ -109,6 +115,12 @@ service LocalContentAddressableStorage {
   // If a CAS remote is configured, the blobs are uploaded.
   // The `bypass_local_cache` parameter is a hint to indicate whether the blobs
   // shall be uploaded without first storing them in the local cache.
+  //
+  // The `move_files` parameter is a hint to indicate that the files could be
+  // moved into the storage. This can make capturing more efficient by
+  // avoiding copies when it is known that files will not be needed after they
+  // are imported. If a server chooses not to move them, the source files will
+  // still exist after this request.
   rpc CaptureFiles(CaptureFilesRequest) returns (CaptureFilesResponse) {}
 
   // Configure remote CAS endpoint.
@@ -125,6 +137,13 @@ service LocalContentAddressableStorage {
   // This returns a string that can be used as instance_name to access the
   // specified endpoints in further requests.
   rpc GetInstanceNameForRemotes(GetInstanceNameForRemotesRequest) returns (GetInstanceNameForRemotesResponse) {}
+
+  // Configure sandboxed clients.
+  //
+  // This returns a string that can be used as instance_name to access
+  // this service from clients running in the specified filesystem/mount
+  // namespace or chroot environment
+  rpc GetInstanceNameForNamespace(GetInstanceNameForNamespaceRequest) returns (GetInstanceNameForNamespaceResponse) {}
 
   // Query total space used by the local cache.
   rpc GetLocalDiskUsage(GetLocalDiskUsageRequest) returns (GetLocalDiskUsageResponse) {}
@@ -264,6 +283,15 @@ message StageTreeRequest {
   // this staged tree will in that case be limited to the lifetime of the
   // parent.
   string path = 3;
+
+  message Credentials {
+    int64 uid = 1;
+  }
+
+  // The UNIX credentials of the processes that will access the staged tree.
+  // This will be used to ensure that the files have the right permissions
+  // for access without risking corruption of files in the local cache.
+  Credentials access_credentials = 4;
 }
 
 // A response message for
@@ -283,6 +311,11 @@ message CaptureTreeRequest {
   // omitted.
   string instance_name = 1;
 
+  // The optional root path to restrict capture to a subtree.
+  // If specified, `path` will be resolved inside this root.
+  // No files outside the root will be captured.
+  string root = 6;
+
   // The path(s) in the local filesystem to capture.
   repeated string path = 2;
 
@@ -292,6 +325,11 @@ message CaptureTreeRequest {
 
   // The properties of path(s) in the local filesystem to capture.
   repeated string node_properties = 4;
+
+  // Hints whether files can be moved into the storage.
+  // If enabled, they MUST NOT be modified after issuing this request in order
+  // to guarantee consistency.
+  bool move_files = 5;
 }
 
 // A response message for
@@ -325,6 +363,11 @@ message CaptureFilesRequest {
   // omitted.
   string instance_name = 1;
 
+  // The optional root path to restrict capture to a subtree.
+  // If specified, `path` will be resolved inside this root.
+  // No files outside the root will be captured.
+  string root = 6;
+
   // The path(s) in the local filesystem to capture.
   repeated string path = 2;
 
@@ -334,6 +377,11 @@ message CaptureFilesRequest {
 
   // The properties of path(s) in the local filesystem to capture.
   repeated string node_properties = 4;
+
+  // Hints whether the files can be moved into the storage.
+  // If enabled, they MUST NOT be modified after issuing this request in order
+  // to guarantee consistency.
+  bool move_files = 5;
 }
 
 // A response message for
@@ -425,13 +473,43 @@ message Remote {
 // A request message for
 // [LocalContentAddressableStorage.GetInstanceNameForRemotes][build.buildgrid.v2.LocalContentAddressableStorage.GetInstanceNameForRemotes].
 message GetInstanceNameForRemotesRequest {
+  // The instance of the execution system to operate against. A server may
+  // support multiple instances of the execution system (with their own workers,
+  // storage, caches, etc.). The server MAY require use of this field to select
+  // between them in an implementation-defined fashion, otherwise it can be
+  // omitted.
+  string instance_name = 3;
+
   Remote content_addressable_storage = 1;
   Remote remote_asset = 2;
+  Remote action_cache = 4;
 }
 
 // A response message for
 // [LocalContentAddressableStorage.GetInstanceNameForRemotes][build.buildgrid.v2.LocalContentAddressableStorage.GetInstanceNameForRemotes].
 message GetInstanceNameForRemotesResponse {
+  string instance_name = 1;
+}
+
+
+// A request message for
+// [LocalContentAddressableStorage.GetInstanceNameForRemote][build.buildgrid.v2.LocalContentAddressableStorage.GetInstanceNameForNamespace].
+message GetInstanceNameForNamespaceRequest {
+  // The instance of the execution system to operate against. A server may
+  // support multiple instances of the execution system (with their own workers,
+  // storage, caches, etc.). The server MAY require use of this field to select
+  // between them in an implementation-defined fashion, otherwise it can be
+  // omitted.
+  string instance_name = 1;
+
+  // The root path of the mount namespace to restrict capture and staging.
+  // All paths in requests to the new instance will be resolved inside this root.
+  string root = 2;
+}
+
+// A response message for
+// [LocalContentAddressableStorage.GetInstanceNameForRemote][build.buildgrid.v2.LocalContentAddressableStorage.GetInstanceNameForNamespace].
+message GetInstanceNameForNamespaceResponse {
   string instance_name = 1;
 }
 

--- a/src/buildstream/_protos/build/buildgrid/local_cas_pb2.py
+++ b/src/buildstream/_protos/build/buildgrid/local_cas_pb2.py
@@ -16,7 +16,7 @@ from buildstream._protos.build.bazel.remote.execution.v2 import remote_execution
 from buildstream._protos.google.rpc import status_pb2 as google_dot_rpc_dot_status__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1f\x62uild/buildgrid/local_cas.proto\x12\x0f\x62uild.buildgrid\x1a\x36\x62uild/bazel/remote/execution/v2/remote_execution.proto\x1a\x17google/rpc/status.proto\"p\n\x18\x46\x65tchMissingBlobsRequest\x12\x15\n\rinstance_name\x18\x01 \x01(\t\x12=\n\x0c\x62lob_digests\x18\x02 \x03(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\"\xcc\x01\n\x19\x46\x65tchMissingBlobsResponse\x12\x46\n\tresponses\x18\x01 \x03(\x0b\x32\x33.build.buildgrid.FetchMissingBlobsResponse.Response\x1ag\n\x08Response\x12\x37\n\x06\x64igest\x18\x01 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\"\n\x06status\x18\x02 \x01(\x0b\x32\x12.google.rpc.Status\"q\n\x19UploadMissingBlobsRequest\x12\x15\n\rinstance_name\x18\x01 \x01(\t\x12=\n\x0c\x62lob_digests\x18\x02 \x03(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\"\xce\x01\n\x1aUploadMissingBlobsResponse\x12G\n\tresponses\x18\x01 \x03(\x0b\x32\x34.build.buildgrid.UploadMissingBlobsResponse.Response\x1ag\n\x08Response\x12\x37\n\x06\x64igest\x18\x01 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\"\n\x06status\x18\x02 \x01(\x0b\x32\x12.google.rpc.Status\"\x81\x01\n\x10\x46\x65tchTreeRequest\x12\x15\n\rinstance_name\x18\x01 \x01(\t\x12<\n\x0broot_digest\x18\x02 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\x18\n\x10\x66\x65tch_file_blobs\x18\x03 \x01(\x08\"\x13\n\x11\x46\x65tchTreeResponse\"h\n\x11UploadTreeRequest\x12\x15\n\rinstance_name\x18\x01 \x01(\t\x12<\n\x0broot_digest\x18\x02 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\"\x14\n\x12UploadTreeResponse\"u\n\x10StageTreeRequest\x12\x15\n\rinstance_name\x18\x01 \x01(\t\x12<\n\x0broot_digest\x18\x02 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\x0c\n\x04path\x18\x03 \x01(\t\"!\n\x11StageTreeResponse\x12\x0c\n\x04path\x18\x01 \x01(\t\"n\n\x12\x43\x61ptureTreeRequest\x12\x15\n\rinstance_name\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x1a\n\x12\x62ypass_local_cache\x18\x03 \x01(\x08\x12\x17\n\x0fnode_properties\x18\x04 \x03(\t\"\xd3\x01\n\x13\x43\x61ptureTreeResponse\x12@\n\tresponses\x18\x01 \x03(\x0b\x32-.build.buildgrid.CaptureTreeResponse.Response\x1az\n\x08Response\x12\x0c\n\x04path\x18\x01 \x01(\t\x12<\n\x0btree_digest\x18\x02 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\"\n\x06status\x18\x03 \x01(\x0b\x32\x12.google.rpc.Status\"o\n\x13\x43\x61ptureFilesRequest\x12\x15\n\rinstance_name\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x1a\n\x12\x62ypass_local_cache\x18\x03 \x01(\x08\x12\x17\n\x0fnode_properties\x18\x04 \x03(\t\"\xb8\x02\n\x14\x43\x61ptureFilesResponse\x12\x41\n\tresponses\x18\x01 \x03(\x0b\x32..build.buildgrid.CaptureFilesResponse.Response\x1a\xdc\x01\n\x08Response\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x37\n\x06\x64igest\x18\x02 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\"\n\x06status\x18\x03 \x01(\x0b\x32\x12.google.rpc.Status\x12\x15\n\ris_executable\x18\x04 \x01(\x08\x12H\n\x0fnode_properties\x18\x06 \x01(\x0b\x32/.build.bazel.remote.execution.v2.NodePropertiesJ\x04\x08\x05\x10\x06\"\x83\x01\n\x1fGetInstanceNameForRemoteRequest\x12\x0b\n\x03url\x18\x01 \x01(\t\x12\x15\n\rinstance_name\x18\x02 \x01(\t\x12\x13\n\x0bserver_cert\x18\x03 \x01(\x0c\x12\x12\n\nclient_key\x18\x04 \x01(\x0c\x12\x13\n\x0b\x63lient_cert\x18\x05 \x01(\x0c\"9\n GetInstanceNameForRemoteResponse\x12\x15\n\rinstance_name\x18\x01 \x01(\t\"j\n\x06Remote\x12\x0b\n\x03url\x18\x01 \x01(\t\x12\x15\n\rinstance_name\x18\x02 \x01(\t\x12\x13\n\x0bserver_cert\x18\x03 \x01(\x0c\x12\x12\n\nclient_key\x18\x04 \x01(\x0c\x12\x13\n\x0b\x63lient_cert\x18\x05 \x01(\x0c\"\x8f\x01\n GetInstanceNameForRemotesRequest\x12<\n\x1b\x63ontent_addressable_storage\x18\x01 \x01(\x0b\x32\x17.build.buildgrid.Remote\x12-\n\x0cremote_asset\x18\x02 \x01(\x0b\x32\x17.build.buildgrid.Remote\":\n!GetInstanceNameForRemotesResponse\x12\x15\n\rinstance_name\x18\x01 \x01(\t\"\x1a\n\x18GetLocalDiskUsageRequest\"D\n\x19GetLocalDiskUsageResponse\x12\x12\n\nsize_bytes\x18\x01 \x01(\x03\x12\x13\n\x0bquota_bytes\x18\x02 \x01(\x03\x32\xbc\x08\n\x1eLocalContentAddressableStorage\x12l\n\x11\x46\x65tchMissingBlobs\x12).build.buildgrid.FetchMissingBlobsRequest\x1a*.build.buildgrid.FetchMissingBlobsResponse\"\x00\x12o\n\x12UploadMissingBlobs\x12*.build.buildgrid.UploadMissingBlobsRequest\x1a+.build.buildgrid.UploadMissingBlobsResponse\"\x00\x12T\n\tFetchTree\x12!.build.buildgrid.FetchTreeRequest\x1a\".build.buildgrid.FetchTreeResponse\"\x00\x12W\n\nUploadTree\x12\".build.buildgrid.UploadTreeRequest\x1a#.build.buildgrid.UploadTreeResponse\"\x00\x12X\n\tStageTree\x12!.build.buildgrid.StageTreeRequest\x1a\".build.buildgrid.StageTreeResponse\"\x00(\x01\x30\x01\x12Z\n\x0b\x43\x61ptureTree\x12#.build.buildgrid.CaptureTreeRequest\x1a$.build.buildgrid.CaptureTreeResponse\"\x00\x12]\n\x0c\x43\x61ptureFiles\x12$.build.buildgrid.CaptureFilesRequest\x1a%.build.buildgrid.CaptureFilesResponse\"\x00\x12\x81\x01\n\x18GetInstanceNameForRemote\x12\x30.build.buildgrid.GetInstanceNameForRemoteRequest\x1a\x31.build.buildgrid.GetInstanceNameForRemoteResponse\"\x00\x12\x84\x01\n\x19GetInstanceNameForRemotes\x12\x31.build.buildgrid.GetInstanceNameForRemotesRequest\x1a\x32.build.buildgrid.GetInstanceNameForRemotesResponse\"\x00\x12l\n\x11GetLocalDiskUsage\x12).build.buildgrid.GetLocalDiskUsageRequest\x1a*.build.buildgrid.GetLocalDiskUsageResponse\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1f\x62uild/buildgrid/local_cas.proto\x12\x0f\x62uild.buildgrid\x1a\x36\x62uild/bazel/remote/execution/v2/remote_execution.proto\x1a\x17google/rpc/status.proto\"p\n\x18\x46\x65tchMissingBlobsRequest\x12\x15\n\rinstance_name\x18\x01 \x01(\t\x12=\n\x0c\x62lob_digests\x18\x02 \x03(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\"\xcc\x01\n\x19\x46\x65tchMissingBlobsResponse\x12\x46\n\tresponses\x18\x01 \x03(\x0b\x32\x33.build.buildgrid.FetchMissingBlobsResponse.Response\x1ag\n\x08Response\x12\x37\n\x06\x64igest\x18\x01 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\"\n\x06status\x18\x02 \x01(\x0b\x32\x12.google.rpc.Status\"q\n\x19UploadMissingBlobsRequest\x12\x15\n\rinstance_name\x18\x01 \x01(\t\x12=\n\x0c\x62lob_digests\x18\x02 \x03(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\"\xce\x01\n\x1aUploadMissingBlobsResponse\x12G\n\tresponses\x18\x01 \x03(\x0b\x32\x34.build.buildgrid.UploadMissingBlobsResponse.Response\x1ag\n\x08Response\x12\x37\n\x06\x64igest\x18\x01 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\"\n\x06status\x18\x02 \x01(\x0b\x32\x12.google.rpc.Status\"\x81\x01\n\x10\x46\x65tchTreeRequest\x12\x15\n\rinstance_name\x18\x01 \x01(\t\x12<\n\x0broot_digest\x18\x02 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\x18\n\x10\x66\x65tch_file_blobs\x18\x03 \x01(\x08\"\x13\n\x11\x46\x65tchTreeResponse\"h\n\x11UploadTreeRequest\x12\x15\n\rinstance_name\x18\x01 \x01(\t\x12<\n\x0broot_digest\x18\x02 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\"\x14\n\x12UploadTreeResponse\"\xdc\x01\n\x10StageTreeRequest\x12\x15\n\rinstance_name\x18\x01 \x01(\t\x12<\n\x0broot_digest\x18\x02 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\x0c\n\x04path\x18\x03 \x01(\t\x12I\n\x12\x61\x63\x63\x65ss_credentials\x18\x04 \x01(\x0b\x32-.build.buildgrid.StageTreeRequest.Credentials\x1a\x1a\n\x0b\x43redentials\x12\x0b\n\x03uid\x18\x01 \x01(\x03\"!\n\x11StageTreeResponse\x12\x0c\n\x04path\x18\x01 \x01(\t\"\x90\x01\n\x12\x43\x61ptureTreeRequest\x12\x15\n\rinstance_name\x18\x01 \x01(\t\x12\x0c\n\x04root\x18\x06 \x01(\t\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x1a\n\x12\x62ypass_local_cache\x18\x03 \x01(\x08\x12\x17\n\x0fnode_properties\x18\x04 \x03(\t\x12\x12\n\nmove_files\x18\x05 \x01(\x08\"\xd3\x01\n\x13\x43\x61ptureTreeResponse\x12@\n\tresponses\x18\x01 \x03(\x0b\x32-.build.buildgrid.CaptureTreeResponse.Response\x1az\n\x08Response\x12\x0c\n\x04path\x18\x01 \x01(\t\x12<\n\x0btree_digest\x18\x02 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\"\n\x06status\x18\x03 \x01(\x0b\x32\x12.google.rpc.Status\"\x91\x01\n\x13\x43\x61ptureFilesRequest\x12\x15\n\rinstance_name\x18\x01 \x01(\t\x12\x0c\n\x04root\x18\x06 \x01(\t\x12\x0c\n\x04path\x18\x02 \x03(\t\x12\x1a\n\x12\x62ypass_local_cache\x18\x03 \x01(\x08\x12\x17\n\x0fnode_properties\x18\x04 \x03(\t\x12\x12\n\nmove_files\x18\x05 \x01(\x08\"\xb8\x02\n\x14\x43\x61ptureFilesResponse\x12\x41\n\tresponses\x18\x01 \x03(\x0b\x32..build.buildgrid.CaptureFilesResponse.Response\x1a\xdc\x01\n\x08Response\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x37\n\x06\x64igest\x18\x02 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\"\n\x06status\x18\x03 \x01(\x0b\x32\x12.google.rpc.Status\x12\x15\n\ris_executable\x18\x04 \x01(\x08\x12H\n\x0fnode_properties\x18\x06 \x01(\x0b\x32/.build.bazel.remote.execution.v2.NodePropertiesJ\x04\x08\x05\x10\x06\"\x83\x01\n\x1fGetInstanceNameForRemoteRequest\x12\x0b\n\x03url\x18\x01 \x01(\t\x12\x15\n\rinstance_name\x18\x02 \x01(\t\x12\x13\n\x0bserver_cert\x18\x03 \x01(\x0c\x12\x12\n\nclient_key\x18\x04 \x01(\x0c\x12\x13\n\x0b\x63lient_cert\x18\x05 \x01(\x0c\"9\n GetInstanceNameForRemoteResponse\x12\x15\n\rinstance_name\x18\x01 \x01(\t\"j\n\x06Remote\x12\x0b\n\x03url\x18\x01 \x01(\t\x12\x15\n\rinstance_name\x18\x02 \x01(\t\x12\x13\n\x0bserver_cert\x18\x03 \x01(\x0c\x12\x12\n\nclient_key\x18\x04 \x01(\x0c\x12\x13\n\x0b\x63lient_cert\x18\x05 \x01(\x0c\"\xd5\x01\n GetInstanceNameForRemotesRequest\x12\x15\n\rinstance_name\x18\x03 \x01(\t\x12<\n\x1b\x63ontent_addressable_storage\x18\x01 \x01(\x0b\x32\x17.build.buildgrid.Remote\x12-\n\x0cremote_asset\x18\x02 \x01(\x0b\x32\x17.build.buildgrid.Remote\x12-\n\x0c\x61\x63tion_cache\x18\x04 \x01(\x0b\x32\x17.build.buildgrid.Remote\":\n!GetInstanceNameForRemotesResponse\x12\x15\n\rinstance_name\x18\x01 \x01(\t\"I\n\"GetInstanceNameForNamespaceRequest\x12\x15\n\rinstance_name\x18\x01 \x01(\t\x12\x0c\n\x04root\x18\x02 \x01(\t\"<\n#GetInstanceNameForNamespaceResponse\x12\x15\n\rinstance_name\x18\x01 \x01(\t\"\x1a\n\x18GetLocalDiskUsageRequest\"D\n\x19GetLocalDiskUsageResponse\x12\x12\n\nsize_bytes\x18\x01 \x01(\x03\x12\x13\n\x0bquota_bytes\x18\x02 \x01(\x03\x32\xc9\t\n\x1eLocalContentAddressableStorage\x12l\n\x11\x46\x65tchMissingBlobs\x12).build.buildgrid.FetchMissingBlobsRequest\x1a*.build.buildgrid.FetchMissingBlobsResponse\"\x00\x12o\n\x12UploadMissingBlobs\x12*.build.buildgrid.UploadMissingBlobsRequest\x1a+.build.buildgrid.UploadMissingBlobsResponse\"\x00\x12T\n\tFetchTree\x12!.build.buildgrid.FetchTreeRequest\x1a\".build.buildgrid.FetchTreeResponse\"\x00\x12W\n\nUploadTree\x12\".build.buildgrid.UploadTreeRequest\x1a#.build.buildgrid.UploadTreeResponse\"\x00\x12X\n\tStageTree\x12!.build.buildgrid.StageTreeRequest\x1a\".build.buildgrid.StageTreeResponse\"\x00(\x01\x30\x01\x12Z\n\x0b\x43\x61ptureTree\x12#.build.buildgrid.CaptureTreeRequest\x1a$.build.buildgrid.CaptureTreeResponse\"\x00\x12]\n\x0c\x43\x61ptureFiles\x12$.build.buildgrid.CaptureFilesRequest\x1a%.build.buildgrid.CaptureFilesResponse\"\x00\x12\x81\x01\n\x18GetInstanceNameForRemote\x12\x30.build.buildgrid.GetInstanceNameForRemoteRequest\x1a\x31.build.buildgrid.GetInstanceNameForRemoteResponse\"\x00\x12\x84\x01\n\x19GetInstanceNameForRemotes\x12\x31.build.buildgrid.GetInstanceNameForRemotesRequest\x1a\x32.build.buildgrid.GetInstanceNameForRemotesResponse\"\x00\x12\x8a\x01\n\x1bGetInstanceNameForNamespace\x12\x33.build.buildgrid.GetInstanceNameForNamespaceRequest\x1a\x34.build.buildgrid.GetInstanceNameForNamespaceResponse\"\x00\x12l\n\x11GetLocalDiskUsage\x12).build.buildgrid.GetLocalDiskUsageRequest\x1a*.build.buildgrid.GetLocalDiskUsageResponse\"\x00\x62\x06proto3')
 
 
 
@@ -31,6 +31,7 @@ _FETCHTREERESPONSE = DESCRIPTOR.message_types_by_name['FetchTreeResponse']
 _UPLOADTREEREQUEST = DESCRIPTOR.message_types_by_name['UploadTreeRequest']
 _UPLOADTREERESPONSE = DESCRIPTOR.message_types_by_name['UploadTreeResponse']
 _STAGETREEREQUEST = DESCRIPTOR.message_types_by_name['StageTreeRequest']
+_STAGETREEREQUEST_CREDENTIALS = _STAGETREEREQUEST.nested_types_by_name['Credentials']
 _STAGETREERESPONSE = DESCRIPTOR.message_types_by_name['StageTreeResponse']
 _CAPTURETREEREQUEST = DESCRIPTOR.message_types_by_name['CaptureTreeRequest']
 _CAPTURETREERESPONSE = DESCRIPTOR.message_types_by_name['CaptureTreeResponse']
@@ -43,6 +44,8 @@ _GETINSTANCENAMEFORREMOTERESPONSE = DESCRIPTOR.message_types_by_name['GetInstanc
 _REMOTE = DESCRIPTOR.message_types_by_name['Remote']
 _GETINSTANCENAMEFORREMOTESREQUEST = DESCRIPTOR.message_types_by_name['GetInstanceNameForRemotesRequest']
 _GETINSTANCENAMEFORREMOTESRESPONSE = DESCRIPTOR.message_types_by_name['GetInstanceNameForRemotesResponse']
+_GETINSTANCENAMEFORNAMESPACEREQUEST = DESCRIPTOR.message_types_by_name['GetInstanceNameForNamespaceRequest']
+_GETINSTANCENAMEFORNAMESPACERESPONSE = DESCRIPTOR.message_types_by_name['GetInstanceNameForNamespaceResponse']
 _GETLOCALDISKUSAGEREQUEST = DESCRIPTOR.message_types_by_name['GetLocalDiskUsageRequest']
 _GETLOCALDISKUSAGERESPONSE = DESCRIPTOR.message_types_by_name['GetLocalDiskUsageResponse']
 FetchMissingBlobsRequest = _reflection.GeneratedProtocolMessageType('FetchMissingBlobsRequest', (_message.Message,), {
@@ -118,11 +121,19 @@ UploadTreeResponse = _reflection.GeneratedProtocolMessageType('UploadTreeRespons
 _sym_db.RegisterMessage(UploadTreeResponse)
 
 StageTreeRequest = _reflection.GeneratedProtocolMessageType('StageTreeRequest', (_message.Message,), {
+
+  'Credentials' : _reflection.GeneratedProtocolMessageType('Credentials', (_message.Message,), {
+    'DESCRIPTOR' : _STAGETREEREQUEST_CREDENTIALS,
+    '__module__' : 'build.buildgrid.local_cas_pb2'
+    # @@protoc_insertion_point(class_scope:build.buildgrid.StageTreeRequest.Credentials)
+    })
+  ,
   'DESCRIPTOR' : _STAGETREEREQUEST,
   '__module__' : 'build.buildgrid.local_cas_pb2'
   # @@protoc_insertion_point(class_scope:build.buildgrid.StageTreeRequest)
   })
 _sym_db.RegisterMessage(StageTreeRequest)
+_sym_db.RegisterMessage(StageTreeRequest.Credentials)
 
 StageTreeResponse = _reflection.GeneratedProtocolMessageType('StageTreeResponse', (_message.Message,), {
   'DESCRIPTOR' : _STAGETREERESPONSE,
@@ -210,6 +221,20 @@ GetInstanceNameForRemotesResponse = _reflection.GeneratedProtocolMessageType('Ge
   })
 _sym_db.RegisterMessage(GetInstanceNameForRemotesResponse)
 
+GetInstanceNameForNamespaceRequest = _reflection.GeneratedProtocolMessageType('GetInstanceNameForNamespaceRequest', (_message.Message,), {
+  'DESCRIPTOR' : _GETINSTANCENAMEFORNAMESPACEREQUEST,
+  '__module__' : 'build.buildgrid.local_cas_pb2'
+  # @@protoc_insertion_point(class_scope:build.buildgrid.GetInstanceNameForNamespaceRequest)
+  })
+_sym_db.RegisterMessage(GetInstanceNameForNamespaceRequest)
+
+GetInstanceNameForNamespaceResponse = _reflection.GeneratedProtocolMessageType('GetInstanceNameForNamespaceResponse', (_message.Message,), {
+  'DESCRIPTOR' : _GETINSTANCENAMEFORNAMESPACERESPONSE,
+  '__module__' : 'build.buildgrid.local_cas_pb2'
+  # @@protoc_insertion_point(class_scope:build.buildgrid.GetInstanceNameForNamespaceResponse)
+  })
+_sym_db.RegisterMessage(GetInstanceNameForNamespaceResponse)
+
 GetLocalDiskUsageRequest = _reflection.GeneratedProtocolMessageType('GetLocalDiskUsageRequest', (_message.Message,), {
   'DESCRIPTOR' : _GETLOCALDISKUSAGEREQUEST,
   '__module__' : 'build.buildgrid.local_cas_pb2'
@@ -248,36 +273,42 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _UPLOADTREEREQUEST._serialized_end=1035
   _UPLOADTREERESPONSE._serialized_start=1037
   _UPLOADTREERESPONSE._serialized_end=1057
-  _STAGETREEREQUEST._serialized_start=1059
-  _STAGETREEREQUEST._serialized_end=1176
-  _STAGETREERESPONSE._serialized_start=1178
-  _STAGETREERESPONSE._serialized_end=1211
-  _CAPTURETREEREQUEST._serialized_start=1213
-  _CAPTURETREEREQUEST._serialized_end=1323
-  _CAPTURETREERESPONSE._serialized_start=1326
-  _CAPTURETREERESPONSE._serialized_end=1537
-  _CAPTURETREERESPONSE_RESPONSE._serialized_start=1415
-  _CAPTURETREERESPONSE_RESPONSE._serialized_end=1537
-  _CAPTUREFILESREQUEST._serialized_start=1539
-  _CAPTUREFILESREQUEST._serialized_end=1650
-  _CAPTUREFILESRESPONSE._serialized_start=1653
-  _CAPTUREFILESRESPONSE._serialized_end=1965
-  _CAPTUREFILESRESPONSE_RESPONSE._serialized_start=1745
-  _CAPTUREFILESRESPONSE_RESPONSE._serialized_end=1965
-  _GETINSTANCENAMEFORREMOTEREQUEST._serialized_start=1968
-  _GETINSTANCENAMEFORREMOTEREQUEST._serialized_end=2099
-  _GETINSTANCENAMEFORREMOTERESPONSE._serialized_start=2101
-  _GETINSTANCENAMEFORREMOTERESPONSE._serialized_end=2158
-  _REMOTE._serialized_start=2160
-  _REMOTE._serialized_end=2266
-  _GETINSTANCENAMEFORREMOTESREQUEST._serialized_start=2269
-  _GETINSTANCENAMEFORREMOTESREQUEST._serialized_end=2412
-  _GETINSTANCENAMEFORREMOTESRESPONSE._serialized_start=2414
-  _GETINSTANCENAMEFORREMOTESRESPONSE._serialized_end=2472
-  _GETLOCALDISKUSAGEREQUEST._serialized_start=2474
-  _GETLOCALDISKUSAGEREQUEST._serialized_end=2500
-  _GETLOCALDISKUSAGERESPONSE._serialized_start=2502
-  _GETLOCALDISKUSAGERESPONSE._serialized_end=2570
-  _LOCALCONTENTADDRESSABLESTORAGE._serialized_start=2573
-  _LOCALCONTENTADDRESSABLESTORAGE._serialized_end=3657
+  _STAGETREEREQUEST._serialized_start=1060
+  _STAGETREEREQUEST._serialized_end=1280
+  _STAGETREEREQUEST_CREDENTIALS._serialized_start=1254
+  _STAGETREEREQUEST_CREDENTIALS._serialized_end=1280
+  _STAGETREERESPONSE._serialized_start=1282
+  _STAGETREERESPONSE._serialized_end=1315
+  _CAPTURETREEREQUEST._serialized_start=1318
+  _CAPTURETREEREQUEST._serialized_end=1462
+  _CAPTURETREERESPONSE._serialized_start=1465
+  _CAPTURETREERESPONSE._serialized_end=1676
+  _CAPTURETREERESPONSE_RESPONSE._serialized_start=1554
+  _CAPTURETREERESPONSE_RESPONSE._serialized_end=1676
+  _CAPTUREFILESREQUEST._serialized_start=1679
+  _CAPTUREFILESREQUEST._serialized_end=1824
+  _CAPTUREFILESRESPONSE._serialized_start=1827
+  _CAPTUREFILESRESPONSE._serialized_end=2139
+  _CAPTUREFILESRESPONSE_RESPONSE._serialized_start=1919
+  _CAPTUREFILESRESPONSE_RESPONSE._serialized_end=2139
+  _GETINSTANCENAMEFORREMOTEREQUEST._serialized_start=2142
+  _GETINSTANCENAMEFORREMOTEREQUEST._serialized_end=2273
+  _GETINSTANCENAMEFORREMOTERESPONSE._serialized_start=2275
+  _GETINSTANCENAMEFORREMOTERESPONSE._serialized_end=2332
+  _REMOTE._serialized_start=2334
+  _REMOTE._serialized_end=2440
+  _GETINSTANCENAMEFORREMOTESREQUEST._serialized_start=2443
+  _GETINSTANCENAMEFORREMOTESREQUEST._serialized_end=2656
+  _GETINSTANCENAMEFORREMOTESRESPONSE._serialized_start=2658
+  _GETINSTANCENAMEFORREMOTESRESPONSE._serialized_end=2716
+  _GETINSTANCENAMEFORNAMESPACEREQUEST._serialized_start=2718
+  _GETINSTANCENAMEFORNAMESPACEREQUEST._serialized_end=2791
+  _GETINSTANCENAMEFORNAMESPACERESPONSE._serialized_start=2793
+  _GETINSTANCENAMEFORNAMESPACERESPONSE._serialized_end=2853
+  _GETLOCALDISKUSAGEREQUEST._serialized_start=2855
+  _GETLOCALDISKUSAGEREQUEST._serialized_end=2881
+  _GETLOCALDISKUSAGERESPONSE._serialized_start=2883
+  _GETLOCALDISKUSAGERESPONSE._serialized_end=2951
+  _LOCALCONTENTADDRESSABLESTORAGE._serialized_start=2954
+  _LOCALCONTENTADDRESSABLESTORAGE._serialized_end=4179
 # @@protoc_insertion_point(module_scope)

--- a/src/buildstream/_protos/build/buildgrid/local_cas_pb2_grpc.py
+++ b/src/buildstream/_protos/build/buildgrid/local_cas_pb2_grpc.py
@@ -59,6 +59,11 @@ class LocalContentAddressableStorageStub(object):
                 request_serializer=build_dot_buildgrid_dot_local__cas__pb2.GetInstanceNameForRemotesRequest.SerializeToString,
                 response_deserializer=build_dot_buildgrid_dot_local__cas__pb2.GetInstanceNameForRemotesResponse.FromString,
                 )
+        self.GetInstanceNameForNamespace = channel.unary_unary(
+                '/build.buildgrid.LocalContentAddressableStorage/GetInstanceNameForNamespace',
+                request_serializer=build_dot_buildgrid_dot_local__cas__pb2.GetInstanceNameForNamespaceRequest.SerializeToString,
+                response_deserializer=build_dot_buildgrid_dot_local__cas__pb2.GetInstanceNameForNamespaceResponse.FromString,
+                )
         self.GetLocalDiskUsage = channel.unary_unary(
                 '/build.buildgrid.LocalContentAddressableStorage/GetLocalDiskUsage',
                 request_serializer=build_dot_buildgrid_dot_local__cas__pb2.GetLocalDiskUsageRequest.SerializeToString,
@@ -170,6 +175,12 @@ class LocalContentAddressableStorageServicer(object):
         If a CAS remote is configured, the blobs are uploaded.
         The `bypass_local_cache` parameter is a hint to indicate whether the blobs
         shall be uploaded without first storing them in the local cache.
+
+        The `move_files` parameter is a hint to indicate that files could be
+        moved into the storage. This can make capturing more efficient by
+        avoiding copies when it is known that files will not be needed after they
+        are imported. If a server chooses not to move them, the source files will
+        still exist after this request.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -183,6 +194,12 @@ class LocalContentAddressableStorageServicer(object):
         If a CAS remote is configured, the blobs are uploaded.
         The `bypass_local_cache` parameter is a hint to indicate whether the blobs
         shall be uploaded without first storing them in the local cache.
+
+        The `move_files` parameter is a hint to indicate that the files could be
+        moved into the storage. This can make capturing more efficient by
+        avoiding copies when it is known that files will not be needed after they
+        are imported. If a server chooses not to move them, the source files will
+        still exist after this request.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -206,6 +223,17 @@ class LocalContentAddressableStorageServicer(object):
 
         This returns a string that can be used as instance_name to access the
         specified endpoints in further requests.
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def GetInstanceNameForNamespace(self, request, context):
+        """Configure sandboxed clients.
+
+        This returns a string that can be used as instance_name to access
+        this service from clients running in the specified filesystem/mount
+        namespace or chroot environment
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -265,6 +293,11 @@ def add_LocalContentAddressableStorageServicer_to_server(servicer, server):
                     servicer.GetInstanceNameForRemotes,
                     request_deserializer=build_dot_buildgrid_dot_local__cas__pb2.GetInstanceNameForRemotesRequest.FromString,
                     response_serializer=build_dot_buildgrid_dot_local__cas__pb2.GetInstanceNameForRemotesResponse.SerializeToString,
+            ),
+            'GetInstanceNameForNamespace': grpc.unary_unary_rpc_method_handler(
+                    servicer.GetInstanceNameForNamespace,
+                    request_deserializer=build_dot_buildgrid_dot_local__cas__pb2.GetInstanceNameForNamespaceRequest.FromString,
+                    response_serializer=build_dot_buildgrid_dot_local__cas__pb2.GetInstanceNameForNamespaceResponse.SerializeToString,
             ),
             'GetLocalDiskUsage': grpc.unary_unary_rpc_method_handler(
                     servicer.GetLocalDiskUsage,
@@ -431,6 +464,23 @@ class LocalContentAddressableStorage(object):
         return grpc.experimental.unary_unary(request, target, '/build.buildgrid.LocalContentAddressableStorage/GetInstanceNameForRemotes',
             build_dot_buildgrid_dot_local__cas__pb2.GetInstanceNameForRemotesRequest.SerializeToString,
             build_dot_buildgrid_dot_local__cas__pb2.GetInstanceNameForRemotesResponse.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def GetInstanceNameForNamespace(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/build.buildgrid.LocalContentAddressableStorage/GetInstanceNameForNamespace',
+            build_dot_buildgrid_dot_local__cas__pb2.GetInstanceNameForNamespaceRequest.SerializeToString,
+            build_dot_buildgrid_dot_local__cas__pb2.GetInstanceNameForNamespaceResponse.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 


### PR DESCRIPTION
This updates `local_cas.proto` from https://gitlab.com/BuildGrid/buildbox/buildbox-common/-/merge_requests/462 such that access credentials can be specified when staging directories. buildbox-casd can use this to ensure that hardlinks are not used in unsafe setups, preventing cache corruption.