### PR TITLE
Use buildbox-casd as remote asset proxy, if supported

### DIFF
--- a/src/buildstream/_cas/casdprocessmanager.py
+++ b/src/buildstream/_cas/casdprocessmanager.py
@@ -63,6 +63,8 @@ _REQUIRED_CASD_MICRO = 58
 #
 class CASDProcessManager:
     def __init__(self, path, log_dir, log_level, cache_quota, remote_cache_spec, protect_session_blobs, messenger):
+        os.makedirs(path, exist_ok=True)
+
         self._log_dir = log_dir
 
         self._socket_path = self._make_socket_path(path)

--- a/src/buildstream/_cas/casremote.py
+++ b/src/buildstream/_cas/casremote.py
@@ -59,18 +59,7 @@ class CASRemote(BaseRemote):
 
         local_cas = self.cascache.get_local_cas()
         request = local_cas_pb2.GetInstanceNameForRemotesRequest()
-        cas_endpoint = request.content_addressable_storage
-        cas_endpoint.url = self.spec.url
-        if self.spec.instance_name:
-            cas_endpoint.instance_name = self.spec.instance_name
-        if self.spec.server_cert:
-            cas_endpoint.server_cert = self.spec.server_cert
-        if self.spec.client_key:
-            cas_endpoint.client_key = self.spec.client_key
-        if self.spec.client_cert:
-            cas_endpoint.client_cert = self.spec.client_cert
-        if self.spec.keepalive_time is not None:
-            cas_endpoint.keepalive_time.FromSeconds(self.spec.keepalive_time)
+        self.spec.to_localcas_remote(request.content_addressable_storage)
         try:
             response = local_cas.GetInstanceNameForRemotes(request)
         except grpc.RpcError as e:

--- a/src/buildstream/_remote.py
+++ b/src/buildstream/_remote.py
@@ -68,9 +68,6 @@ class BaseRemote:
             if self._initialized:
                 return
 
-            if self.spec:
-                self.channel = self.spec.open_channel()
-
             self._configure_protocols()
             self._initialized = True
 

--- a/src/buildstream/_remotespec.py
+++ b/src/buildstream/_remotespec.py
@@ -218,6 +218,23 @@ class RemoteSpec:
 
         return channel
 
+    # to_localcas_remote()
+    #
+    # Create a `LocalContentAddressableStorage.Remote` proto from the `RemoteSpec` object.
+    #
+    def to_localcas_remote(self, remote):
+        remote.url = self.url
+        if self.instance_name:
+            remote.instance_name = self.instance_name
+        if self.server_cert:
+            remote.server_cert = self.server_cert
+        if self.client_key:
+            remote.client_key = self.client_key
+        if self.client_cert:
+            remote.client_cert = self.client_cert
+        if self.keepalive_time is not None:
+            remote.keepalive_time.FromSeconds(self.keepalive_time)
+
     # new_from_node():
     #
     # Creates a RemoteSpec() from a YAML loaded node.

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -1799,7 +1799,7 @@ class Stream:
             self._session_start_callback()
 
         self._running = True
-        status = self._scheduler.run(self.queues, self._context.get_cascache().get_casd_process_manager())
+        status = self._scheduler.run(self.queues, self._context.get_cascache().get_casd())
         self._running = False
 
         if status == SchedStatus.ERROR:

--- a/src/buildstream/_testing/runcli.py
+++ b/src/buildstream/_testing/runcli.py
@@ -725,7 +725,7 @@ class TestArtifact:
     def _extract_subdirectory(self, tmpdir, digest):
         with tempfile.TemporaryDirectory() as extractdir:
             try:
-                cas = CASCache(str(tmpdir), casd=False)
+                cas = CASCache(str(tmpdir), casd=None)
                 cas.checkout(extractdir, digest)
                 yield extractdir
             except FileNotFoundError:

--- a/src/buildstream/sandbox/_sandboxbuildboxrun.py
+++ b/src/buildstream/sandbox/_sandboxbuildboxrun.py
@@ -87,7 +87,7 @@ class SandboxBuildBoxRun(SandboxREAPI):
 
         context = self._get_context()
         cascache = context.get_cascache()
-        casd_process_manager = cascache.get_casd_process_manager()
+        casd = cascache.get_casd()
 
         with utils._tempnamedfile() as action_file, utils._tempnamedfile() as result_file:
             action_file.write(action.SerializeToString())
@@ -95,7 +95,7 @@ class SandboxBuildBoxRun(SandboxREAPI):
 
             buildbox_command = [
                 self.__buildbox_run(),
-                "--remote={}".format(casd_process_manager._connection_string),
+                "--remote={}".format(casd._connection_string),
                 "--action={}".format(action_file.name),
                 "--action-result={}".format(result_file.name),
             ]

--- a/tests/artifactcache/expiry.py
+++ b/tests/artifactcache/expiry.py
@@ -22,20 +22,18 @@ import time
 
 import pytest
 
-from buildstream._cas import CASCache
 from buildstream.exceptions import ErrorDomain, LoadErrorReason
 from buildstream._testing import cli  # pylint: disable=unused-import
 from buildstream._testing._utils.site import have_subsecond_mtime
 
-from tests.testutils import create_element_size, wait_for_cache_granularity
+from tests.testutils import casd_cache, create_element_size, wait_for_cache_granularity
 
 
 DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "expiry")
 
 
 def get_cache_usage(directory):
-    cas_cache = CASCache(directory, log_directory=os.path.dirname(directory))
-    try:
+    with casd_cache(directory) as cas_cache:
         wait = 0.1
         for _ in range(0, int(5 / wait)):
             used_size = cas_cache.get_cache_usage().used_size
@@ -45,8 +43,6 @@ def get_cache_usage(directory):
 
         assert False, "Unable to retrieve cache usage"
         return None
-    finally:
-        cas_cache.release_resources()
 
 
 # Ensure that the cache successfully removes an old artifact if we do

--- a/tests/artifactcache/pull.py
+++ b/tests/artifactcache/pull.py
@@ -203,9 +203,6 @@ def test_pull_tree(cli, tmpdir, datafiles):
             cli.remove_artifact_from_cache(project_dir, "target.bst")
 
             # Assert that we are not cached locally anymore
-            artifactcache.release_resources()
-            cas._casd_channel.request_shutdown()
-            cas.close_grpc_channels()
             assert cli.get_element_state(project_dir, "target.bst") != "cached"
 
             tree_digest = remote_execution_pb2.Digest(hash=tree_hash, size_bytes=tree_size)

--- a/tests/internals/storage.py
+++ b/tests/internals/storage.py
@@ -24,9 +24,10 @@ from typing import List, Optional
 import pytest
 
 from buildstream import DirectoryError, FileType
-from buildstream._cas import CASCache
 from buildstream.storage._casbaseddirectory import CasBasedDirectory
 from buildstream.storage._filebaseddirectory import FileBasedDirectory
+
+from tests.testutils import casd_cache
 
 DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "storage")
 
@@ -38,11 +39,8 @@ def setup_backend(backend_class, tmpdir):
         os.mkdir(path)
         yield backend_class(path)
     else:
-        cas_cache = CASCache(os.path.join(tmpdir, "cas"), log_directory=os.path.join(tmpdir, "logs"))
-        try:
+        with casd_cache(os.path.join(tmpdir, "cas")) as cas_cache:
             yield backend_class(cas_cache)
-        finally:
-            cas_cache.release_resources()
 
 
 @pytest.mark.parametrize("backend", [FileBasedDirectory, CasBasedDirectory])

--- a/tests/testutils/__init__.py
+++ b/tests/testutils/__init__.py
@@ -20,6 +20,7 @@
 #
 
 from .artifactshare import create_artifact_share, create_split_share, assert_shared, assert_not_shared, ArtifactShare
+from .casd import casd_cache
 from .context import dummy_context
 from .element_generators import create_element_size
 from .junction import generate_junction

--- a/tests/testutils/artifactshare.py
+++ b/tests/testutils/artifactshare.py
@@ -142,7 +142,7 @@ class ArtifactShare(BaseArtifactShare):
         super().__init__()
 
         # Set after subprocess creation as it's not picklable
-        self.cas = CASCache(self.repodir, casd=False)
+        self.cas = CASCache(self.repodir, casd=None)
 
     def _create_server(self):
         return create_server(

--- a/tests/testutils/casd.py
+++ b/tests/testutils/casd.py
@@ -10,10 +10,23 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#
-#  Authors:
-#        Tristan Van Berkom <tristan.vanberkom@codethink.co.uk>
 
-from .cascache import CASCache, CASLogLevel
-from .casdprocessmanager import CASDProcessManager
-from .casremote import CASRemote
+import os
+from contextlib import contextmanager
+
+from buildstream._cas import CASCache, CASDProcessManager, CASLogLevel
+
+
+@contextmanager
+def casd_cache(path, messenger=None):
+    casd = CASDProcessManager(
+        str(path), os.path.join(str(path), "..", "logs", "_casd"), CASLogLevel.WARNING, None, None, True, None
+    )
+    try:
+        cascache = CASCache(str(path), casd=casd)
+        try:
+            yield cascache
+        finally:
+            cascache.release_resources()
+    finally:
+        casd.release_resources(messenger)


### PR DESCRIPTION
buildbox-casd is already used as CAS proxy. Using buildbox-casd for all remote connections aims to improve robustness (e.g., consistent retry behavior) and will allow adding support for token-based authentication (#1913).

This does not yet use buildbox-casd as remote execution proxy

This depends on https://gitlab.com/BuildGrid/buildbox/buildbox/-/merge_requests/605 for the remote asset proxy to be used. However, BuildStream will fall back to direct gRPC connections if buildbox-casd doesn't support asset-only remotes.