### PR TITLE
source: disable check for URL marking at configure time

### DIFF
--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -2890,7 +2890,7 @@ class Element(Plugin):
         self.__config = self.__extract_config(load_element)
         self.__variables.expand(self.__config)
 
-        self._configure(self.__config)
+        self.configure(self.__config)
 
         # Extract Sandbox config
         sandbox_config = self.__extract_sandbox_config(project, load_element)

--- a/src/buildstream/plugin.py
+++ b/src/buildstream/plugin.py
@@ -328,7 +328,6 @@ class Plugin:
 
         self.__provenance_node = provenance_node  # The originating YAML node
         self.__type_tag = type_tag  # The type of plugin (element or source)
-        self.__configuring = False  # Whether we are currently configuring
 
         # Get the full_name as project & type_tag are resolved
         self.__full_name = self.__get_full_name()
@@ -869,30 +868,6 @@ class Plugin:
                 yield output
         else:
             yield log
-
-    # _configure():
-    #
-    # Calls configure() for the plugin, this must be called by
-    # the core instead of configure() directly, so that the
-    # _get_configuring() state is up to date.
-    #
-    # Args:
-    #    node (buildstream.node.MappingNode): The loaded configuration dictionary
-    #
-    def _configure(self, node):
-        self.__configuring = True
-        self.configure(node)
-        self.__configuring = False
-
-    # _get_configuring():
-    #
-    # Checks whether the plugin is in the middle of having
-    # its Plugin.configure() method called
-    #
-    # Returns:
-    #    (bool): Whether we are currently configuring
-    def _get_configuring(self):
-        return self.__configuring
 
     # _preflight():
     #

--- a/src/buildstream/source.py
+++ b/src/buildstream/source.py
@@ -427,7 +427,7 @@ class Source(Plugin):
         # cached values for commonly access values on the source
         self.__mirror_directory = None  # type: Optional[str]
 
-        self._configure(self.__config)
+        self.configure(self.__config)
 
         self.__is_cached = None
 


### PR DESCRIPTION
This check is triggered by plugins that have URLs (or URL fragments) as part of their ref, such as cargo. These plugins currently resort to only translating part of the URL and appending the rest later. Dropping the check allows these plugins to call mark_download_url() or translate_url() a second time when tracking.
    
It also allows plugins to postpone calling them until fetch(), which is the behaviour the check was supposed to prevent. This is still considered wrong, but will no longer trigger an AssertionError.

This MR also removes the `_configure()` and `_get_configuring()` methods of `Plugin` as they are no longer needed.