### PR TITLE
tox.ini: Pin version of types-* in mypy tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -181,9 +181,9 @@ commands =
     mypy --namespace-packages {posargs}
 deps =
     mypy==0.910
-    types-protobuf
-    types-setuptools
-    types-ujson
+    types-protobuf==4.24.0.20240106
+    types-setuptools==67.4.0
+    types-ujson==5.7.0.0
     -rrequirements/requirements.txt
     -rrequirements/dev-requirements.txt
 


### PR DESCRIPTION
Leaving them unpinned risks breakages (and is already broken right now), especially since we're using a very old version of mypy.