### PR TITLE
pyproject.toml: Require at least the first version of cython which supports 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ requires = [
     "setuptools>=36.6.0",
     # In order to build wheels, and as required by PEP 517
     "wheel",
-    "Cython",
+    # Require a new enough cython for the python versions we support
+    "Cython>=0.29.25",
     "packaging",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This is the alternative patch to #1777 

Instead of not distributing cython generated C files, just ensure that we roll out source distributions using a cython version which supports every version of python which we support.

We create source distributions in CI with `pipx run build --sdist`, and this will correctly observe the `pyproject.toml` and appropriately install the cython version according to our specifications.
