### PR TITLE
buildstream/utils.py: Fix regex Deprecation Warning

### DIFF
--- a/buildstream/utils.py
+++ b/buildstream/utils.py
@@ -1138,7 +1138,7 @@ def _call(*popenargs, terminate=False, **kwargs):
 #
 def _glob2re(pat):
     i, n = 0, len(pat)
-    res = ''
+    res = '(?ms)'
     while i < n:
         c = pat[i]
         i = i + 1
@@ -1175,7 +1175,7 @@ def _glob2re(pat):
                 res = '{}[{}]'.format(res, stuff)
         else:
             res = res + re.escape(c)
-    return res + r'\Z(?ms)'
+    return res + r'\Z'
 
 
 # _deduplicate()


### PR DESCRIPTION
Part of https://github.com/apache/buildstream/issues/1758, backport of https://github.com/apache/buildstream/commit/e8055a56d265d558248557782fa3ed0e6419caa4