### PR TITLE
Update grpcio

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 click==8.1.3
-grpcio==1.46.0
+grpcio==1.51.1
 Jinja2==3.1.2
 pluginbase==1.0.1
 protobuf==4.21.12


### PR DESCRIPTION
This updates grpcio to 1.51.1 and fixes tests to work with the new version.

This disables coverage collection in the artifactshare subprocess as it seems to be incompatible with forkserver, however, unblocking the grpcio update is currently more important.