### PR TITLE
Fix pulling buildtrees in bst shell

### DIFF
--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -308,7 +308,7 @@ class Stream:
             element = self.targets[0]
             element._set_required(scope)
 
-            if scope == _Scope.BUILD:
+            if scope == _Scope.BUILD and not usebuildtree:
                 pull_elements = [element] + elements
             else:
                 pull_elements = elements


### PR DESCRIPTION
We use _PipelineSelection.NONE when using the buildtrees, which includes the element. But then, we also add the element once more, and end up with two jobs running at once and (sometimes) failing to link the artifacts into place

This fixes test_shell_pull_cached_buildtree[pull-without-buildtree] failing randomly