### PR TITLE
Unpin coverage

### DIFF
--- a/.github/common.env
+++ b/.github/common.env
@@ -1,6 +1,6 @@
 # Shared common variables
 
 CI_IMAGE_VERSION=master-643533272
-CI_TOXENV_MAIN=py37,py38-nocover,py39-nocover,py310-nocover,py311-nocover
-CI_TOXENV_PLUGINS=py37-plugins,py38-plugins-nocover,py39-plugins-nocover,py310-plugins-nocover,py311-plugins-nocover
+CI_TOXENV_MAIN=py37,py38,py39,py310,py311
+CI_TOXENV_PLUGINS=py37-plugins,py38-plugins,py39-plugins,py310-plugins,py311-plugins
 CI_TOXENV_ALL="${CI_TOXENV_MAIN},${CI_TOXENV_PLUGINS}"

--- a/requirements/cov-requirements.in
+++ b/requirements/cov-requirements.in
@@ -1,4 +1,4 @@
-coverage == 4.4.0
+coverage >= 6
 pytest-cov >= 2.5.0
 pytest >= 6.0.1
 Cython

--- a/requirements/cov-requirements.txt
+++ b/requirements/cov-requirements.txt
@@ -1,5 +1,5 @@
-coverage==4.4
-pytest-cov==2.10.1
+coverage==7.0.5
+pytest-cov==4.0.0
 pytest==7.2.0
 Cython==0.29.32
 ## The following requirements were added by pip freeze:

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@
 # Tox global configuration
 #
 [tox]
-envlist = py37,py{38,39,310,311}-nocover
+envlist = py{37,38,39,310,311}
 skip_missing_interpreters = true
 isolated_build = true
 


### PR DESCRIPTION
Coverage 6 works with Cython on Python 3.8+. This enables coverage support for all Python versions.