### PR TITLE
Do not use `zip(..., strict=True)` as it requires Python 3.10

### DIFF
--- a/src/buildstream/_artifact.py
+++ b/src/buildstream/_artifact.py
@@ -279,7 +279,10 @@ class Artifact:
 
             # Capture queued files and store returned digests
             digests = self._cas.add_objects(paths=[entry[0] for entry in files_to_capture])
-            for entry, digest in zip(files_to_capture, digests, strict=True):
+            # add_objects() should guarantee this.
+            # `zip(..., strict=True)` could be used in Python 3.10+
+            assert len(files_to_capture) == len(digests)
+            for entry, digest in zip(files_to_capture, digests):
                 entry[1].CopyFrom(digest)
                 size += digest.size_bytes
 


### PR DESCRIPTION
This is a fix for older Python versions. The issue was introduced in #1697.