### PR TITLE
Use buildbox-casd as remote execution proxy

### DIFF
--- a/.github/common.env
+++ b/.github/common.env
@@ -1,6 +1,6 @@
 # Shared common variables
 
-CI_IMAGE_VERSION=master-1091773482
+CI_IMAGE_VERSION=master-1361451963
 CI_TOXENV_MAIN=py37,py38,py39,py310,py311,py312
 CI_TOXENV_PLUGINS=py37-plugins,py38-plugins,py39-plugins,py310-plugins,py311-plugins,py312-plugins
 CI_TOXENV_ALL="${CI_TOXENV_MAIN},${CI_TOXENV_PLUGINS}"

--- a/tests/remotecache/simple.py
+++ b/tests/remotecache/simple.py
@@ -80,4 +80,5 @@ def test_remote_autotools_build_no_cache(cli, datafiles):
     result.assert_success()
 
     assert """WARNING Failed to initialize remote""" in result.stderr
-    assert """Remote initialisation failed with status UNAVAILABLE: DNS resolution failed""" in result.stderr
+    assert """Remote initialisation failed with status UNAVAILABLE""" in result.stderr
+    assert """DNS resolution failed""" in result.stderr


### PR DESCRIPTION
buildbox-casd is already used as CAS and RA proxy. Using buildbox-casd for all remote connections aims to improve robustness (e.g., consistent retry behavior) and enables support for token-based authentication (#1913).

This depends on BuildBox 1.2.6+ for the remote execution proxy to be used. However, BuildStream will fall back to direct gRPC connections if buildbox-casd doesn't support execution remotes.