### PR TITLE
Deprioritize search_subprojects_dir

### DIFF
--- a/src/buildstream/utils.py
+++ b/src/buildstream/utils.py
@@ -731,7 +731,7 @@ def _get_host_tool_internal(
 ) -> str:
     search_path = os.environ.get("PATH", "").split(os.pathsep)
     if search_subprojects_dir:
-        search_path.insert(0, os.path.join(_site.subprojects, search_subprojects_dir))
+        search_path.append(os.path.join(_site.subprojects, search_subprojects_dir))
 
     program_path = shutil.which(name, path=os.pathsep.join(search_path))
 


### PR DESCRIPTION
Make the provided binary be a fallback if tool is not found from PATH.
Fixes https://github.com/apache/buildstream/issues/1873