### PR TITLE
Remove unnecessary dependency on dateutil

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -9,4 +9,3 @@ ruamel.yaml.clib >= 0.1.2
 setuptools
 pyroaring
 ujson
-python-dateutil >= 2.7.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,7 +9,5 @@ ruamel.yaml.clib==0.2.7
 setuptools==67.4.0
 pyroaring==0.3.8
 ujson==5.7.0
-python-dateutil==2.8.2
 ## The following requirements were added by pip freeze:
 MarkupSafe==2.1.2
-six==1.16.0

--- a/tests/internals/storage_vdir_import.py
+++ b/tests/internals/storage_vdir_import.py
@@ -21,7 +21,7 @@ from buildstream import DirectoryError
 from buildstream.storage._casbaseddirectory import CasBasedDirectory
 from buildstream.storage._filebaseddirectory import FileBasedDirectory
 from buildstream._cas import CASCache
-from buildstream.utils import _set_file_mtime, _parse_timestamp
+from buildstream.utils import _set_file_mtime
 from buildstream._testing._utils.site import have_subsecond_mtime
 
 
@@ -48,7 +48,6 @@ root_filesets = [
 empty_hash_ref = sha256().hexdigest()
 RANDOM_SEED = 69105
 NUM_RANDOM_TESTS = 4
-TIMESTAMP = "2019-12-16T08:49:04.012Z"
 MTIME = 1576486144.0120000
 
 
@@ -69,7 +68,7 @@ def generate_import_root(rootdir, filelist):
             with open(fullpath, "wt", encoding="utf-8") as f:
                 f.write(content)
             # set file mtime to arbitrary
-            _set_file_mtime(fullpath, _parse_timestamp(TIMESTAMP))
+            _set_file_mtime(fullpath, MTIME)
         elif typesymbol == "D":
             os.makedirs(os.path.join(rootdir, path), exist_ok=True)
         elif typesymbol == "S":
@@ -103,7 +102,7 @@ def generate_random_root(rootno, directory):
         elif thing == "file":
             with open(target, "wt", encoding="utf-8") as f:
                 f.write("This is node {}\n".format(i))
-            _set_file_mtime(target, _parse_timestamp(TIMESTAMP))
+            _set_file_mtime(target, MTIME)
         elif thing == "link":
             symlink_type = random.choice(["absolute", "relative", "broken"])
             if symlink_type == "broken" or not things:

--- a/tests/internals/utils_move_atomic.py
+++ b/tests/internals/utils_move_atomic.py
@@ -14,14 +14,14 @@
 # Pylint doesn't play well with fixtures and dependency injection from pytest
 # pylint: disable=redefined-outer-name
 
+from os.path import getmtime
+
 import pytest
 
 from buildstream.utils import (
     move_atomic,
     DirectoryExistsError,
-    _get_file_mtimestamp,
     _set_file_mtime,
-    _parse_timestamp,
 )
 from buildstream._testing._utils.site import have_subsecond_mtime
 
@@ -123,10 +123,6 @@ def test_move_to_empty_dir_set_mtime(src, tmp_path):
     assert dst.joinpath("test").exists()
     _dst = str(dst)
     # set the mtime via stamp
-    timestamp1 = "2020-01-08T11:05:50.832123Z"
-    _set_file_mtime(_dst, _parse_timestamp(timestamp1))
-    assert timestamp1 == _get_file_mtimestamp(_dst)
-    # reset the mtime using an offset stamp
-    timestamp2 = "2010-02-12T12:05:50.832123+01:00"
-    _set_file_mtime(_dst, _parse_timestamp(timestamp2))
-    assert _get_file_mtimestamp(_dst) == "2010-02-12T11:05:50.832123Z"
+    timestamp1 = 1578481550.832123
+    _set_file_mtime(_dst, timestamp1)
+    assert timestamp1 == getmtime(_dst)

--- a/tox.ini
+++ b/tox.ini
@@ -182,7 +182,6 @@ commands =
 deps =
     mypy==0.910
     types-protobuf
-    types-python-dateutil
     types-setuptools
     types-ujson
     -rrequirements/requirements.txt


### PR DESCRIPTION
Remove unnecessary utility functions for the parsing and generating of ISO 8601 timestamps since they are no longer used outside of the tests, which have been instead adapted to use unix timestamps directly.

Closes https://github.com/apache/buildstream/issues/1866.