### PR TITLE
_sandboxbuildboxrun.py: Restore terminal after exit of interactive child

### DIFF
--- a/src/buildstream/sandbox/_sandboxbuildboxrun.py
+++ b/src/buildstream/sandbox/_sandboxbuildboxrun.py
@@ -223,7 +223,7 @@ class SandboxBuildBoxRun(SandboxREAPI):
             except psutil.NoSuchProcess:
                 pass
 
-            if interactive:
+            if interactive and stdin.isatty():
                 # Make this process the foreground process again, otherwise the
                 # next read() on stdin will trigger SIGTTIN and stop the process.
                 # This is required because the sandboxed process does not have


### PR DESCRIPTION
This is a port of 8f401127c450ea1c2a1e2878d2ac28a7166d355c to the buildbox-run sandbox

Thanks to @adoakley for investigating the issue. This was previously #41

Fixes #1690