### PR TITLE
requirements.txt: Bump grpc version to be compatible with Python 3.11

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 click==8.1.3
-grpcio==1.46.0
+grpcio==1.49.1
 Jinja2==3.1.2
 pluginbase==1.0.1
 protobuf==4.21.12


### PR DESCRIPTION
missed this in #1806 