### PR TITLE
doc/source/main_install.rst: Buildstream depends on lzip

### DIFF
--- a/doc/source/main_install.rst
+++ b/doc/source/main_install.rst
@@ -25,6 +25,7 @@ BuildStream requires the following base system requirements:
 
 - python3 >= 3.7
 - pip
+- lzip
 - :ref:`buildbox-casd<install-buildbox>`
 
 BuildStream also depends on the host tools for the :mod:`Source <buildstream.source>` plugins.

--- a/doc/source/main_install.rst
+++ b/doc/source/main_install.rst
@@ -25,7 +25,7 @@ BuildStream requires the following base system requirements:
 
 - python3 >= 3.7
 - pip
-- lzip
+- lzip (optional, for ``.tar.lz`` support)
 - :ref:`buildbox-casd<install-buildbox>`
 
 BuildStream also depends on the host tools for the :mod:`Source <buildstream.source>` plugins.


### PR DESCRIPTION
This is a dependency of the core tar plugin

See https://github.com/apache/buildstream/pull/1705#issuecomment-1199046601