### PR TITLE
Use reversed order for sources while tracking

### DIFF
--- a/src/buildstream/source.py
+++ b/src/buildstream/source.py
@@ -1372,7 +1372,7 @@ class Source(Plugin):
         # NOTE: We are assuming here that tracking only requires substituting the
         #       first alias used
         last_error = None
-        for uri in project.get_alias_uris(alias, first_pass=self.__first_pass, tracking=True):
+        for uri in reversed(project.get_alias_uris(alias, first_pass=self.__first_pass, tracking=True)):
             new_source = self.__clone_for_uri(uri)
             try:
                 ref = new_source.track(**kwargs)  # pylint: disable=assignment-from-none


### PR DESCRIPTION
Related to https://github.com/apache/buildstream/issues/1762

This is currently not controllable so revert to same order bst1 had. Reasoning: when resolving new content, we want to prefer upstream whereas when downloading, we want to prefer mirrors. Ideally this order should be controllable through user config.