### PR TITLE
_context.py: Don't call utils._get_bst_api_version() at load time.

### DIFF
--- a/src/buildstream/_context.py
+++ b/src/buildstream/_context.py
@@ -273,8 +273,7 @@ class Context:
             # trying a (major point) version specific configuration file
             # and then falling back to buildstream.conf.
             #
-            major_version, _ = utils._get_bst_api_version()
-            for config_filename in ("buildstream{}.conf".format(major_version), "buildstream.conf"):
+            for config_filename in ("buildstream2.conf", "buildstream.conf"):
                 default_config = os.path.join(os.environ["XDG_CONFIG_HOME"], config_filename)
                 if os.path.exists(default_config):
                     config = default_config


### PR DESCRIPTION
Getting the version requires importing the __version__ module which not
available at bash completion time, and we need to load the buildstream.conf
file when completing artifact names (because the config may determine where
the local artifact cache resides).

This fixes stack traces which were occurring in `bst artifact checkout <TAB>`