### PR TITLE
Keep track of the parent alias when aliases are mapped

### DIFF
--- a/src/buildstream/_project.py
+++ b/src/buildstream/_project.py
@@ -15,7 +15,7 @@
 #        Tristan Van Berkom <tristan.vanberkom@codethink.co.uk>
 #        Tiago Gomes <tiago.gomes@codethink.co.uk>
 
-from typing import TYPE_CHECKING, Optional, Dict, Union, List, Sequence
+from typing import TYPE_CHECKING, Optional, Dict, Union, List, Sequence, Tuple
 
 import os
 import urllib.parse
@@ -453,7 +453,7 @@ class Project:
     #
     def get_alias_uris(
         self, alias: str, *, first_pass: bool = False, tracking: bool = False
-    ) -> Sequence[Union[SourceMirror, str, None]]:
+    ) -> Sequence[Union[Tuple[str, Union[SourceMirror, str]], None]]:
 
         if first_pass:
             config = self.first_pass_config
@@ -489,7 +489,7 @@ class Project:
         if policy in (_SourceUriPolicy.ALL, _SourceUriPolicy.ALIASES):
             uri_list.append(config._aliases.get_str(alias))
 
-        return uri_list
+        return [(alias, mirror) for mirror in uri_list]
 
     # load_elements()
     #

--- a/src/buildstream/_project.py
+++ b/src/buildstream/_project.py
@@ -15,7 +15,7 @@
 #        Tristan Van Berkom <tristan.vanberkom@codethink.co.uk>
 #        Tiago Gomes <tiago.gomes@codethink.co.uk>
 
-from typing import TYPE_CHECKING, Optional, Dict, Union, List, Sequence, Tuple
+from typing import TYPE_CHECKING, Optional, Dict, Union, List, Sequence
 
 import os
 import urllib.parse
@@ -40,7 +40,7 @@ from ._includes import Includes
 from ._workspaces import WORKSPACE_PROJECT_FILE
 from ._remotespec import RemoteSpec
 from .sourcemirror import SourceMirror
-from .source import SourceError
+from .source import AliasSubstitution, SourceError
 
 
 if TYPE_CHECKING:
@@ -453,7 +453,7 @@ class Project:
     #
     def get_alias_uris(
         self, alias: str, *, first_pass: bool = False, tracking: bool = False
-    ) -> Sequence[Union[Tuple[str, Union[SourceMirror, str]], None]]:
+    ) -> Sequence[Optional[AliasSubstitution]]:
 
         if first_pass:
             config = self.first_pass_config
@@ -489,7 +489,7 @@ class Project:
         if policy in (_SourceUriPolicy.ALL, _SourceUriPolicy.ALIASES):
             uri_list.append(config._aliases.get_str(alias))
 
-        return [(alias, mirror) for mirror in uri_list]
+        return [AliasSubstitution(alias, mirror) for mirror in uri_list]
 
     # load_elements()
     #

--- a/src/buildstream/source.py
+++ b/src/buildstream/source.py
@@ -218,6 +218,7 @@ Class Reference
 import os
 from contextlib import contextmanager
 from typing import Iterable, Iterator, Optional, Tuple, Dict, Any, Set, TYPE_CHECKING, Union
+from dataclasses import dataclass
 
 from . import _yaml, utils
 from .node import MappingNode
@@ -259,6 +260,12 @@ class SourceError(BstError):
         super().__init__(message, detail=detail, domain=ErrorDomain.SOURCE, reason=reason, temporary=temporary)
 
 
+@dataclass
+class AliasSubstitution:
+    _effective_alias: str
+    _mirror: Union[SourceMirror, str]
+
+
 class SourceFetcher:
     """SourceFetcher()
 
@@ -280,7 +287,7 @@ class SourceFetcher:
     #############################################################
     #                      Abstract Methods                     #
     #############################################################
-    def fetch(self, alias_override: Optional[Tuple[str, Union[str, SourceMirror]]] = None, **kwargs) -> None:
+    def fetch(self, alias_override: Optional[AliasSubstitution] = None, **kwargs) -> None:
         """Fetch remote sources and mirror them locally, ensuring at least
         that the specific reference is cached locally.
 
@@ -387,7 +394,7 @@ class Source(Plugin):
         meta: MetaSource,
         variables: Variables,
         *,
-        alias_override: Optional[Tuple[str, Tuple[str, Union[str, SourceMirror]]]] = None,
+        alias_override: Optional[Tuple[str, AliasSubstitution]] = None,
         unique_id: Optional[int] = None,
     ):
         # Set element_name member before parent init, as needed for debug messaging
@@ -699,7 +706,7 @@ class Source(Plugin):
         self,
         url: str,
         *,
-        alias_override: Optional[Tuple[str, Union[str, SourceMirror]]] = None,
+        alias_override: Optional[AliasSubstitution] = None,
         primary: bool = True,
         suffix: Optional[str] = None,
         extra_data: Optional[Dict[str, Any]] = None,
@@ -745,7 +752,7 @@ class Source(Plugin):
 
             if self.__alias_override is not None:
                 override_alias = self.__alias_override[0]
-                effective_alias, override_mirror = self.__alias_override[1]
+                override_subst = self.__alias_override[1]
 
                 # Implicit alias overrides may only be done for one
                 # specific alias, so that sources that fetch from multiple
@@ -756,16 +763,19 @@ class Source(Plugin):
                     return url
 
             elif alias_override is not None:
-                effective_alias, override_mirror = alias_override
+                override_subst = alias_override
 
             # The default source mirror will give prefix URLs
-            if isinstance(override_mirror, str):
-                return override_mirror + url_body
+            if isinstance(override_subst._mirror, str):
+                return override_subst._mirror + url_body
             #
             # Delegate the URL translation to the SourceMirror plugin
             #
-            return override_mirror.translate_url(
-                alias=effective_alias, alias_url=project_alias_url, source_url=url_body, extra_data=extra_data
+            return override_subst._mirror.translate_url(
+                alias=override_subst._effective_alias,
+                alias_url=project_alias_url,
+                source_url=url_body,
+                extra_data=extra_data,
             )
         else:
             return project.translate_url(url, source=self, first_pass=self.__first_pass)

--- a/src/buildstream/source.py
+++ b/src/buildstream/source.py
@@ -280,7 +280,7 @@ class SourceFetcher:
     #############################################################
     #                      Abstract Methods                     #
     #############################################################
-    def fetch(self, alias_override: Optional[Union[str, SourceMirror]] = None, **kwargs) -> None:
+    def fetch(self, alias_override: Optional[Tuple[str, Union[str, SourceMirror]]] = None, **kwargs) -> None:
         """Fetch remote sources and mirror them locally, ensuring at least
         that the specific reference is cached locally.
 
@@ -387,7 +387,7 @@ class Source(Plugin):
         meta: MetaSource,
         variables: Variables,
         *,
-        alias_override: Optional[Tuple[str, Union[str, SourceMirror]]] = None,
+        alias_override: Optional[Tuple[str, Tuple[str, Union[str, SourceMirror]]]] = None,
         unique_id: Optional[int] = None,
     ):
         # Set element_name member before parent init, as needed for debug messaging
@@ -699,7 +699,7 @@ class Source(Plugin):
         self,
         url: str,
         *,
-        alias_override: Optional[Union[str, SourceMirror]] = None,
+        alias_override: Optional[Tuple[str, Union[str, SourceMirror]]] = None,
         primary: bool = True,
         suffix: Optional[str] = None,
         extra_data: Optional[Dict[str, Any]] = None,
@@ -745,7 +745,7 @@ class Source(Plugin):
 
             if self.__alias_override is not None:
                 override_alias = self.__alias_override[0]
-                override_mirror = self.__alias_override[1]
+                effective_alias, override_mirror = self.__alias_override[1]
 
                 # Implicit alias overrides may only be done for one
                 # specific alias, so that sources that fetch from multiple
@@ -756,7 +756,7 @@ class Source(Plugin):
                     return url
 
             elif alias_override is not None:
-                override_mirror = alias_override
+                effective_alias, override_mirror = alias_override
 
             # The default source mirror will give prefix URLs
             if isinstance(override_mirror, str):
@@ -765,7 +765,7 @@ class Source(Plugin):
             # Delegate the URL translation to the SourceMirror plugin
             #
             return override_mirror.translate_url(
-                alias=url_alias, alias_url=project_alias_url, source_url=url_body, extra_data=extra_data
+                alias=effective_alias, alias_url=project_alias_url, source_url=url_body, extra_data=extra_data
             )
         else:
             return project.translate_url(url, source=self, first_pass=self.__first_pass)

--- a/tests/frontend/mirror.py
+++ b/tests/frontend/mirror.py
@@ -889,6 +889,18 @@ def test_source_mirror_plugin(cli, tmpdir):
         assert bar_str in contents
 
 
+# Test subproject alias mapping. As there are quite a few corner cases and interactions with other
+# features that need to be tested, this test relies heavily on parametrization. Here is what each
+# parameter means:
+# * subproject_mirrors: whether the subproject defines a (failing) mirror
+# * unaliased_sources: whether the subproject has unaliased sources
+# * disallow_subproject_uris: define disallow-subproject-uris in the parent project
+# * fetch_source: whether to fetch from aliases or mirrors
+# * alias_override: which aliases to override ("global" means use "map-aliases")
+# * alias_mapping: how to map aliases to the overrides
+# * source_mirror: whether to use a custom source mirror plugin
+
+
 @pytest.mark.datafiles(DATA_DIR)
 @pytest.mark.usefixtures("datafiles")
 @pytest.mark.parametrize("subproject_mirrors", [True, False])

--- a/tests/frontend/mirror.py
+++ b/tests/frontend/mirror.py
@@ -895,10 +895,26 @@ def test_source_mirror_plugin(cli, tmpdir):
 @pytest.mark.parametrize("unaliased_sources", [True, False])
 @pytest.mark.parametrize("disallow_subproject_uris", [True, False])
 @pytest.mark.parametrize("fetch_source", ["aliases", "mirrors"])
-@pytest.mark.parametrize("alias_override", [["foo"], ["foo", "bar"], "global", "invalid"])
+@pytest.mark.parametrize("alias_override", [["foo"], ["foo", "bar"], "global"])
+@pytest.mark.parametrize("alias_mapping", ["identity", "project-prefix", "invalid"])
 def test_mirror_subproject_aliases(
-    cli, tmpdir, subproject_mirrors, unaliased_sources, disallow_subproject_uris, fetch_source, alias_override
+    cli,
+    tmpdir,
+    subproject_mirrors,
+    unaliased_sources,
+    disallow_subproject_uris,
+    fetch_source,
+    alias_override,
+    alias_mapping,
 ):
+    if alias_override == "global":
+        if alias_mapping == "invalid":
+            # we can't have an invalid mapping using a predefined option
+            pytest.skip()
+        elif alias_mapping == "project-prefix":
+            # project-prefix alias mapping not yet implemented
+            pytest.xfail()
+
     output_file = os.path.join(str(tmpdir), "output.txt")
     project_dir = tmpdir
 
@@ -941,7 +957,62 @@ def test_mirror_subproject_aliases(
     # copy the source plugin to the subproject
     shutil.copytree(project_dir / "sources", subproject_dir / "sources")
 
-    project = generate_project(MirrorConfig.SUCCESS_MIRRORS, fetch_source == "aliases")
+    if alias_mapping == "identity":
+
+        def map_alias(x):
+            return x
+
+    elif alias_mapping == "project-prefix":
+
+        def map_alias(x):
+            return subproject["name"] + "/" + x
+
+    else:
+
+        def map_alias(x):
+            return "invalid-" + x
+
+    if alias_mapping != "invalid":
+        map_alias_valid = map_alias
+    else:
+
+        def map_alias_valid(x):
+            return x
+
+    project = {
+        "name": "test",
+        "min-version": "2.0",
+        "element-path": "elements",
+        "aliases": {
+            map_alias_valid("foo"): "FOO/",
+            map_alias_valid("bar"): "RAB/" if fetch_source == "aliases" else "BAR/",
+        },
+        "plugins": [{"origin": "local", "path": "sources", "sources": ["fetch_source"]}],
+        # Copy of SUCCESS_MIRROR_LIST from above
+        "mirrors": [
+            {
+                "name": "middle-earth",
+                "aliases": {
+                    map_alias_valid("foo"): ["OOF/"],
+                    map_alias_valid("bar"): ["RAB/"],
+                },
+            },
+            {
+                "name": "arrakis",
+                "aliases": {
+                    map_alias_valid("foo"): ["FOO/"],
+                    map_alias_valid("bar"): ["RBA/"],
+                },
+            },
+            {
+                "name": "oz",
+                "aliases": {
+                    map_alias_valid("foo"): ["ooF/"],
+                    map_alias_valid("bar"): ["raB/"],
+                },
+            },
+        ],
+    }
 
     if disallow_subproject_uris:
         project["junctions"] = {"disallow-subproject-uris": "true"}
@@ -960,16 +1031,9 @@ def test_mirror_subproject_aliases(
     }
 
     if alias_override == "global":
-        junction["config"] = {"map-aliases": "identity"}
-    elif alias_override == "invalid":
-        junction["config"] = {
-            "aliases": {
-                "foo": "invalid-foo",
-                "bar": "invalid-bar",
-            }
-        }
+        junction["config"] = {"map-aliases": alias_mapping}
     else:
-        junction["config"] = {"aliases": {alias: alias for alias in alias_override}}
+        junction["config"] = {"aliases": {alias: map_alias(alias) for alias in alias_override}}
 
     _yaml.roundtrip_dump(junction, str(element_dir / junction_name))
 
@@ -977,7 +1041,7 @@ def test_mirror_subproject_aliases(
     cli.configure(userconfig)
 
     result = cli.run(project=project_dir, args=["source", "fetch", "{}:{}".format(junction_name, element_name)])
-    if alias_override == "invalid":
+    if alias_mapping == "invalid":
         # Mapped alias does not exist in the parent project
         result.assert_main_error(ErrorDomain.SOURCE, "invalid-source-alias")
     elif disallow_subproject_uris and unaliased_sources:

--- a/tests/frontend/mirror.py
+++ b/tests/frontend/mirror.py
@@ -897,6 +897,7 @@ def test_source_mirror_plugin(cli, tmpdir):
 @pytest.mark.parametrize("fetch_source", ["aliases", "mirrors"])
 @pytest.mark.parametrize("alias_override", [["foo"], ["foo", "bar"], "global"])
 @pytest.mark.parametrize("alias_mapping", ["identity", "project-prefix", "invalid"])
+@pytest.mark.parametrize("source_mirror", [True, False])
 def test_mirror_subproject_aliases(
     cli,
     tmpdir,
@@ -906,6 +907,7 @@ def test_mirror_subproject_aliases(
     fetch_source,
     alias_override,
     alias_mapping,
+    source_mirror,
 ):
     if alias_override == "global":
         if alias_mapping == "invalid":
@@ -1013,6 +1015,13 @@ def test_mirror_subproject_aliases(
             },
         ],
     }
+    if source_mirror:
+        project["plugins"].append({"origin": "local", "path": "sourcemirrors", "source-mirrors": ["mirror"]})
+
+        mirrors = []
+        for mirror in project["mirrors"]:
+            mirrors.append({"name": mirror["name"], "kind": "mirror", "config": {"aliases": mirror["aliases"]}})
+        project["mirrors"] = mirrors
 
     if disallow_subproject_uris:
         project["junctions"] = {"disallow-subproject-uris": "true"}


### PR DESCRIPTION
This also adds tests for non-identity alias mapping and interaction between alias mapping and source mirrors.