### PR TITLE
.asf.yaml: Delete branches when pull requests are merged

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -33,6 +33,9 @@ github:
     # disable rebase button:
     rebase: false
 
+  # Close branches when pull requests are merged
+  del_branch_on_merge: true
+
   # Enable pages publishing
   ghp_branch: gh-pages
   ghp_path: /


### PR DESCRIPTION
https://github.com/apache/buildstream/branches/all shows a lot of branches that have already been merged into master. They should perhaps be cleaned up separately, but enable the `del_branch_on_merge` flag to automatically delete such branches in the future.