### PR TITLE
Support mapping subproject aliases to aliases of the parent project

### DIFF
--- a/doc/source/format_project.rst
+++ b/doc/source/format_project.rst
@@ -204,6 +204,9 @@ URLs which are to be used in the individual ``.bst`` files.
      foo: git://git.foo.org/
      bar: http://bar.com/downloads/
 
+If you want this project's alias definitions to also be used for subprojects,
+see :ref:`Mapping source aliases of subprojects <project_junctions_source_aliases>`.
+
 
 Sandbox options
 ~~~~~~~~~~~~~~~
@@ -318,6 +321,9 @@ The mirrors can be overridden on a per project basis using
 :ref:`user configuration <config_mirrors>`. One can also specify which mirror should
 be used first in the :ref:`user configuration <config_default_mirror>`, or using
 the  :ref:`--default-mirror <invoking_bst>` command-line argument.
+
+If you want this project's mirrors to also be used for subprojects,
+see :ref:`Mapping source aliases of subprojects <project_junctions_source_aliases>`.
 
 
 .. _project_plugins:
@@ -987,6 +993,35 @@ subproject.
 
    Declaring a junction as *internal* is a promise that dependant projects
    will not accrue runtime dependencies on elements in your *internal* subproject.
+
+
+.. _project_junctions_source_aliases:
+
+Mapping source aliases of subprojects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:mod:`junction <elements.junction>` elements allow source aliases of subprojects
+to be mapped to aliases of the parent project. This makes it possible to control
+the translation of aliases to URLs including mirror configuration across multiple
+project levels.
+
+To ensure that there are mappings for all aliases of all subprojects, you can set the
+``disallow-subproject-uris`` flag in the ``junctions`` group here in ``project.conf``.
+
+top-level
+
+.. code:: yaml
+
+   junctions:
+     disallow-subproject-uris: True
+
+This will raise an error if an alias without a mapping is encountered. This flag
+is applied recursively across all junctions.
+
+It also configures ``unaliased-url`` as a fatal warning in all subprojects to
+ensure that the current project is in full control over all source URLs.
+As the fatal warning configuration contributes to the cache key, this flag will
+affect the cache key of subprojects that haven't already configured
+``unaliased-url`` as a fatal warning.
 
 
 .. _project_defaults:

--- a/src/buildstream/_project.py
+++ b/src/buildstream/_project.py
@@ -245,7 +245,7 @@ class Project:
             if alias_url:
                 if self.junction:
                     parent_project = self.junction._get_project()
-                    parent_alias = self.junction.aliases.get_str(url_alias, default=None)
+                    parent_alias = self.junction.get_parent_alias(url_alias)
                     if parent_alias:
                         # Delegate translation to parent project
                         return parent_project.translate_url(
@@ -418,7 +418,7 @@ class Project:
 
         if self.junction:
             parent_project = self.junction._get_project()
-            parent_alias = self.junction.aliases.get_str(alias, default=None)
+            parent_alias = self.junction.get_parent_alias(alias)
             if parent_alias:
                 if parent_project.alias_exists(parent_alias, source=source, first_pass=first_pass):
                     return True
@@ -465,7 +465,7 @@ class Project:
 
         if self.junction:
             parent_project = self.junction._get_project()
-            parent_alias = self.junction.aliases.get_str(alias, default=None)
+            parent_alias = self.junction.get_parent_alias(alias)
             if parent_alias:
                 # Delegate translation to parent project
                 return parent_project.get_alias_uris(parent_alias, first_pass=first_pass, tracking=tracking)

--- a/src/buildstream/plugins/elements/junction.py
+++ b/src/buildstream/plugins/elements/junction.py
@@ -50,6 +50,11 @@ Overview
      overrides:
        subproject-junction.bst: local-junction.bst
 
+     # Optionally override aliases in subprojects, to allow using mirrors
+     # defined in the parent project.
+     aliases:
+       subproject-alias: local-alias
+
 With a junction element in place, local elements can depend on elements in
 the other BuildStream project using :ref:`element paths <format_element_names>`.
 For example, if you have a ``toolchain.bst`` junction element referring to
@@ -338,7 +343,7 @@ class JunctionElement(Element):
 
     def configure(self, node):
 
-        node.validate_keys(["path", "options", "overrides"])
+        node.validate_keys(["path", "options", "overrides", "aliases"])
 
         self.path = node.get_str("path", default="")
         self.options = node.get_mapping("options", default={})
@@ -360,6 +365,9 @@ class JunctionElement(Element):
                     reason="override-junction-with-self",
                 )
             self.overrides[key] = junction_name
+
+        # Map from subproject alias to local alias
+        self.aliases = node.get_mapping("aliases", default={})
 
     def preflight(self):
         pass

--- a/src/buildstream/plugins/elements/junction.py
+++ b/src/buildstream/plugins/elements/junction.py
@@ -55,6 +55,9 @@ Overview
      aliases:
        subproject-alias: local-alias
 
+     # A default mapping can be set (defaults to none)
+     map-aliases: identity
+
 With a junction element in place, local elements can depend on elements in
 the other BuildStream project using :ref:`element paths <format_element_names>`.
 For example, if you have a ``toolchain.bst`` junction element referring to
@@ -329,6 +332,12 @@ in the same build pipeline, please refer to the
 
 from buildstream import Element, ElementError
 from buildstream._pipeline import PipelineError
+from buildstream.types import FastEnum
+
+
+class _AliasMappingStrategy(FastEnum):
+    NONE = "none"
+    IDENTITY = "identity"
 
 
 # Element implementation for the 'junction' kind.
@@ -343,7 +352,7 @@ class JunctionElement(Element):
 
     def configure(self, node):
 
-        node.validate_keys(["path", "options", "overrides", "aliases"])
+        node.validate_keys(["path", "options", "overrides", "aliases", "map-aliases"])
 
         self.path = node.get_str("path", default="")
         self.options = node.get_mapping("options", default={})
@@ -368,6 +377,13 @@ class JunctionElement(Element):
 
         # Map from subproject alias to local alias
         self.aliases = node.get_mapping("aliases", default={})
+        self.map_aliases = node.get_enum("map-aliases", _AliasMappingStrategy, default=_AliasMappingStrategy.NONE)
+
+    def get_parent_alias(self, alias):
+        parent_alias = self.aliases.get_str(alias, default=None)
+        if parent_alias is None and self.map_aliases == _AliasMappingStrategy.IDENTITY:
+            parent_alias = alias
+        return parent_alias
 
     def preflight(self):
         pass

--- a/src/buildstream/source.py
+++ b/src/buildstream/source.py
@@ -768,7 +768,7 @@ class Source(Plugin):
                 alias=url_alias, alias_url=project_alias_url, source_url=url_body, extra_data=extra_data
             )
         else:
-            return project.translate_url(url, first_pass=self.__first_pass)
+            return project.translate_url(url, source=self, first_pass=self.__first_pass)
 
     def mark_download_url(self, url: str, *, primary: bool = True) -> None:
         """Identifies the URL that this Source uses to download
@@ -830,7 +830,7 @@ class Source(Plugin):
         # If there is an alias in use, ensure that it exists in the project
         if alias:
             project = self._get_project()
-            if not project.alias_exists(alias, first_pass=self.__first_pass):
+            if not project.alias_exists(alias, first_pass=self.__first_pass, source=self):
                 raise SourceError(
                     "{}: Invalid alias '{}' specified in URL: {}".format(self, alias, url),
                     reason="invalid-source-alias",
@@ -1287,7 +1287,7 @@ class Source(Plugin):
     def _get_alias(self):
         alias = self.__expected_alias
         project = self._get_project()
-        if project.alias_exists(alias, first_pass=self.__first_pass):
+        if project.alias_exists(alias, first_pass=self.__first_pass, source=self):
             # The alias must already be defined in the project's aliases
             # otherwise http://foo gets treated like it contains an alias
             return alias

--- a/tests/frontend/mirror.py
+++ b/tests/frontend/mirror.py
@@ -16,9 +16,11 @@
 # pylint: disable=redefined-outer-name
 
 import os
+import shutil
+
 import pytest
 
-from buildstream import _yaml
+from buildstream import CoreWarnings, _yaml
 from buildstream.exceptions import ErrorDomain
 from buildstream._testing import create_repo
 from buildstream._testing import cli  # pylint: disable=unused-import
@@ -885,3 +887,129 @@ def test_source_mirror_plugin(cli, tmpdir):
         # Success if the expanded %{project-root} is found
         assert foo_str in contents
         assert bar_str in contents
+
+
+@pytest.mark.datafiles(DATA_DIR)
+@pytest.mark.usefixtures("datafiles")
+@pytest.mark.parametrize("subproject_mirrors", [True, False])
+@pytest.mark.parametrize("unaliased_sources", [True, False])
+@pytest.mark.parametrize("disallow_subproject_uris", [True, False])
+@pytest.mark.parametrize("fetch_source", ["aliases", "mirrors"])
+@pytest.mark.parametrize("alias_override", [["foo"], ["foo", "bar"], "global", "invalid"])
+def test_mirror_subproject_aliases(
+    cli, tmpdir, subproject_mirrors, unaliased_sources, disallow_subproject_uris, fetch_source, alias_override
+):
+    output_file = os.path.join(str(tmpdir), "output.txt")
+    project_dir = tmpdir
+
+    element_dir = project_dir / "elements"
+    os.makedirs(element_dir, exist_ok=True)
+
+    subproject_dir = project_dir / "subproject"
+    subproject_element_dir = subproject_dir / "elements"
+    os.makedirs(subproject_element_dir, exist_ok=True)
+
+    subproject_bar_alias_succeed = (
+        fetch_source == "aliases" and not disallow_subproject_uris and alias_override == ["foo"]
+    )
+
+    subproject = {
+        "name": "test-subproject",
+        "min-version": "2.0",
+        "element-path": "elements",
+        "aliases": {
+            "foo": "OOF/",
+            "bar": "RAB/" if subproject_bar_alias_succeed else "BAR/",
+        },
+        "plugins": [
+            {"origin": "local", "path": "sources", "sources": ["fetch_source"]},
+        ],
+    }
+
+    if subproject_mirrors:
+        subproject["mirrors"] = FAIL_MIRROR_LIST
+
+    _yaml.roundtrip_dump(subproject, str(subproject_dir / "project.conf"))
+
+    element_name = "test.bst"
+    element = generate_element(output_file)
+
+    if unaliased_sources:
+        element["sources"][0]["urls"] = ["foo:repo1", "RAB/repo2"]
+    _yaml.roundtrip_dump(element, str(subproject_element_dir / element_name))
+
+    # copy the source plugin to the subproject
+    shutil.copytree(project_dir / "sources", subproject_dir / "sources")
+
+    project = generate_project(MirrorConfig.SUCCESS_MIRRORS, fetch_source == "aliases")
+
+    if disallow_subproject_uris:
+        project["junctions"] = {"disallow-subproject-uris": "true"}
+
+    _yaml.roundtrip_dump(project, str(project_dir / "project.conf"))
+
+    junction_name = "subproject.bst"
+    junction = {
+        "kind": "junction",
+        "sources": [
+            {
+                "kind": "local",
+                "path": "subproject",
+            }
+        ],
+    }
+
+    if alias_override == "global":
+        junction["config"] = {"map-aliases": "identity"}
+    elif alias_override == "invalid":
+        junction["config"] = {
+            "aliases": {
+                "foo": "invalid-foo",
+                "bar": "invalid-bar",
+            }
+        }
+    else:
+        junction["config"] = {"aliases": {alias: alias for alias in alias_override}}
+
+    _yaml.roundtrip_dump(junction, str(element_dir / junction_name))
+
+    userconfig = {"fetch": {"source": fetch_source}}
+    cli.configure(userconfig)
+
+    result = cli.run(project=project_dir, args=["source", "fetch", "{}:{}".format(junction_name, element_name)])
+    if alias_override == "invalid":
+        # Mapped alias does not exist in the parent project
+        result.assert_main_error(ErrorDomain.SOURCE, "invalid-source-alias")
+    elif disallow_subproject_uris and unaliased_sources:
+        # Subproject defines unaliased source and the parent project disallows subproject URIs
+        result.assert_main_error(ErrorDomain.PLUGIN, CoreWarnings.UNALIASED_URL)
+    elif disallow_subproject_uris and alias_override == ["foo"]:
+        # No alias mapping defined for `bar` and the parent project disallows subproject URIs
+        result.assert_main_error(ErrorDomain.SOURCE, "missing-alias-mapping")
+    elif fetch_source == "mirrors" and not unaliased_sources and alias_override == ["foo"]:
+        # Mirror required and no alias mapping defined for `bar`
+        if not subproject_mirrors:
+            # and the subproject has no mirror configured
+            result.assert_main_error(ErrorDomain.SOURCE, "missing-source-alias-target")
+        else:
+            # and the subproject has a failing mirror configured
+            result.assert_task_error(ErrorDomain.SOURCE, None)
+
+            with open(output_file, encoding="utf-8") as f:
+                contents = f.read()
+
+                assert "Fetch foo:repo1 succeeded from FOO/repo1" in contents
+                assert "Fetch bar:repo2 failed from rabbit/repo2" in contents
+                assert "Fetch bar:repo2 failed from buffalo/repo2" in contents
+    else:
+        result.assert_success()
+
+        with open(output_file, encoding="utf-8") as f:
+            contents = f.read()
+
+            assert "Fetch foo:repo1 succeeded from FOO/repo1" in contents
+
+            if unaliased_sources:
+                assert "Fetch RAB/repo2 succeeded from RAB/repo2" in contents
+            else:
+                assert "Fetch bar:repo2 succeeded from RAB/repo2" in contents


### PR DESCRIPTION
This is an improved branch of #1906 with documentation, error handling, passing tests, implicitly fatal `unaliased-url` and an enum for the `map-alias` option.