### PR TITLE
Support %{description} in bst show commands

### DIFF
--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -600,6 +600,7 @@ def show(app, elements, deps, except_, order, format_):
 
     \b
         %{name}           The element name
+        %{description}    The element description, on a single line (Since: 2.3)
         %{key}            The abbreviated cache key (if all sources are consistent)
         %{full-key}       The full cache key (if all sources are consistent)
         %{state}          cached, buildable, waiting, inconsistent or junction

--- a/src/buildstream/_frontend/widget.py
+++ b/src/buildstream/_frontend/widget.py
@@ -351,9 +351,13 @@ class LogLine(Widget):
             key = element._get_display_key()
             dim_keys = not key.strict
 
+            # Guarantee that description is reported on a single line.
+            description = " ".join(element._description.splitlines())
+
             line = p.fmt_subst(line, "name", element._get_full_name(), fg="blue", bold=True)
             line = p.fmt_subst(line, "key", key.brief, fg="yellow", dim=dim_keys)
             line = p.fmt_subst(line, "full-key", key.full, fg="yellow", dim=dim_keys)
+            line = p.fmt_subst(line, "description", description, fg="yellow", dim=dim_keys)
 
             try:
                 if not element._has_all_sources_resolved():

--- a/src/buildstream/_loader/loadelement.pyi
+++ b/src/buildstream/_loader/loadelement.pyi
@@ -24,5 +24,6 @@ class LoadElement:
     first_pass: bool
     kind: str
     name: str
+    description: str
     node: Node
     link_target: ScalarNode

--- a/src/buildstream/_loader/loadelement.pyx
+++ b/src/buildstream/_loader/loadelement.pyx
@@ -227,6 +227,7 @@ cdef class LoadElement:
     cdef readonly MappingNode node
     cdef readonly str name
     cdef readonly str full_name
+    cdef readonly str description
     cdef readonly str kind
     cdef int node_id
     cdef readonly bint first_pass
@@ -272,6 +273,7 @@ cdef class LoadElement:
         self.node.validate_keys(_valid_element_keys)
 
         self.kind = node.get_str(Symbol.KIND, default=None)
+        self.description = node.get_str(Symbol.DESCRIPTION, default=None)
         self.first_pass = self.kind in ("junction", "link")
 
         #

--- a/src/buildstream/_loader/types.py
+++ b/src/buildstream/_loader/types.py
@@ -22,6 +22,7 @@
 class Symbol:
     FILENAME = "filename"
     KIND = "kind"
+    DESCRIPTION = "description"
     DEPENDS = "depends"
     BUILD_DEPENDS = "build-depends"
     RUNTIME_DEPENDS = "runtime-depends"

--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -248,6 +248,7 @@ class Element(Plugin):
         #
         self._depth = None  # Depth of Element in its current dependency graph
         self._overlap_collector = None  # type: Optional[OverlapCollector]
+        self._description = load_element.description or ""  # type: str
 
         #
         # Private instance properties


### PR DESCRIPTION
We haven't really been using the valid `description` element key, there is a use case for it in the sense that we can at least use it to make reports via the cli.
