### PR TITLE
DownloadableFileSource: Support "auth-header-format" extra data

### DIFF
--- a/doc/source/core_framework.rst
+++ b/doc/source/core_framework.rst
@@ -29,6 +29,7 @@ useful for working on BuildStream itself.
    buildstream.node
    buildstream.plugin
    buildstream.source
+   buildstream.sourcemirror
    buildstream.downloadablefilesource
    buildstream.element
    buildstream.buildelement

--- a/src/buildstream/__init__.py
+++ b/src/buildstream/__init__.py
@@ -32,6 +32,7 @@ if "_BST_COMPLETION" not in os.environ:
     from .node import MappingNode, Node, ProvenanceInformation, ScalarNode, SequenceNode
     from .plugin import Plugin
     from .source import Source, SourceError, SourceFetcher
+    from .sourcemirror import SourceMirror
     from .downloadablefilesource import DownloadableFileSource
     from .element import Element, ElementError, DependencyConfiguration
     from .buildelement import BuildElement

--- a/src/buildstream/_pluginfactory/__init__.py
+++ b/src/buildstream/_pluginfactory/__init__.py
@@ -18,6 +18,7 @@ from .pluginoriginpip import PluginOriginPip
 from .pluginoriginjunction import PluginOriginJunction
 from .sourcefactory import SourceFactory
 from .elementfactory import ElementFactory
+from .sourcemirrorfactory import SourceMirrorFactory
 
 
 # load_plugin_origin()

--- a/src/buildstream/_pluginfactory/elementfactory.py
+++ b/src/buildstream/_pluginfactory/elementfactory.py
@@ -14,8 +14,16 @@
 #  Authors:
 #        Tristan Van Berkom <tristan.vanberkom@codethink.co.uk>
 
+from typing import TYPE_CHECKING, Type, cast
+
 from .pluginfactory import PluginFactory
 from .pluginorigin import PluginType
+from .._loader import LoadElement
+from ..element import Element
+
+if TYPE_CHECKING:
+    from .._context import Context
+    from .._project import Project
 
 
 # A ElementFactory creates Element instances
@@ -30,8 +38,7 @@ class ElementFactory(PluginFactory):
 
     # create():
     #
-    # Create an Element object, the pipeline uses this to create Element
-    # objects on demand for a given pipeline.
+    # Create an Element object.
     #
     # Args:
     #    context (object): The Context object for processing
@@ -44,7 +51,8 @@ class ElementFactory(PluginFactory):
     #    PluginError (if the kind lookup failed)
     #    LoadError (if the element itself took issue with the config)
     #
-    def create(self, context, project, load_element):
-        element_type, default_config = self.lookup(context.messenger, load_element.kind, load_element.node)
+    def create(self, context: "Context", project: "Project", load_element: LoadElement) -> Element:
+        plugin_type, default_config = self.lookup(context.messenger, load_element.kind, load_element.node)
+        element_type = cast(Type[Element], plugin_type)
         element = element_type(context, project, load_element, default_config)
         return element

--- a/src/buildstream/_pluginfactory/pluginfactory.py
+++ b/src/buildstream/_pluginfactory/pluginfactory.py
@@ -15,7 +15,7 @@
 #        Tristan Van Berkom <tristan.vanberkom@codethink.co.uk>
 
 import os
-from typing import Tuple, Type, Iterator
+from typing import Tuple, Type, Iterator, Optional
 from pluginbase import PluginSource
 
 from .. import utils
@@ -127,7 +127,7 @@ class PluginFactory:
     #
     # Raises: PluginError
     #
-    def lookup(self, messenger: Messenger, kind: str, provenance_node: Node) -> Tuple[Type[Plugin], str]:
+    def lookup(self, messenger: Messenger, kind: str, provenance_node: Node) -> Tuple[Type[Plugin], Optional[str]]:
         plugin_type, defaults = self._ensure_plugin(kind, provenance_node)
 
         # We can be called with None for the messenger here in the
@@ -180,7 +180,7 @@ class PluginFactory:
     #           the plugin's preferred defaults.
     #    (str): The explanatory display string describing how this plugin was loaded
     #
-    def get_plugin_paths(self, kind: str):
+    def get_plugin_paths(self, kind: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:
         try:
             origin = self._origins[kind]
         except KeyError:
@@ -208,7 +208,7 @@ class PluginFactory:
     # Raises:
     #    (PluginError): In case something went wrong loading the plugin
     #
-    def _ensure_plugin(self, kind: str, provenance_node: Node) -> Tuple[Type[Plugin], str]:
+    def _ensure_plugin(self, kind: str, provenance_node: Node) -> Tuple[Type[Plugin], Optional[str]]:
 
         if kind not in self._types:
 

--- a/src/buildstream/_pluginfactory/pluginfactory.py
+++ b/src/buildstream/_pluginfactory/pluginfactory.py
@@ -22,6 +22,7 @@ from .. import utils
 from .. import _site
 from ..plugin import Plugin
 from ..source import Source
+from ..sourcemirror import SourceMirror
 from ..element import Element
 from ..node import Node
 from ..utils import UtilError
@@ -314,6 +315,8 @@ class PluginFactory:
             base_type = Source
         elif self._plugin_type == PluginType.ELEMENT:
             base_type = Element
+        elif self._plugin_type == PluginType.SOURCE_MIRROR:
+            base_type = SourceMirror
 
         try:
             if not issubclass(plugin_type, base_type):

--- a/src/buildstream/_pluginfactory/pluginfactory.py
+++ b/src/buildstream/_pluginfactory/pluginfactory.py
@@ -84,6 +84,8 @@ class PluginFactory:
             self._site_plugins_path = _site.source_plugins
         elif self._plugin_type == PluginType.ELEMENT:
             self._site_plugins_path = _site.element_plugins
+        elif self._plugin_type == PluginType.SOURCE_MIRROR:
+            self._site_plugins_path = _site.source_mirror_plugins
 
         self._site_source = self._plugin_base.make_plugin_source(
             searchpath=[self._site_plugins_path],

--- a/src/buildstream/_pluginfactory/pluginorigin.py
+++ b/src/buildstream/_pluginfactory/pluginorigin.py
@@ -30,6 +30,9 @@ class PluginType(FastEnum):
     # An Element plugin
     ELEMENT = "element"
 
+    # A SourceMirror plugin
+    SOURCE_MIRROR = "source-mirror"
+
     def __str__(self):
         return str(self.value)
 
@@ -68,7 +71,7 @@ class PluginConfiguration:
 class PluginOrigin:
 
     # Common fields valid for all plugin origins
-    _COMMON_CONFIG_KEYS = ["origin", "sources", "elements", "allow-deprecated"]
+    _COMMON_CONFIG_KEYS = ["origin", "sources", "elements", "source-mirrors", "allow-deprecated"]
 
     def __init__(self, origin_type):
 
@@ -76,6 +79,7 @@ class PluginOrigin:
         self.origin_type = origin_type  # The PluginOriginType
         self.elements = {}  # A dictionary of PluginConfiguration
         self.sources = {}  # A dictionary of PluginConfiguration objects
+        self.source_mirrors = {}  # A dictionary of PluginConfiguration objects
         self.provenance_node = None
         self.project = None
 
@@ -111,6 +115,9 @@ class PluginOrigin:
 
         source_sequence = origin_node.get_sequence("sources", [])
         self._load_plugin_configurations(source_sequence, self.sources)
+
+        source_mirror_sequence = origin_node.get_sequence("source-mirrors", [])
+        self._load_plugin_configurations(source_mirror_sequence, self.source_mirrors)
 
     ##############################################
     #              Abstract methods              #

--- a/src/buildstream/_pluginfactory/sourcefactory.py
+++ b/src/buildstream/_pluginfactory/sourcefactory.py
@@ -14,8 +14,18 @@
 #  Authors:
 #        Tristan Van Berkom <tristan.vanberkom@codethink.co.uk>
 
+from typing import TYPE_CHECKING, Type, cast
+
 from .pluginfactory import PluginFactory
 from .pluginorigin import PluginType
+from ..source import Source
+from .._loader import MetaSource
+from .._variables import Variables
+
+if TYPE_CHECKING:
+    from .._context import Context
+    from .._project import Project
+
 
 # A SourceFactory creates Source instances
 # in the context of a given factory
@@ -29,8 +39,7 @@ class SourceFactory(PluginFactory):
 
     # create():
     #
-    # Create a Source object, the pipeline uses this to create Source
-    # objects on demand for a given pipeline.
+    # Create a Source object.
     #
     # Args:
     #    context (object): The Context object for processing
@@ -45,7 +54,8 @@ class SourceFactory(PluginFactory):
     #    PluginError (if the kind lookup failed)
     #    LoadError (if the source itself took issue with the config)
     #
-    def create(self, context, project, meta, variables):
-        source_type, _ = self.lookup(context.messenger, meta.kind, meta.config)
+    def create(self, context: "Context", project: "Project", meta: MetaSource, variables: Variables) -> Source:
+        plugin_type, _ = self.lookup(context.messenger, meta.kind, meta.config)
+        source_type = cast(Type[Source], plugin_type)
         source = source_type(context, project, meta, variables)
         return source

--- a/src/buildstream/_pluginfactory/sourcemirrorfactory.py
+++ b/src/buildstream/_pluginfactory/sourcemirrorfactory.py
@@ -1,0 +1,71 @@
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Authors:
+#        Tristan Van Berkom <tristan.vanberkom@codethink.co.uk>
+
+from typing import TYPE_CHECKING, Type, cast
+
+from .pluginfactory import PluginFactory
+from .pluginorigin import PluginType
+
+from ..node import MappingNode
+from ..plugin import Plugin
+from ..sourcemirror import SourceMirror
+
+if TYPE_CHECKING:
+    from .._context import Context
+    from .._project import Project
+
+
+# A SourceMirrorFactory creates SourceMirror instances
+# in the context of a given factory
+#
+# Args:
+#     plugin_base (PluginBase): The main PluginBase object to work with
+#
+class SourceMirrorFactory(PluginFactory):
+    def __init__(self, plugin_base):
+        super().__init__(plugin_base, PluginType.SOURCE_MIRROR)
+
+    # create():
+    #
+    # Create a SourceMirror object.
+    #
+    # Args:
+    #    context (object): The Context object for processing
+    #    project (object): The project object
+    #    node (MappingNode): The node where the mirror was defined
+    #
+    # Returns:
+    #    A newly created SourceMirror object of the appropriate kind
+    #
+    # Raises:
+    #    PluginError (if the kind lookup failed)
+    #    LoadError (if the source mirror itself took issue with the config)
+    #
+    def create(self, context: "Context", project: "Project", node: MappingNode) -> SourceMirror:
+        plugin_type: Type[Plugin]
+
+        # Shallow parsing to get the custom plugin type, delegate the remainder
+        # of the parsing to SourceMirror
+        #
+        kind = node.get_str("kind", None)
+        if kind is None:
+            plugin_type = SourceMirror
+        else:
+            plugin_type, _ = self.lookup(context.messenger, kind, node)
+
+        source_mirror_type = cast(Type[SourceMirror], plugin_type)
+        source_mirror = source_mirror_type(context, project, node)
+        return source_mirror

--- a/src/buildstream/_site.py
+++ b/src/buildstream/_site.py
@@ -30,6 +30,9 @@ element_plugins = os.path.join(root, "plugins", "elements")
 # The Source plugin directory
 source_plugins = os.path.join(root, "plugins", "sources")
 
+# The SourceMirror plugin directory
+source_mirror_plugins = os.path.join(root, "plugins", "sourcemirrors")
+
 # Default user configuration
 default_user_config = os.path.join(root, "data", "userconfig.yaml")
 

--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -71,7 +71,7 @@ from contextlib import contextmanager, suppress
 from functools import partial
 from itertools import chain
 import string
-from typing import cast, TYPE_CHECKING, Any, Dict, Iterator, Iterable, List, Optional, Set, Sequence
+from typing import cast, TYPE_CHECKING, Dict, Iterator, Iterable, List, Optional, Set, Sequence
 
 from pyroaring import BitMap  # pylint: disable=no-name-in-module
 
@@ -210,7 +210,7 @@ class Element(Plugin):
         context: "Context",
         project: "Project",
         load_element: "LoadElement",
-        plugin_conf: Dict[str, Any],
+        plugin_conf: Optional[str],
         *,
         artifact_key: str = None,
     ):
@@ -2857,7 +2857,7 @@ class Element(Plugin):
     #
     # Normal element initialization procedure.
     #
-    def __initialize_from_yaml(self, load_element: "LoadElement", plugin_conf: Dict[str, Any]):
+    def __initialize_from_yaml(self, load_element: "LoadElement", plugin_conf: Optional[str]):
 
         context = self._get_context()
         project = self._get_project()

--- a/src/buildstream/source.py
+++ b/src/buildstream/source.py
@@ -217,7 +217,7 @@ Class Reference
 
 import os
 from contextlib import contextmanager
-from typing import Iterable, Iterator, Optional, Tuple, TYPE_CHECKING
+from typing import Iterable, Iterator, Optional, Tuple, Dict, Any, Set, TYPE_CHECKING
 
 from . import _yaml, utils
 from .node import MappingNode
@@ -235,8 +235,6 @@ from ._variables import Variables
 from .sourcemirror import SourceMirror
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Set
-
     # pylint: disable=cyclic-import
     from ._context import Context
     from ._project import Project
@@ -340,7 +338,7 @@ class Source(Plugin):
     """
 
     # The defaults from the project
-    __defaults = None  # type: Optional[Dict[str, Any]]
+    __defaults: Optional[Dict[str, Any]] = None
 
     BST_REQUIRES_PREVIOUS_SOURCES_TRACK = False
     """Whether access to previous sources is required during track
@@ -415,7 +413,7 @@ class Source(Plugin):
         self.__alias_override = alias_override  # Tuple of alias and its override to use instead
         self.__expected_alias = None  # The primary alias
         # Set of marked download URLs
-        self.__marked_urls = set()  # type: Set[str]
+        self.__marked_urls: Set[str] = set()
 
         # The active SourceMirror in context of fetch/track
         self.__active_mirror: Optional[SourceMirror] = active_mirror
@@ -701,7 +699,14 @@ class Source(Plugin):
 
         return self.__mirror_directory
 
-    def translate_url(self, url: str, *, alias_override: Optional[str] = None, primary: bool = True) -> str:
+    def translate_url(
+        self,
+        url: str,
+        *,
+        alias_override: Optional[str] = None,
+        primary: bool = True,
+        extra_data: Optional[Dict[str, Any]] = None,
+    ) -> str:
         """Translates the given url which may be specified with an alias
         into a fully qualified url.
 
@@ -709,6 +714,7 @@ class Source(Plugin):
            url: A URL, which may be using an alias
            alias_override: Optionally, an URI to override the alias with.
            primary: Whether this is the primary URL for the source.
+           extra_data: Additional data provided by :class:`SourceMirror <buildstream.sourcemirror.SourceMirror>` (*Since: 2.2*)
 
         Returns:
            The fully qualified URL, with aliases resolved
@@ -764,9 +770,13 @@ class Source(Plugin):
             # Delegate the URL translation to the SourceMirror plugin
             #
             return self.__active_mirror.translate_url(
-                project.name, url_alias, project_alias_url, alias_override, url_body
+                project_name=project.name,
+                alias=url_alias,
+                alias_url=project_alias_url,
+                alias_substitute_url=alias_override,
+                source_url=url_body,
+                extra_data=extra_data,
             )
-
         else:
             return project.translate_url(url, first_pass=self.__first_pass)
 

--- a/src/buildstream/sourcemirror.py
+++ b/src/buildstream/sourcemirror.py
@@ -1,0 +1,193 @@
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  Authors:
+#        Tristan Van Berkom <tristan.vanberkom@codethink.co.uk>
+"""
+SourceMirror - Base source mirror class
+=======================================
+The SourceMirror plugin allows one to customize how
+:func:`Source.translate_url() <buildstream.source.Source.translate_url>` will
+behave when looking up mirrors, allowing some additional flexibility in the
+implementation of source mirrors.
+
+
+.. _core_source_mirror_abstract_methods:
+
+Abstract Methods
+----------------
+For loading and configuration purposes, SourceMirrors may optionally implement
+the :func:`Plugin base class Plugin.configure() method <buildstream.plugin.Plugin.configure>`
+in order to load any custom configuration in the `config` dictionary.
+
+The remaining :ref:`Plugin base class abstract methods <core_plugin_abstract_methods>` are
+not relevant to the SourceMirror plugin object and need not be implemented.
+
+Sources expose the following abstract methods. Unless explicitly mentioned,
+these methods are mandatory to implement.
+
+* :func:`SourceMirror.translate_url() <buildstream.source.SourceMirror.translate_url>`
+ 
+  Produce an appropriate URL for the given URL and alias.
+
+
+Class Reference
+---------------
+"""
+
+from typing import Optional, Dict, List, TYPE_CHECKING
+
+from .node import MappingNode, SequenceNode
+from .plugin import Plugin
+from ._exceptions import BstError, LoadError
+from .exceptions import ErrorDomain, LoadErrorReason
+
+if TYPE_CHECKING:
+
+    # pylint: disable=cyclic-import
+    from ._context import Context
+    from ._project import Project
+
+    # pylint: enable=cyclic-import
+
+
+class SourceMirrorError(BstError):
+    """This exception should be raised by :class:`.SourceMirror` implementations
+    to report errors to the user.
+
+    Args:
+       message: The breif error description to report to the user
+       detail: A possibly multiline, more detailed error message
+       reason: An optional machine readable reason string, used for test cases
+
+    *Since: 2.2*
+    """
+
+    def __init__(
+        self, message: str, *, detail: Optional[str] = None, reason: Optional[str] = None, temporary: bool = False
+    ):
+        super().__init__(message, detail=detail, domain=ErrorDomain.SOURCE, reason=reason)
+
+
+class SourceMirror(Plugin):
+    """SourceMirror()
+
+    Base SourceMirror class.
+
+    All SourceMirror plugins derive from this class, this interface defines how
+    the core will be interacting with SourceMirror plugins.
+
+    *Since: 2.2*
+    """
+
+    # The SourceMirror plugin type is only supported since BuildStream 2.2
+    BST_MIN_VERSION = "2.2"
+
+    def __init__(
+        self,
+        context: "Context",
+        project: "Project",
+        node: MappingNode,
+    ):
+        # Note: the MappingNode passed here is already expanded with
+        #       the project level base variables, so there is no need
+        #       to expand them redundantly here.
+        #
+        node.validate_keys(["name", "kind", "config", "aliases"])
+
+        # Do local base class parsing first
+        name: str = node.get_str("name")
+        self.__aliases: Dict[str, List[str]] = self.__load_aliases(node)
+
+        # Chain up to Plugin
+        super().__init__(name, context, project, node, "source-mirror")
+
+        # Plugin specific parsing
+        config = node.get_mapping("config", default={})
+        self._configure(config)
+
+    ##########################################################
+    #                        Public API                      #
+    ##########################################################
+    def translate_url(
+        self, project_name: str, alias: str, alias_url: str, alias_substitute_url: Optional[str], source_url: str
+    ) -> str:
+        """Produce an alternative url for `url` for the given alias.
+
+        Args:
+           project_name: The name of the project this URL comes from
+           alias: The alias to translate for
+           alias_url: The default URL configured for this alias in the originating project
+           alias_substitute_url: The alias substitute URL configured in the mirror configuration, or None
+           source_url: The URL as specified by original source YAML, excluding the alias
+        """
+        #
+        # Default implementation behaves in the same way we behaved before
+        # introducing the SourceMirror plugin.
+        #
+        assert alias_substitute_url is not None
+
+        return alias_substitute_url + source_url
+
+    #############################################################
+    #                   Plugin API implementation               #
+    #############################################################
+
+    #
+    # Provide a dummy implementation as the base class is used as a default
+    #
+    def configure(self, node: MappingNode) -> None:
+        pass
+
+    ##########################################################
+    #                       Internal API                     #
+    ##########################################################
+
+    # _get_alias_uris():
+    #
+    # Get a list of URIs for the specified alias
+    #
+    # Args:
+    #    alias: The alias to fetch URIs for
+    #
+    # Returns:
+    #    A list of URIs for the given alias
+    #
+    def _get_alias_uris(self, alias: str) -> List[str]:
+
+        aliases: List[str]
+        try:
+            aliases = self.__aliases[alias]
+        except KeyError:
+            aliases = []
+
+        return aliases
+
+    ##########################################################
+    #                        Private API                     #
+    ##########################################################
+    def __load_aliases(self, node: MappingNode) -> Dict[str, List[str]]:
+
+        aliases: Dict[str, List[str]] = {}
+        alias_node: MappingNode = node.get_mapping("aliases")
+
+        for alias, uris in alias_node.items():
+            if not isinstance(uris, SequenceNode):
+                raise LoadError(
+                    "{}: Value of '{}' expected to be a list of strings".format(uris, alias),
+                    LoadErrorReason.INVALID_DATA,
+                )
+
+            aliases[alias] = uris.as_str_list()
+
+        return aliases

--- a/src/buildstream/sourcemirror.py
+++ b/src/buildstream/sourcemirror.py
@@ -45,7 +45,7 @@ Class Reference
 ---------------
 """
 
-from typing import Optional, Dict, List, TYPE_CHECKING
+from typing import Optional, Dict, List, Any, TYPE_CHECKING
 
 from .node import MappingNode, SequenceNode
 from .plugin import Plugin
@@ -120,9 +120,18 @@ class SourceMirror(Plugin):
     #                        Public API                      #
     ##########################################################
     def translate_url(
-        self, project_name: str, alias: str, alias_url: str, alias_substitute_url: Optional[str], source_url: str
+        self,
+        *,
+        project_name: str,
+        alias: str,
+        alias_url: str,
+        alias_substitute_url: Optional[str],
+        source_url: str,
+        extra_data: Optional[Dict[str, Any]],
     ) -> str:
         """Produce an alternative url for `url` for the given alias.
+
+        This method implements the behavior of :func:`Source.translate_url() <buildstream.source.Source.translate_url>`.
 
         Args:
            project_name: The name of the project this URL comes from
@@ -130,6 +139,7 @@ class SourceMirror(Plugin):
            alias_url: The default URL configured for this alias in the originating project
            alias_substitute_url: The alias substitute URL configured in the mirror configuration, or None
            source_url: The URL as specified by original source YAML, excluding the alias
+           extra_data: An optional extra dictionary to return additional data
         """
         #
         # Default implementation behaves in the same way we behaved before

--- a/tests/frontend/mirror.py
+++ b/tests/frontend/mirror.py
@@ -807,3 +807,93 @@ def test_mirror_expand_project_and_toplevel_root(cli, tmpdir):
         # Success if the expanded %{project-root} is found
         assert foo_str in contents
         assert bar_str in contents
+
+
+# Test a simple SourceMirror implementation which reads
+# plugin configuration and behaves in the same way as default
+# mirrors but using data in the plugin configuration instead.
+#
+@pytest.mark.datafiles(DATA_DIR)
+@pytest.mark.usefixtures("datafiles")
+def test_source_mirror_plugin(cli, tmpdir):
+    output_file = os.path.join(str(tmpdir), "output.txt")
+    project_dir = str(tmpdir)
+    element_dir = os.path.join(project_dir, "elements")
+    os.makedirs(element_dir, exist_ok=True)
+    element_name = "test.bst"
+    element_path = os.path.join(element_dir, element_name)
+    element = generate_element(output_file)
+    _yaml.roundtrip_dump(element, element_path)
+
+    project_file = os.path.join(project_dir, "project.conf")
+    project = {
+        "name": "test",
+        "min-version": "2.0",
+        "element-path": "elements",
+        "aliases": {
+            "foo": "FOO/",
+            "bar": "BAR/",
+        },
+        "mirrors": [
+            {
+                "name": "middle-earth",
+                "kind": "mirror",
+                "aliases": {
+                    "foo": ["<invalid>"],
+                    "bar": ["<invalid>"],
+                },
+                "config": {
+                    "aliases": {
+                        "foo": ["OOF/"],
+                        "bar": ["RAB/"],
+                    },
+                },
+            },
+            {
+                "name": "arrakis",
+                "kind": "mirror",
+                "aliases": {
+                    "foo": ["<invalid>"],
+                    "bar": ["<invalid>"],
+                },
+                "config": {
+                    "aliases": {
+                        "foo": ["%{project-root}/OFO/"],
+                        "bar": ["%{project-root}/RBA/"],
+                    },
+                },
+            },
+            {
+                "name": "oz",
+                "kind": "mirror",
+                "aliases": {
+                    "foo": ["<invalid>"],
+                    "bar": ["<invalid>"],
+                },
+                "config": {
+                    "aliases": {
+                        "foo": ["ooF/"],
+                        "bar": ["raB/"],
+                    },
+                },
+            },
+        ],
+        "plugins": [
+            {"origin": "local", "path": "sources", "sources": ["fetch_source"]},
+            {"origin": "local", "path": "sourcemirrors", "source-mirrors": ["mirror"]},
+        ],
+    }
+
+    _yaml.roundtrip_dump(project, project_file)
+
+    result = cli.run(project=project_dir, args=["--default-mirror", "arrakis", "source", "fetch", element_name])
+    result.assert_success()
+    with open(output_file, encoding="utf-8") as f:
+        contents = f.read()
+        print(contents)
+        foo_str = os.path.join(project_dir, "OFO/repo1")
+        bar_str = os.path.join(project_dir, "RBA/repo2")
+
+        # Success if the expanded %{project-root} is found
+        assert foo_str in contents
+        assert bar_str in contents

--- a/tests/frontend/project/sourcemirrors/mirror.py
+++ b/tests/frontend/project/sourcemirrors/mirror.py
@@ -1,0 +1,27 @@
+from buildstream import SourceMirror, MappingNode
+
+
+# This mirror plugin basically implements the default behavior
+# by loading the alias definitions as custom "config" configuration
+# instead, and implementing the translate_url method.
+#
+class Sample(SourceMirror):
+    BST_MIN_VERSION = "2.0"
+
+    def configure(self, node):
+        node.validate_keys(["aliases"])
+
+        self.aliases = {}
+
+        aliases = node.get_mapping("aliases")
+        for alias_name, url_list in aliases.items():
+            self.aliases[alias_name] = url_list.as_str_list()
+
+    def translate_url(self, project_name, alias, alias_url, alias_substitute_url, source_url):
+        return self.aliases[alias][0] + source_url
+
+
+# Plugin entry point
+def setup():
+
+    return Sample

--- a/tests/frontend/project/sourcemirrors/mirror.py
+++ b/tests/frontend/project/sourcemirrors/mirror.py
@@ -1,3 +1,5 @@
+from typing import Optional, Dict, Any
+
 from buildstream import SourceMirror, MappingNode
 
 
@@ -17,7 +19,16 @@ class Sample(SourceMirror):
         for alias_name, url_list in aliases.items():
             self.aliases[alias_name] = url_list.as_str_list()
 
-    def translate_url(self, project_name, alias, alias_url, alias_substitute_url, source_url):
+    def translate_url(
+        self,
+        *,
+        project_name: str,
+        alias: str,
+        alias_url: str,
+        alias_substitute_url: Optional[str],
+        source_url: str,
+        extra_data: Optional[Dict[str, Any]],
+    ) -> str:
         return self.aliases[alias][0] + source_url
 
 

--- a/tests/sources/tar.py
+++ b/tests/sources/tar.py
@@ -29,7 +29,7 @@ from buildstream.exceptions import ErrorDomain
 from buildstream._testing import generate_project, generate_element
 from buildstream._testing import cli  # pylint: disable=unused-import
 from buildstream._testing._utils.site import HAVE_LZIP
-from tests.testutils.file_server import create_file_server
+from tests.testutils.file_server import create_file_server, create_bearer_http_server
 from . import list_dir_contents
 
 DATA_DIR = os.path.join(
@@ -334,6 +334,74 @@ def test_use_netrc(cli, datafiles, server_type, tmpdir):
     with create_file_server(server_type) as server:
         server.add_user("testuser", "12345", file_server_files)
         generate_project(project, config={"aliases": {"tmpdir": server.base_url()}})
+
+        src_tar = os.path.join(file_server_files, "a.tar.gz")
+        _assemble_tar(os.path.join(str(datafiles), "content"), "a", src_tar)
+
+        server.start()
+
+        result = cli.run(project=project, args=["source", "track", "target.bst"])
+        result.assert_success()
+        result = cli.run(project=project, args=["source", "fetch", "target.bst"])
+        result.assert_success()
+        result = cli.run(project=project, args=["build", "target.bst"])
+        result.assert_success()
+        result = cli.run(project=project, args=["artifact", "checkout", "target.bst", "--directory", checkoutdir])
+        result.assert_success()
+
+        original_dir = os.path.join(str(datafiles), "content", "a")
+        original_contents = list_dir_contents(original_dir)
+        checkout_contents = list_dir_contents(checkoutdir)
+        assert checkout_contents == original_contents
+
+
+@pytest.mark.datafiles(os.path.join(DATA_DIR, "fetch"))
+def test_use_netrc_bearer_auth(cli, datafiles, tmpdir):
+    file_server_files = os.path.join(str(tmpdir), "file_server")
+    fake_home = os.path.join(str(tmpdir), "fake_home")
+    os.makedirs(file_server_files, exist_ok=True)
+    os.makedirs(fake_home, exist_ok=True)
+    project = str(datafiles)
+    checkoutdir = os.path.join(str(tmpdir), "checkout")
+
+    os.environ["HOME"] = fake_home
+    with open(os.path.join(fake_home, ".netrc"), "wb") as f:
+        os.fchmod(f.fileno(), 0o700)
+        f.write(b"machine 127.0.0.1\n")
+        f.write(b"password 12345\n")
+
+    #
+    # Enable using mirrors for source tracking
+    #
+    cli.configure({"track": {"source": "mirrors"}})
+
+    #
+    # Create a file server which uses bearer authentication
+    #
+    with create_bearer_http_server() as server:
+        server.set_directory(file_server_files)
+        server.add_token("12345")
+
+        #
+        # Configure the project to load our source mirror plugin which
+        # reports the "auth-header-format" extra data
+        #
+        additional_config = {
+            "aliases": {"tmpdir": server.base_url()},
+            "mirrors": [
+                {
+                    "name": "middle-earth",
+                    "kind": "bearermirror",
+                    "aliases": {
+                        "tmpdir": [server.base_url()],
+                    },
+                },
+            ],
+            "plugins": [
+                {"origin": "local", "path": "sourcemirrors", "source-mirrors": ["bearermirror"]},
+            ],
+        }
+        generate_project(project, config=additional_config)
 
         src_tar = os.path.join(file_server_files, "a.tar.gz")
         _assemble_tar(os.path.join(str(datafiles), "content"), "a", src_tar)

--- a/tests/sources/tar/fetch/sourcemirrors/bearermirror.py
+++ b/tests/sources/tar/fetch/sourcemirrors/bearermirror.py
@@ -1,0 +1,29 @@
+from typing import Optional, Dict, Any
+
+from buildstream import SourceMirror, MappingNode
+
+
+class Sample(SourceMirror):
+    BST_MIN_VERSION = "2.0"
+
+    def translate_url(
+        self,
+        *,
+        project_name: str,
+        alias: str,
+        alias_url: str,
+        alias_substitute_url: Optional[str],
+        source_url: str,
+        extra_data: Optional[Dict[str, Any]],
+    ) -> str:
+
+        if extra_data is not None:
+            extra_data["auth-header-format"] = "Bearer {password}"
+
+        return alias_substitute_url + source_url
+
+
+# Plugin entry point
+def setup():
+
+    return Sample

--- a/tests/testutils/bearer_http_server.py
+++ b/tests/testutils/bearer_http_server.py
@@ -1,0 +1,116 @@
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import multiprocessing
+import os
+import posixpath
+import html
+from http.server import SimpleHTTPRequestHandler, HTTPServer, HTTPStatus
+
+
+class Unauthorized(Exception):
+    pass
+
+
+class BearerRequestHandler(SimpleHTTPRequestHandler):
+    def get_root_dir(self):
+        authorization = self.headers.get("authorization")
+        if not authorization:
+            raise Unauthorized("unauthorized")
+
+        authorization = authorization.split()
+        if len(authorization) != 2 or authorization[0].lower() != "bearer":
+            raise Unauthorized("unauthorized")
+
+        token = authorization[1]
+        if token not in self.server.tokens:
+            raise Unauthorized("unauthorized")
+
+        return self.server.directory
+
+    def unauthorized(self):
+        shortmsg, longmsg = self.responses[HTTPStatus.UNAUTHORIZED]
+        self.send_response(HTTPStatus.UNAUTHORIZED, shortmsg)
+        self.send_header("Connection", "close")
+
+        content = self.error_message_format % {
+            "code": HTTPStatus.UNAUTHORIZED,
+            "message": html.escape(longmsg, quote=False),
+            "explain": html.escape(longmsg, quote=False),
+        }
+        body = content.encode("UTF-8", "replace")
+        self.send_header("Content-Type", self.error_content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("WWW-Authenticate", 'Bearer realm="{}"'.format(self.server.realm))
+        self.end_headers()
+        self.end_headers()
+
+        if self.command != "HEAD" and body:
+            self.wfile.write(body)
+
+    def do_GET(self):
+        try:
+            super().do_GET()
+        except Unauthorized:
+            self.unauthorized()
+
+    def do_HEAD(self):
+        try:
+            super().do_HEAD()
+        except Unauthorized:
+            self.unauthorized()
+
+    def translate_path(self, path):
+        path = path.split("?", 1)[0]
+        path = path.split("#", 1)[0]
+        path = posixpath.normpath(path)
+        assert posixpath.isabs(path)
+        path = posixpath.relpath(path, "/")
+        return os.path.join(self.get_root_dir(), path)
+
+
+class BearerHTTPServer(HTTPServer):
+    def __init__(self, *args, **kwargs):
+        self.tokens = set()
+        self.directory = None
+        self.realm = "Realm"
+        super().__init__(*args, **kwargs)
+
+
+class BearerHttpServer(multiprocessing.Process):
+    def __init__(self):
+        super().__init__()
+        self.server = BearerHTTPServer(("127.0.0.1", 0), BearerRequestHandler)
+        self.started = False
+
+    def start(self):
+        self.started = True
+        super().start()
+
+    def run(self):
+        self.server.serve_forever()
+
+    def stop(self):
+        if not self.started:
+            return
+        self.terminate()
+        self.join()
+
+    def set_directory(self, directory):
+        self.server.directory = directory
+
+    def add_token(self, token):
+        self.server.tokens.add(token)
+
+    def base_url(self):
+        return "http://127.0.0.1:{}".format(self.server.server_port)

--- a/tests/testutils/file_server.py
+++ b/tests/testutils/file_server.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager
 
 from .ftp_server import SimpleFtpServer
 from .http_server import SimpleHttpServer
+from .bearer_http_server import BearerHttpServer
 
 
 @contextmanager
@@ -26,6 +27,22 @@ def create_file_server(file_server_type):
     else:
         assert False
 
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+#
+# We use a separate function here in order to avoid
+# confusing the linter (which thinks that anything
+# yielded by `create_file_server()` is a SimpleFtpServer).
+#
+# And no, type annotations with Union[...] does not fix this.
+#
+@contextmanager
+def create_bearer_http_server():
+    server = BearerHttpServer()
     try:
         yield server
     finally:


### PR DESCRIPTION
Using the new `extra_data` parameter reported from SourceMirror objects (See #1890), support the `"auth-header-format"` extra data and use this to construct and add addition auth headers.

E.g.:

```
Authorization: Bearer 1234
```
