### PR TITLE
_yaml.pyx: disallow duplicate keys in yaml mappings

### DIFF
--- a/src/buildstream/_yaml.pyx
+++ b/src/buildstream/_yaml.pyx
@@ -169,6 +169,8 @@ cdef class Representer:
         return RepresenterState.wait_key
 
     cdef RepresenterState _handle_wait_key_ScalarEvent(self, object ev):
+        if ev.value in self.output[-1]:
+            raise YAMLLoadError(f"Duplicate key {ev.value} at line {ev.start_mark.line} column {ev.start_mark.column}")
         self.keys.append(ev.value)
         return RepresenterState.wait_value
 

--- a/tests/format/link.py
+++ b/tests/format/link.py
@@ -192,7 +192,7 @@ def test_cross_link_junction_include(cli, tmpdir, datafiles):
     project = os.path.join(str(datafiles), "cross-link-junction-include")
 
     # Show the variables and parse our test variable from the subsubproject
-    result = cli.run(project=project, args=["show", "--format", "%{vars}", "target.bst"])
+    result = cli.run(project=project, args=["show", "--deps", "none", "--format", "%{vars}", "target.bst"])
     result.assert_success()
 
     # Read back some of our project defaults from the env


### PR DESCRIPTION
The current behaviour is to silently keep the latst one which is obviously wrong.

ruamel-yaml as used in the round-tripping code also raises an error (at least in the current version)