### PR TITLE
Allow artifact names in bst shell

### DIFF
--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -668,12 +668,12 @@ def show(app, elements, deps, except_, order, format_):
 @click.option(
     "--ignore-project-source-remotes", is_flag=True, help="Ignore remote source cache servers recommended by projects"
 )
-@click.argument("element", required=False, type=click.Path(readable=False))
+@click.argument("target", required=False, type=click.Path(readable=False))
 @click.argument("command", type=click.STRING, nargs=-1)
 @click.pass_obj
 def shell(
     app,
-    element,
+    target,
     command,
     mount,
     isolate,
@@ -713,16 +713,16 @@ def shell(
     scope = _Scope.BUILD if build_ else _Scope.RUN
 
     with app.initialized():
-        if not element:
-            element = app.project.get_default_target()
-            if not element:
-                raise AppError('Missing argument "ELEMENT".')
+        if not target:
+            target = app.project.get_default_target()
+            if not target:
+                raise AppError('Missing argument "TARGET".')
 
         mounts = [_HostMount(path, host_path) for host_path, path in mount]
 
         try:
             exitcode = app.stream.shell(
-                element,
+                target,
                 scope,
                 app.shell_prompt,
                 mounts=mounts,

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -288,6 +288,7 @@ class Stream:
             elements = self.load_selection(
                 (target,),
                 selection=selection,
+                load_artifacts=True,
                 connect_artifact_cache=True,
                 connect_source_cache=True,
                 artifact_remotes=artifact_remotes,

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -285,17 +285,26 @@ class Stream:
             else:
                 selection = _PipelineSelection.RUN
 
-            elements = self.load_selection(
-                (target,),
-                selection=selection,
-                load_artifacts=True,
-                connect_artifact_cache=True,
-                connect_source_cache=True,
-                artifact_remotes=artifact_remotes,
-                source_remotes=source_remotes,
-                ignore_project_artifact_remotes=ignore_project_artifact_remotes,
-                ignore_project_source_remotes=ignore_project_source_remotes,
-            )
+            try:
+                elements = self.load_selection(
+                    (target,),
+                    selection=selection,
+                    load_artifacts=True,
+                    connect_artifact_cache=True,
+                    connect_source_cache=True,
+                    artifact_remotes=artifact_remotes,
+                    source_remotes=source_remotes,
+                    ignore_project_artifact_remotes=ignore_project_artifact_remotes,
+                    ignore_project_source_remotes=ignore_project_source_remotes,
+                )
+            except StreamError as e:
+                if e.reason == "deps-not-supported":
+                    raise StreamError(
+                        "Only buildtrees are supported with artifact names",
+                        detail="Use the --build and --use-buildtree options to shell into a cached build tree",
+                        reason="only-buildtrees-supported",
+                    ) from e
+                raise
 
             # Get element to stage from `targets` list.
             # If scope is BUILD, it will not be in the `elements` list.

--- a/tests/integration/shell.py
+++ b/tests/integration/shell.py
@@ -436,3 +436,16 @@ def test_build_shell_fetch(cli, datafiles):
     result = cli.run(project=project, args=["shell", "--build", element_name, "cat", "hello.txt"])
     result.assert_success()
     assert result.output == test_message
+
+
+@pytest.mark.datafiles(DATA_DIR)
+@pytest.mark.skipif(not HAVE_SANDBOX, reason="Only available with a functioning sandbox")
+def test_shell_artifact_failure(cli, datafiles):
+    project = str(datafiles)
+
+    # This happens to be the artifact name of "autotools/amhello.bst" if we built it, but we don't
+    # need to build it for this test.
+    artifact_name = "test/autotools-amhello/847d23cd0e61c54a6beca9071b64643388ad2ab783191358b2a499fe77e86563"
+
+    result = cli.run(project=project, args=["shell", artifact_name, "--", "hello"])
+    result.assert_main_error(ErrorDomain.APP, "only-buildtrees-supported")

--- a/tests/integration/shellbuildtrees.py
+++ b/tests/integration/shellbuildtrees.py
@@ -327,6 +327,40 @@ def test_shell_pull_cached_buildtree(share_with_buildtrees, datafiles, cli, pull
 
 
 #
+# Test behavior of shelling into a buildtree by its artifact name
+#
+@pytest.mark.datafiles(DATA_DIR)
+@pytest.mark.skipif(not HAVE_SANDBOX, reason="Only available with a functioning sandbox")
+def test_shell_pull_artifact_cached_buildtree(share_with_buildtrees, datafiles, cli):
+    project = str(datafiles)
+    artifact_name = "test/build-shell-buildtree/4a47c98a10df39e65e99d471f96edc5b58d4ea5b9b1f221d0be832a8124b8099"
+
+    cli.configure({"artifacts": {"servers": [{"url": share_with_buildtrees.repo}]}})
+
+    # Run the shell and request that required artifacts and buildtrees should be pulled
+    result = cli.run(
+        project=project,
+        args=[
+            "--pull-buildtrees",
+            "shell",
+            "--build",
+            "--use-buildtree",
+            artifact_name,
+            "--",
+            "cat",
+            # We don't preserve the working directory in artifacts, so we will be executing at /
+            "/buildstream/test/build-shell/buildtree.bst/test",
+        ],
+    )
+
+    # In this case, we should succeed every time, regardless of what was
+    # originally available in the local cache.
+    #
+    result.assert_success()
+    assert "Hi" in result.output
+
+
+#
 # Test behavior of launching a shell and requesting to use a buildtree.
 #
 # In this case we download everything we need first, but the buildtree was never cached at build time


### PR DESCRIPTION
Now that we cache the full tree when builds fail, it becomes more interesting to have a buildshell on a failed artifact without needing to reproduce the project data.

Fixes #1711 
