### PR TITLE
_frontend/cli.py: Fix default version after 2.1 release

### DIFF
--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -408,7 +408,7 @@ def help_command(ctx, command):
 @click.option(
     "--min-version",
     type=click.STRING,
-    default="2.0",
+    default="2.1",
     show_default=True,
     help="The required format version",
 )

--- a/tests/frontend/init.py
+++ b/tests/frontend/init.py
@@ -28,15 +28,6 @@ from buildstream.exceptions import ErrorDomain, LoadErrorReason
 def get_default_min_version():
     bst_major, bst_minor = utils.get_bst_version()
 
-    # For the version check, artificially set the version to at least
-    # version 2.0
-    #
-    # TODO: Remove this code block after releasing 2.0
-    #
-    if bst_major < 2:
-        bst_major = 2
-        bst_minor = 0
-
     return "{}.{}".format(bst_major, bst_minor)
 
 


### PR DESCRIPTION
And remove some test code which we can delete after 2.0 release.

This fixes tests which were broken as a consequence of releasing 2.1