### PR TITLE
Cleanup testing for Fedora versions

### DIFF
--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -22,10 +22,6 @@ x-tests-template: &tests-template
 
 services:
 
-  fedora-37:
-    <<: *tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:37-${CI_IMAGE_VERSION:-latest}
-
   fedora-38:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:38-${CI_IMAGE_VERSION:-latest}

--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -102,7 +102,7 @@ function runServiceTest() {
 
 
 if [ -z "${test_names}" ]; then
-    for test_name in mypy debian-10 fedora-37 fedora-38 fedora-missing-deps; do
+    for test_name in mypy debian-10 fedora-37 fedora-38 fedora-39 fedora-missing-deps; do
 	if ! runTest "${test_name}"; then
 	    echo "Tests failed"
 	    exit 1

--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -102,7 +102,7 @@ function runServiceTest() {
 
 
 if [ -z "${test_names}" ]; then
-    for test_name in mypy debian-10 fedora-37 fedora-38 fedora-39 fedora-missing-deps; do
+    for test_name in mypy debian-10 fedora-38 fedora-39 fedora-missing-deps; do
 	if ! runTest "${test_name}"; then
 	    echo "Tests failed"
 	    exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
         # "../compose/ci.docker-compose.yml"
         test-name:
           - debian-10
-          - fedora-37
           - fedora-38
           - fedora-39
           - fedora-missing-deps


### PR DESCRIPTION
* Add Fedora 39 to one place where it was missing
* Remove Fedora 37 completely because it doesn't actually add to Python versions being tested and is EOL since today