### PR TITLE
Continue post processing when quitting the scheduler

### DIFF
--- a/src/buildstream/_scheduler/queues/artifactpushqueue.py
+++ b/src/buildstream/_scheduler/queues/artifactpushqueue.py
@@ -31,8 +31,8 @@ class ArtifactPushQueue(Queue):
     complete_name = "Artifacts Pushed"
     resources = [ResourceType.UPLOAD]
 
-    def __init__(self, scheduler, *, skip_uncached=False):
-        super().__init__(scheduler)
+    def __init__(self, scheduler, *, imperative=False, skip_uncached=False):
+        super().__init__(scheduler, imperative=imperative)
 
         self._skip_uncached = skip_uncached
 

--- a/src/buildstream/_scheduler/queues/queue.py
+++ b/src/buildstream/_scheduler/queues/queue.py
@@ -64,7 +64,7 @@ class Queue:
     # Resources this queues' jobs want
     resources = []  # type: List[int]
 
-    def __init__(self, scheduler):
+    def __init__(self, scheduler, *, imperative=False):
 
         #
         # Private members
@@ -77,6 +77,11 @@ class Queue:
         self._queued_elements = 0  # Number of elements queued
 
         self._required_element_check = False  # Whether we should check that elements are required before enqueuing
+
+        #
+        # Public members
+        #
+        self.imperative = imperative
 
         # Assert the subclass has setup class data
         assert self.action_name is not None

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -423,7 +423,7 @@ class Stream:
 
         self._add_queue(FetchQueue(self._scheduler, skip_cached=True))
 
-        self._add_queue(BuildQueue(self._scheduler))
+        self._add_queue(BuildQueue(self._scheduler, imperative=True))
 
         if self._artifacts.has_push_remotes():
             self._add_queue(ArtifactPushQueue(self._scheduler, skip_uncached=True))
@@ -553,7 +553,7 @@ class Stream:
 
         self._add_queue(FetchQueue(self._scheduler))
 
-        self._add_queue(SourcePushQueue(self._scheduler))
+        self._add_queue(SourcePushQueue(self._scheduler, imperative=True))
 
         self._enqueue_plan(elements)
         self._run(announce_session=True)
@@ -652,7 +652,7 @@ class Stream:
 
         self._reset()
         self._add_queue(PullQueue(self._scheduler))
-        self._add_queue(ArtifactPushQueue(self._scheduler))
+        self._add_queue(ArtifactPushQueue(self._scheduler, imperative=True))
         self._enqueue_plan(elements)
         self._run(announce_session=True)
 

--- a/tests/integration/cachedfail.py
+++ b/tests/integration/cachedfail.py
@@ -138,9 +138,6 @@ def test_build_depend_on_cached_fail(cli, datafiles):
 @pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.parametrize("on_error", ("continue", "quit"))
 def test_push_cached_fail(cli, tmpdir, datafiles, on_error):
-    if on_error == "quit":
-        pytest.xfail("https://gitlab.com/BuildStream/buildstream/issues/534")
-
     project = str(datafiles)
     element_path = os.path.join(project, "elements", "element.bst")
 
@@ -185,9 +182,6 @@ def test_push_failed_missing_shell(cli, tmpdir, datafiles, on_error):
     When we don't have a valid shell, the artifact will be empty, not even the root directory.
     This ensures we handle the case of an entirely empty artifact correctly.
     """
-    if on_error == "quit":
-        pytest.xfail("https://gitlab.com/BuildStream/buildstream/issues/534")
-
     project = str(datafiles)
     element_path = os.path.join(project, "elements", "element.bst")
 
@@ -342,11 +336,6 @@ def test_nonstrict_retry_failed(cli, tmpdir, datafiles, use_share, retry):
         assert cli.get_element_state(project, "target.bst") == "failed"
 
         if use_share:
-            # Ensure that the target.bst has been shared, this is needed because of:
-            #     https://github.com/apache/buildstream/issues/534
-            result = cli.run(project=project, args=["artifact", "push", "target.bst"])
-            result.assert_success()
-
             # Delete the local cache, provoke pulling of the failed build
             cli.remove_artifact_from_cache(project, "target.bst")
 

--- a/tests/sourcecache/push.py
+++ b/tests/sourcecache/push.py
@@ -280,9 +280,8 @@ def test_source_push_build_fail(cli, tmpdir, datafiles):
         res.assert_main_error(ErrorDomain.STREAM, None)
         res.assert_task_error(ErrorDomain.ELEMENT, None)
 
-        # Sources are not pushed as the build queue is before the source push
-        # queue.
-        assert "Pushed source " not in res.stderr
+        # Sources are still pushed after failing a build
+        assert "Pushed source " in res.stderr
 
 
 # Test that source push succeeds if the source needs to be fetched


### PR DESCRIPTION
This changes the meaning of `--on-error quit` such that post-processing of the work most relevant to the command issued continues to happen after a failure occurs.

Fixes #534
