### PR TITLE
tests/testutils/repo/git.py: Fix submodule tests with recent git

### DIFF
--- a/tests/testutils/repo/git.py
+++ b/tests/testutils/repo/git.py
@@ -78,7 +78,7 @@ class Git(Repo):
         if url is not None:
             submodule["url"] = url
         self.submodules[subdir] = submodule
-        self._run_git("submodule", "add", url, subdir)
+        self._run_git("-c", "protocol.file.allow=always", "submodule", "add", url, subdir)
         self._run_git("commit", "-m", "Added the submodule")
         return self.latest_commit()
 


### PR DESCRIPTION
git 2.38.1+ (and backports to earlier branches) changed the default value of `protocol.file.allow` to `user`, which breaks submodule tests.