### PR TITLE
Add .gitattributes to syntax highlight bst files as yaml

### DIFF
--- a/tests/.gitattributes
+++ b/tests/.gitattributes
@@ -1,0 +1,2 @@
+*.bst linguist-language=yaml
+project.conf linguist-language=yaml


### PR DESCRIPTION
Add a `.gitattributes` file to suggest GitHub Linguist to treat `.bst` files and `project.conf` file anywhere in the project as YAML for the purposes of syntax highlighting.

If we agree with this change, we can also add something in our documentation to suggest users to add something similar to their projects. Although that suggestion will depend on the Git hosting service used. GitHub and GitLab both support overrides via `.gitattributes` file but use different keywords. See:

* https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#using-gitattributes
* https://docs.gitlab.com/ee/user/project/highlighting.html#override-syntax-highlighting-for-a-file-type