### PR TITLE
tox.ini: use allowlist_externals instead of whitelist_externals

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -97,7 +97,7 @@ setenv =
     py{37,38,39,310,311,312}-!nocover: BST_CYTHON_TRACE = 1
     randomized: PYTEST_ADDOPTS="--random-order-bucket=global"
 
-whitelist_externals =
+allowlist_externals =
     py{37,38,39,310,311,312}:
         mv
         mkdir
@@ -117,7 +117,7 @@ deps =
     windows-curses
     cython
     .
-whitelist_externals =
+allowlist_externals =
     bst
     cmd
 
@@ -208,7 +208,7 @@ passenv =
     HOME
     LANG
     LC_ALL
-whitelist_externals =
+allowlist_externals =
     make
 
 #
@@ -230,7 +230,7 @@ commands = {posargs}
 deps =
     -rrequirements/requirements.txt
     -rrequirements/dev-requirements.txt
-whitelist_externals = *
+allowlist_externals = *
 
 
 #


### PR DESCRIPTION
whitelist_externals is deprecated since tox 3.18 and removed in tox 4.x