### PR TITLE
source: add suffix parameter to translate_url

### DIFF
--- a/src/buildstream/source.py
+++ b/src/buildstream/source.py
@@ -696,7 +696,9 @@ class Source(Plugin):
 
         return self.__mirror_directory
 
-    def translate_url(self, url: str, *, alias_override: Optional[str] = None, primary: bool = True) -> str:
+    def translate_url(
+        self, url: str, *, alias_override: Optional[str] = None, primary: bool = True, suffix: Optional[str] = None
+    ) -> str:
         """Translates the given url which may be specified with an alias
         into a fully qualified url.
 
@@ -704,6 +706,7 @@ class Source(Plugin):
            url: A URL, which may be using an alias
            alias_override: Optionally, an URI to override the alias with.
            primary: Whether this is the primary URL for the source.
+           suffix: an optional suffix to append to the URL (*Since: 2.2*)
 
         Returns:
            The fully qualified URL, with aliases resolved
@@ -713,9 +716,16 @@ class Source(Plugin):
            :func:`Plugin.configure() <buildstream.plugin.Plugin.configure>` if
            :func:`Source.mark_download_url() <buildstream.source.Source.mark_download_url>`
            is not called.
+
+           The *suffix* argument may be used to translate URLs for which only the base portion of
+           the URL was previously marked with :func:`Source.mark_download_url() <buildstream.source.Source.mark_download_url>`
+           at :func:`Plugin.configure() <buildstream.plugin.Plugin.configure>` time.
         """
         # Ensure that the download URL is also marked
         self.mark_download_url(url, primary=primary)
+
+        if suffix:
+            url = url + suffix
 
         # Alias overriding can happen explicitly (by command-line) or
         # implicitly (the Source being constructed with an __alias_override).


### PR DESCRIPTION
Some sources need to download more than one file from a given URL. An instance of this is the cargo plugin, which needs to download multiple crates from the same crate registry. The names of the crates come from the ref, so it can't know all the URLs it needs at configure time (as they may change with tracking). Instead, it appends the path to the crate after calling Source.translate_url() with the crate registry URL. This will be problematic for source mirrors as they need to know the entire URL to translate it correctly.

This change allows passing the suffix separately so that only the first part, which may contain an alias, is marked and the entire URL is translated. This allows keeping in place the check that all URLs are marked (to check and store the aliases for the purpose of mirroring), while allowing source plugins to avoid workarounds and thus allowing the upcoming source mirrors plugins to translate the full URL.

This attempts to implement this proposal on the mailing list https://lists.apache.org/thread/c9xjlvlv1zhd479l5rqr47pgt82fzb78