### PR TITLE
Zsh tab-completions, with related doc changes

### DIFF
--- a/doc/source/main_install.rst
+++ b/doc/source/main_install.rst
@@ -223,11 +223,15 @@ consider using `pipx <https://docs.python.org/3/tutorial/venv.html>`_.
 Installing completions
 ----------------------
 
-BuildStream integrates with Bash to provide helpful tab-completion. These
-are provided by the `bst` completion script, available online
-`here <https://raw.githubusercontent.com/apache/buildstream/master/src/buildstream/data/bst>`_
-and in your local Git clone at ``src/buildstream/data/bst``. The completion
-script requires manaul installation.
+BuildStream integrates with Bash and Zsh to provide helpful tab-completion.
+These completion scripts require manual installation.
+
+Bash completions
+~~~~~~~~~~~~~~~~
+
+Bash completions are provided by the ``bst`` completion script, available online
+(`src/buildstream/data/bst <https://raw.githubusercontent.com/apache/buildstream/master/src/buildstream/data/bst>`_)
+and in your local Git clone at ``src/buildstream/data/bst``.
 
 To install for the current user, paste the contents of the completion script
 into the file ``~/.bash_completion``.
@@ -239,3 +243,41 @@ bash-completion installation path, which you can discover as follows::
 
 See the `bash-completion FAQ <https://github.com/scop/bash-completion#faq>`_
 for more information.
+
+Zsh completions
+~~~~~~~~~~~~~~~~
+
+Zsh completions are provided by the ``_bst`` completion script, available online
+(`src/buildstream/data/zsh/_bst <https://raw.githubusercontent.com/apache/buildstream/master/src/buildstream/data/zsh/_bst>`_)
+and in your local Git clone at ``src/buildstream/data/zsh/_bst``.
+
+Copy the above file to the completions location for your Zsh framework:
+
+**Prezto**::
+
+    cp src/buildstream/data/zsh/_bst ~/.zprezto/modules/completion/external/src/_bst
+
+You may have to reset your zcompdump cache, if you have one, and then restart your shell::
+
+    rm ~/.zcompdump ${XDG_CACHE_HOME:-$HOME/.cache}/prezto/zcompdump
+
+**Oh My Zsh**::
+
+    mkdir $ZSH_CUSTOM/plugins/bst
+    cp src/buildstream/data/zsh/_bst $ZSH_CUSTOM/plugins/bst/_bst
+
+You must then add ``bst`` to your plugins array in ``~/.zshrc``::
+
+    plugins(
+      bst
+      ...
+    )
+
+**None**::
+
+    cp src/buildstream/data/zsh/_bst ~/.zfunc/_bst
+
+You must then add the following lines in your ``~/.zshrc``, if they do not already exist::
+
+    fpath+=~/.zfunc
+    autoload -Uz compinit && compinit

--- a/doc/source/main_install.rst
+++ b/doc/source/main_install.rst
@@ -251,7 +251,18 @@ Zsh completions are provided by the ``_bst`` completion script, available online
 (`src/buildstream/data/zsh/_bst <https://raw.githubusercontent.com/apache/buildstream/master/src/buildstream/data/zsh/_bst>`_)
 and in your local Git clone at ``src/buildstream/data/zsh/_bst``.
 
-Copy the above file to the completions location for your Zsh framework:
+Copy the above file to your Zsh completions location. Here are some instructions
+for vanilla Zsh, as well as the *Prezto* and *Oh My Zsh* frameworks:
+
+**Zsh**::
+
+    cp src/buildstream/data/zsh/_bst ~/.zfunc/_bst
+
+You must then add the following lines in your ``~/.zshrc``, if they do not already exist::
+
+    fpath+=~/.zfunc
+    autoload -Uz compinit && compinit
+
 
 **Prezto**::
 
@@ -272,12 +283,3 @@ You must then add ``bst`` to your plugins array in ``~/.zshrc``::
       bst
       ...
     )
-
-**None**::
-
-    cp src/buildstream/data/zsh/_bst ~/.zfunc/_bst
-
-You must then add the following lines in your ``~/.zshrc``, if they do not already exist::
-
-    fpath+=~/.zfunc
-    autoload -Uz compinit && compinit

--- a/src/buildstream/data/zsh/_bst
+++ b/src/buildstream/data/zsh/_bst
@@ -1,0 +1,21 @@
+#compdef bst
+_bst_cmpl() {
+    local idx completions name
+    idx="${#words[@]}"
+    # ZSH arrays start at 1
+    let idx=idx-1
+    completions=( $( env COMP_WORDS="$words" \
+                     COMP_CWORD=$idx \
+                     _BST_COMPLETION=complete bst ) )
+    for name in ${completions[@]}; do
+        # For items that are an incomplete path, do not add trailing space
+        if [[ $name = */ ]]; then
+            compadd -S '' $name
+        else
+            A=($name)
+            compadd -a A
+        fi
+    done
+    return 0
+}
+_bst_cmpl "$@"


### PR DESCRIPTION
Hello, I found a related ticket for this: #558

I primarily use Zsh with Prezto, and not having tab-completions was bothering me, so here you go :) 

It just uses your existing Bash completion code, but rearranges it for Zsh's `compdef`. File name must be `_bst`, and I placed in a `zsh` directory in the same location as the bash `bst` script is. Hope that's okay.

Also added related usage instructions to the docs.

For future enhancements in this area, I would recommend doing tab-completions similar to how Poetry does it, but that's up to you:  https://python-poetry.org/docs/#enable-tab-completion-for-bash-fish-or-zsh 

Thanks!