### PR TITLE
Build and release wheel packages

### DIFF
--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -85,3 +85,27 @@ services:
   mypy:
     <<: *tests-template
     command: tox -e mypy
+
+  # Test that each BuildStream+BuildBox wheel package can install and run.
+  # on the PyPA official 'manylinux' images that define the base ABI for
+  # Python binary packages.
+
+  wheels-manylinux_2_28-cp37:
+    <<: *tests-template
+    image: quay.io/pypa/manylinux_2_28_x86_64
+    command: .github/wheel-helpers/test-wheel-manylinux.sh cp37-cp37m-manylinux_2_28_x86_64 /opt/python/cp37-cp37m/bin/python3
+
+  wheels-manylinux_2_28-cp38:
+    <<: *tests-template
+    image: quay.io/pypa/manylinux_2_28_x86_64
+    command: .github/wheel-helpers/test-wheel-manylinux.sh cp38-cp38-manylinux_2_28_x86_64 /opt/python/cp38-cp38/bin/python3
+
+  wheels-manylinux_2_28-cp39:
+    <<: *tests-template
+    image: quay.io/pypa/manylinux_2_28_x86_64
+    command: .github/wheel-helpers/test-wheel-manylinux.sh cp39-cp39-manylinux_2_28_x86_64 /opt/python/cp39-cp39/bin/python3
+
+  wheels-manylinux_2_28-cp310:
+    <<: *tests-template
+    image: quay.io/pypa/manylinux_2_28_x86_64
+    command: .github/wheel-helpers/test-wheel-manylinux.sh cp310-cp310-manylinux_2_28_x86_64 /opt/python/cp310-cp310/bin/python3

--- a/.github/wheel-helpers/fetch-latest-buildbox-release.sh
+++ b/.github/wheel-helpers/fetch-latest-buildbox-release.sh
@@ -6,10 +6,15 @@
 
 set -eux
 
-curl -L -O https://gitlab.com/buildgrid/buildbox/buildbox-integration/-/releases/permalink/latest/downloads/binaries.tgz
+#
+# For now we only support building wheels for linux x86_64 linked against glibc
+#
+tarball="buildbox-x86_64-linux-gnu.tgz"
+
+curl -L -O "https://gitlab.com/buildgrid/buildbox/buildbox-integration/-/releases/permalink/latest/downloads/${tarball}"
 
 mkdir -p src/buildstream/subprojects/buildbox
-tar --extract --file ./binaries.tgz --directory src/buildstream/subprojects/buildbox
+tar --extract --file "./${tarball}" --directory src/buildstream/subprojects/buildbox
 
 cd src/buildstream/subprojects/buildbox
 rm buildbox-run

--- a/.github/wheel-helpers/fetch-latest-buildbox-release.sh
+++ b/.github/wheel-helpers/fetch-latest-buildbox-release.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Download latest release binaries of BuildBox. These are statically linked
+# binaries produced by the buildbox-integration GitLab project, which we
+# bundle into BuildStream wheel packages.
+
+set -eux
+
+curl -L -O https://gitlab.com/buildgrid/buildbox/buildbox-integration/-/releases/permalink/latest/downloads/binaries.tgz
+
+mkdir -p src/buildstream/subprojects/buildbox
+tar --extract --file ./binaries.tgz --directory src/buildstream/subprojects/buildbox
+
+cd src/buildstream/subprojects/buildbox
+rm buildbox-run
+mv buildbox-run-bubblewrap buildbox-run

--- a/.github/wheel-helpers/test-wheel-manylinux.sh
+++ b/.github/wheel-helpers/test-wheel-manylinux.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Script to test that a generated BuildStream+BuildBox wheel package is
+# functional in the PyPA "manylinux" container images.
+#
+# The test is run via `run-ci.sh` which in turn uses `docker-compose` to
+# execute this script.
+
+set -eux
+
+COMPATIBILITY_TAGS=$1
+PYTHON=$2
+
+dnf install -y bubblewrap
+
+"$PYTHON" -m venv /tmp/venv
+/tmp/venv/bin/pip3 install ./wheelhouse/BuildStream-*-$COMPATIBILITY_TAGS.whl buildstream-plugins
+
+cd doc/examples/autotools
+/tmp/venv/bin/bst build hello.bst

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           ${GITHUB_WORKSPACE}/.github/run-ci.sh --service ${{ matrix.test-name }}
 
-  docs:
+  build_docs:
     runs-on: ubuntu-18.04
     steps:
       - name: Check out repository
@@ -108,3 +108,55 @@ jobs:
         with:
           name: docs
           path: doc/build/html
+
+  build_wheels:
+    name: Build Python wheel packages on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Fetch latest BuildBox release
+        run: ${GITHUB_WORKSPACE}/.github/wheel-helpers/fetch-latest-buildbox-release.sh
+
+      - name: Build wheels
+        run: pipx run cibuildwheel==2.8.1
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: ./wheelhouse/*.whl
+
+  test_wheels:
+    name: "Test Python packages: ${{ matrix.test-name }}"
+    needs: [build_wheels]
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        # The names here should map to a valid service defined in
+        # "../compose/ci.docker-compose.yml"
+        test-name:
+          - wheels-manylinux_2_28-cp37
+          - wheels-manylinux_2_28-cp38
+          - wheels-manylinux_2_28-cp39
+          - wheels-manylinux_2_28-cp310
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: ./wheelhouse
+
+      - name: Run tests with Docker Compose
+        run: |
+          ${GITHUB_WORKSPACE}/.github/run-ci.sh ${{ matrix.test-name }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -6,7 +6,7 @@ on:
     - master
 
 jobs:
-  build:
+  build_docs:
     name: Build documentation
     runs-on: ubuntu-18.04
     steps:
@@ -42,7 +42,7 @@ jobs:
           doc/build/html
           docs.tgz
 
-  publish:
+  publish_docs:
     needs: build
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_docs:
-    name: Build documentation
+    name: "Build documentation tarball"
     runs-on: ubuntu-18.04
     steps:
     - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Upload Release Asset
+name: Release actions
 
 on:
   push:
@@ -6,8 +6,8 @@ on:
     - '*.*.*'
 
 jobs:
-  build:
-    name: Upload Release Asset
+  build_docs:
+    name: "Build documentation tarball"
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout code
@@ -32,9 +32,114 @@ jobs:
 
           tar -C doc/build/html -zcf docs.tgz .
 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          path: docs.tgz
+
+  build_sdist:
+    name: "Build Python source distribution tarball"
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Build sdist
+      run: pipx run build --sdist
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: sdist
+        path: dist/*.tar.gz
+
+  build_wheels:
+    name: Build Python wheel packages on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Fetch latest BuildBox release
+        run: ${GITHUB_WORKSPACE}/.github/wheel-helpers/fetch-latest-buildbox-release.sh
+
+      - name: Build wheels
+        run: pipx run cibuildwheel==2.8.1
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: ./wheelhouse/*.whl
+
+  test_wheels:
+    name: Test Python wheel packages on ${{ matrix.os }}
+    needs: [build_wheels]
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        # The names here should map to a valid service defined in
+        # "../compose/ci.docker-compose.yml"
+        test-name:
+          - wheels-manylinux_2_28-cp37
+          - wheels-manylinux_2_28-cp38
+          - wheels-manylinux_2_28-cp39
+          - wheels-manylinux_2_28-cp310
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: ./wheelhouse
+
+      - name: Run tests with Docker Compose
+        run: |
+          ${GITHUB_WORKSPACE}/.github/run-ci.sh ${{ matrix.test-name }}
+
+  upload_github_release:
+    name: Upload GitHub release assets
+    needs: [build_docs, build_sdist, build_wheels, test_wheels]
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: docs
+
       - name: Upload release assets
         run: |
           tag_name="${GITHUB_REF##*/}"
           hub release create -a "docs.tgz" -m "$tag_name" "$tag_name"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  upload_pypi_release:
+    name: Upload PyPI release assets
+    needs: [build_docs, build_sdist, build_wheels, test_wheels]
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: sdist
+          path: dist
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
+      - name: Upload to PyPI
+        run: |
+          pipx run twine upload --repository pypi --username __token__ --password "${{ secrets.PYPI_TOKEN }}" dist/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -47,3 +47,6 @@ include versioneer.py
 
 # setuptools.build_meta don't include setup.py by default. Add it
 include setup.py
+
+# bundled binaries should only be in the bdist packages
+recursive-exclude src/buildstream/subprojects *

--- a/doc/source/hacking/making_releases.rst
+++ b/doc/source/hacking/making_releases.rst
@@ -173,6 +173,11 @@ Release process
      git tag -s 1.1.1
      git push origin 1.1.1
 
+  This will trigger the "Release actions" workflow which also takes care of:
+
+    * uploading Github release artifacts
+    * uploading Python source and binary packages to PyPI
+
 * Upload the release tarball
 
   First get yourself into a clean repository state, ensure that you
@@ -213,16 +218,9 @@ Post-release activities
 Once the release has been published, there are some activities
 which need to be done to ensure everything is up to date.
 
-* If this is a stable release, then the tarball should also be
-  uploaded to PyPI.
-
-  Make sure you have ``twine`` installed and upload the tarball
-  like so:
-
-  .. code:: shell
-
-     pip3 install --user twine
-     twine upload -r pypi dist/BuildStream-1.0.1.tar.gz
+* Check that the release was successfully uploaded to PyPI. If
+  it is an unstable release, make sure the version on PyPI has
+  the correct "dev0" postfix so to avoid being treated as stable.
 
 * Update the topic line in the #buildstream IRC channel if needed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ requires = [
     "setuptools>=36.6.0",
     # In order to build wheels, and as required by PEP 517
     "wheel",
-    "Cython"
+    "Cython",
+    "packaging",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,26 @@ exclude = '''
   | src/buildstream/_protos
 )
 '''
+
+[tool.cibuildwheel]
+build-frontend = "build"
+environment = { BST_BUNDLE_BUILDBOX = "1" }
+
+# The BuildBox binaries produced in buildbox-integration are linked against GLIBC 2.28
+# from Debian 10. See: https://gitlab.com/BuildGrid/buildbox/buildbox-integration.
+#
+# The PyPA manylinux_2_28 platform tag identifies that our wheel will run on any x86_64
+# OS with GLIBC >= 2.28. Following this setting, `cibuildwheel` builds the packages in
+# the corresponding manylinux_2_28 container image. See: https://github.com/pypa/manylinux
+manylinux-x86_64-image = "manylinux_2_28"
+
+skip = [
+  # BuildStream supports Python >= 3.7
+  "cp36-*",
+  # PyPy may work, but nobody is testing it so avoid distributing prebuilt binaries.
+  "pp*",
+  # Skipping this niche archicture ~halves overall build time.
+  "*_i686",
+  # The prebuilt BuildBox binaries link against GLibc so will work on manylinux but not musllinux
+  "*-musllinux_*",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [versioneer]
 VCS = git
-style = pep440
+style = pep440_buildstream
 versionfile_source = src/buildstream/_version.py
 versionfile_build = buildstream/_version.py
 tag_prefix =

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,63 @@ except ImportError:
     sys.exit(1)
 
 
+############################################################
+# List the BuildBox binaries to ship in the wheel packages #
+############################################################
+#
+# BuildBox isn't widely available in OS distributions. To enable a "one click"
+# install for BuildStream, we bundle prebuilt BuildBox binaries in our binary
+# wheel packages.
+#
+# The binaries are provided by the buildbox-integration Gitlab project:
+# https://gitlab.com/BuildGrid/buildbox/buildbox-integration
+#
+# If you want to build a wheel with the BuildBox binaries included, set the
+# env var "BST_BUNDLE_BUILDBOX=1" when running setup.py.
+
+try:
+    BUNDLE_BUILDBOX = int(os.environ.get("BST_BUNDLE_BUILDBOX", "0"))
+except ValueError:
+    print("BST_BUNDLE_BUILDBOX must be an integer. Please set it to '1' to enable, '0' to disable", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def list_buildbox_binaries():
+    expected_binaries = [
+        "buildbox-casd",
+        "buildbox-fuse",
+        "buildbox-run",
+    ]
+
+    if BUNDLE_BUILDBOX:
+        bst_package_dir = Path(__file__).parent.joinpath("src/buildstream")
+        buildbox_dir = bst_package_dir.joinpath("subprojects", "buildbox")
+        buildbox_binaries = [buildbox_dir.joinpath(name) for name in expected_binaries]
+
+        missing_binaries = [path for path in buildbox_binaries if not path.is_file()]
+        if missing_binaries:
+            paths_text = "\n".join(["  * {}".format(path) for path in missing_binaries])
+            print(
+                "Expected BuildBox binaries were not found. "
+                "Set BST_BUNDLE_BUILDBOX=0 or provide:\n\n"
+                "{}\n".format(paths_text),
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
+        for path in buildbox_binaries:
+            if path.is_symlink():
+                print(
+                    "Bundled BuildBox binaries must not be symlinks. Please fix {}".format(path),
+                    file=sys.stderr,
+                )
+                raise SystemExit(1)
+
+        return [str(path.relative_to(bst_package_dir)) for path in buildbox_binaries]
+    else:
+        return []
+
+
 ###########################################
 # List the pre-built man pages to install #
 ###########################################
@@ -351,7 +408,7 @@ setup(
     },
     python_requires="~={}.{}".format(REQUIRED_PYTHON_MAJOR, REQUIRED_PYTHON_MINOR),
     package_dir={"": "src"},
-    packages=find_packages(where="src", exclude=("tests", "tests.*")),
+    packages=find_packages(where="src", exclude=("subprojects", "tests", "tests.*")),
     package_data={
         "buildstream": [
             "py.typed",
@@ -359,6 +416,7 @@ setup(
             "plugins/*/*.yaml",
             "data/*.yaml",
             "data/*.sh.in",
+            *list_buildbox_binaries(),
             *list_testing_datafiles(),
         ]
     },

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ from pathlib import Path
 import re
 import sys
 
+import packaging.version
+
 
 ###################################
 # Ensure we have a version number #
@@ -32,11 +34,49 @@ import sys
 sys.path.append(os.path.dirname(__file__))
 import versioneer  # pylint: disable=wrong-import-position
 
+
+def mark_unstable_version(version_string):
+    # When publishing to PyPI we must be sure that unstable releases are
+    # marked as such, so `pip install` doesn't install them by default.
+
+    v = packaging.version.parse(version_string)
+
+    # BuildStream version scheme: if MINOR version is odd, then
+    # this is an unstable release.
+    is_unstable_release = v.minor % 2 != 0
+
+    # Python PEP440 version scheme: use an explicit postfix to mark development
+    # and prereleases.
+    if is_unstable_release:
+        if v.local or v.is_devrelease or v.is_prerelease:
+            # PyPI will ignore these without us marking them.
+            return version_string
+        else:
+            return version_string + ".dev0"
+
+    return version_string
+
+
+# Extend versioneer to support our custom version style.
+_render = versioneer.render
+
+
+def render_version(pieces, style):
+    if style == "pep440_buildstream":
+        result = _render(pieces, "pep440")
+        result["version"] = mark_unstable_version(result["version"])
+    else:
+        result = _render(pieces, style)
+    return result
+
+
+versioneer.render = render_version
+
 version = versioneer.get_version()
 
 if version.startswith("0+untagged"):
     print(
-        "Your git repository has no tags - BuildStream can't " "determine its version. Please run `git fetch --tags`.",
+        "Your git repository has no tags - BuildStream can't determine its version. Please run `git fetch --tags`.",
         file=sys.stderr,
     )
     sys.exit(1)

--- a/src/buildstream/_cas/casdprocessmanager.py
+++ b/src/buildstream/_cas/casdprocessmanager.py
@@ -35,6 +35,7 @@ from .._protos.build.bazel.remote.execution.v2 import remote_execution_pb2_grpc
 from .._protos.build.buildgrid import local_cas_pb2_grpc
 from .._protos.google.bytestream import bytestream_pb2_grpc
 
+from .. import _site
 from .. import utils
 from .._exceptions import CASCacheError
 
@@ -103,11 +104,28 @@ class CASDProcessManager:
             # The frontend will take care of terminating buildbox-casd.
             # Create a new process group for it such that SIGINT won't reach it.
             self.process = subprocess.Popen(  # pylint: disable=consider-using-with, subprocess-popen-preexec-fn
-                casd_args, cwd=path, stdout=logfile_fp, stderr=subprocess.STDOUT, preexec_fn=os.setpgrp
+                casd_args,
+                cwd=path,
+                stdout=logfile_fp,
+                stderr=subprocess.STDOUT,
+                preexec_fn=os.setpgrp,
+                env=self.__buildbox_casd_env(),
             )
 
     def __buildbox_casd(self):
         return utils._get_host_tool_internal("buildbox-casd", search_subprojects_dir="buildbox")
+
+    def __buildbox_casd_env(self):
+        env = os.environ.copy()
+
+        # buildbox-casd needs to have buildbox-fuse in its PATH at runtime,
+        # otherwise it will fallback to the HardLinkStager backend.
+        bundled_buildbox_dir = os.path.join(_site.subprojects, "buildbox")
+        if os.path.exists(bundled_buildbox_dir):
+            path = env.get("PATH", "").split(os.pathsep)
+            path = [bundled_buildbox_dir] + path
+            env["PATH"] = os.pathsep.join(path)
+        return env
 
     # _check_casd_version()
     #

--- a/src/buildstream/_cas/casdprocessmanager.py
+++ b/src/buildstream/_cas/casdprocessmanager.py
@@ -73,7 +73,7 @@ class CASDProcessManager:
         # Early version check
         self._check_casd_version(messenger)
 
-        casd_args = [utils.get_host_tool("buildbox-casd")]
+        casd_args = [self.__buildbox_casd()]
         casd_args.append("--bind=" + self._connection_string)
         casd_args.append("--log-level=" + log_level.value)
 
@@ -106,6 +106,9 @@ class CASDProcessManager:
                 casd_args, cwd=path, stdout=logfile_fp, stderr=subprocess.STDOUT, preexec_fn=os.setpgrp
             )
 
+    def __buildbox_casd(self):
+        return utils._get_host_tool_internal("buildbox-casd", search_subprojects_dir="buildbox")
+
     # _check_casd_version()
     #
     # Check for minimal acceptable version of buildbox-casd.
@@ -121,7 +124,7 @@ class CASDProcessManager:
         # We specify a trailing "path" argument because some versions of buildbox-casd
         # require specifying the storage path even for invoking the --version option.
         #
-        casd_args = [utils.get_host_tool("buildbox-casd")]
+        casd_args = [self.__buildbox_casd()]
         casd_args.append("--version")
         casd_args.append("/")
 

--- a/src/buildstream/_site.py
+++ b/src/buildstream/_site.py
@@ -43,3 +43,6 @@ build_all_template = os.path.join(root, "data", "build-all.sh.in")
 
 # Module building script template
 build_module_template = os.path.join(root, "data", "build-module.sh.in")
+
+# The bundled subprojects directory
+subprojects = os.path.join(root, "subprojects")

--- a/src/buildstream/_testing/_utils/site.py
+++ b/src/buildstream/_testing/_utils/site.py
@@ -55,7 +55,7 @@ try:
 except ProgramNotFoundError:
     HAVE_LZIP = False
 
-casd_path = utils.get_host_tool("buildbox-casd")
+casd_path = utils._get_host_tool_internal("buildbox-casd", search_subprojects_dir="buildbox")
 CASD_SEPARATE_USER = bool(os.stat(casd_path).st_mode & stat.S_ISUID)
 del casd_path
 
@@ -68,7 +68,7 @@ HAVE_SANDBOX = None
 BUILDBOX_RUN = None
 
 try:
-    path = utils.get_host_tool("buildbox-run")
+    path = utils._get_host_tool_internal("buildbox-run", search_subprojects_dir="buildbox")
     subprocess.run([path, "--capabilities"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     BUILDBOX_RUN = os.path.basename(os.readlink(path))
     HAVE_SANDBOX = "buildbox-run"

--- a/src/buildstream/sandbox/_sandboxbuildboxrun.py
+++ b/src/buildstream/sandbox/_sandboxbuildboxrun.py
@@ -35,9 +35,13 @@ from ._sandboxreapi import SandboxREAPI
 #
 class SandboxBuildBoxRun(SandboxREAPI):
     @classmethod
+    def __buildbox_run(cls):
+        return utils._get_host_tool_internal("buildbox-run", search_subprojects_dir="buildbox")
+
+    @classmethod
     def check_available(cls):
         try:
-            path = utils.get_host_tool("buildbox-run")
+            path = cls.__buildbox_run()
         except utils.ProgramNotFoundError as Error:
             cls._dummy_reasons += ["buildbox-run not found"]
             raise SandboxError(" and ".join(cls._dummy_reasons), reason="unavailable-local-sandbox") from Error
@@ -92,7 +96,7 @@ class SandboxBuildBoxRun(SandboxREAPI):
             action_file.flush()
 
             buildbox_command = [
-                utils.get_host_tool("buildbox-run"),
+                self.__buildbox_run(),
                 "--remote={}".format(casd_process_manager._connection_string),
                 "--action={}".format(action_file.name),
                 "--action-result={}".format(result_file.name),

--- a/tests/integration/cachedfail.py
+++ b/tests/integration/cachedfail.py
@@ -217,7 +217,7 @@ def test_host_tools_errors_are_not_cached(cli, datafiles, tmp_path):
     # Create symlink to buildbox-casd to work with custom PATH
     buildbox_casd = tmp_path.joinpath("bin/buildbox-casd")
     buildbox_casd.parent.mkdir()
-    os.symlink(utils.get_host_tool("buildbox-casd"), str(buildbox_casd))
+    os.symlink(utils._get_host_tool_internal("buildbox-casd", search_subprojects_dir="buildbox"), str(buildbox_casd))
 
     project = str(datafiles)
     element_path = os.path.join(project, "elements", "element.bst")

--- a/tests/sandboxes/selection.py
+++ b/tests/sandboxes/selection.py
@@ -33,7 +33,7 @@ def test_dummy_sandbox_fallback(cli, datafiles, tmp_path):
     # Create symlink to buildbox-casd to work with custom PATH
     buildbox_casd = tmp_path.joinpath("bin/buildbox-casd")
     buildbox_casd.parent.mkdir()
-    os.symlink(utils.get_host_tool("buildbox-casd"), str(buildbox_casd))
+    os.symlink(utils._get_host_tool_internal("buildbox-casd", search_subprojects_dir="buildbox"), str(buildbox_casd))
 
     project = str(datafiles)
     element_path = os.path.join(project, "elements", "element.bst")

--- a/tox.ini
+++ b/tox.ini
@@ -209,27 +209,6 @@ deps =
 
 
 #
-# Publish a release on PyPI.
-#
-# This can be run manually but is useful to have here just to document how it's done,
-# it's also easier to just run:
-#
-#   TWINE_USERNAME=buildstream TWINE_PASSWORD=<password> tox -e release
-#
-[testenv:release]
-skip_install = true
-commands =
-    python3 setup.py sdist bdist_wheel
-    twine upload -r pypi dist/*
-deps =
-    twine
-    wheel
-passenv =
-    TWINE_USERNAME
-    TWINE_PASSWORD
-
-
-#
 # Usefull for running arbitrary scripts in a BuildStream virtual env
 #
 [testenv:venv]


### PR DESCRIPTION
This updates the CI config to:

  * build x86_64 wheel packages on each update of 'master', which can be downloaded as Action artifacts. The packages contain release binaries of BuildBox casd/fuse/run-bubblewrap.
  * build sdist and wheel packages on each release tag, test the wheels, and upload them to Test PyPI at https://test.pypi.org/project/BuildStream/

Before actually landing this, we need to make some changes:

  * [x] update documentation around release process and installation (https://gitlab.com/BuildStream/website/-/merge_requests/153)
  * [x] release to the real PyPI instead of [Test PyPI](https://test.pypi.org/) (in release.yml)
  * [x] create and add a [PyPI API token](https://pypi.org/help/#apitoken) as a [repository secret](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-encrypted-secrets-for-your-repository-and-organization-for-github-codespaces)
  * [x] review and merge latest [buildbox-fuse patches](https://gitlab.com/BuildGrid/buildbox/buildbox-fuse/-/merge_requests/46) so we can have a new buildbox release
  * [x] tag [buildbox-integration](https://gitlab.com/BuildGrid/buildbox/buildbox-integration/) so that we can have the binaries uploaded with the [new descriptive filenames](https://gitlab.com/BuildGrid/buildbox/buildbox-integration/-/merge_requests/5)
  * [x] apply new patch 85a8953940ee8a03d85b0277457583b67acd1656 to update the permalinks for downloading buildbox binaries

Fixes #1712
