### PR TITLE
ci: Update cibuildwheel for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         run: ${GITHUB_WORKSPACE}/.github/wheel-helpers/fetch-latest-buildbox-release.sh
 
       - name: Build wheels
-        run: pipx run cibuildwheel==2.11.3
+        run: pipx run cibuildwheel==v2.16.2
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
It was updated in 82d10333545581a2b9288fa1d316fdebbdf0b93c for tests to support python 3.12, but releases where still using an older version. Use the same version of cibuildwheel for both.