### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/common.env
+++ b/.github/common.env
@@ -1,6 +1,6 @@
 # Shared common variables
 
 CI_IMAGE_VERSION=master-1361451963
-CI_TOXENV_MAIN=py37,py38,py39,py310,py311,py312
-CI_TOXENV_PLUGINS=py37-plugins,py38-plugins,py39-plugins,py310-plugins,py311-plugins,py312-plugins
+CI_TOXENV_MAIN=py38,py39,py310,py311,py312
+CI_TOXENV_PLUGINS=py38-plugins,py39-plugins,py310-plugins,py311-plugins,py312-plugins
 CI_TOXENV_ALL="${CI_TOXENV_MAIN},${CI_TOXENV_PLUGINS}"

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -30,10 +30,6 @@ services:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:39-${CI_IMAGE_VERSION:-latest}
 
-  debian-10:
-    <<: *tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-debian:10-${CI_IMAGE_VERSION:-latest}
-
   ubuntu-20.04:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-ubuntu:20.04-${CI_IMAGE_VERSION:-latest}

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -34,6 +34,10 @@ services:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-debian:10-${CI_IMAGE_VERSION:-latest}
 
+  ubuntu-20.04:
+    <<: *tests-template
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-ubuntu:20.04-${CI_IMAGE_VERSION:-latest}
+
   # Ensure that tests also pass in the absence of a sandboxing tool
   fedora-missing-deps:
     <<: *tests-template

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -90,11 +90,6 @@ services:
   # on the PyPA official 'manylinux' images that define the base ABI for
   # Python binary packages.
 
-  wheels-manylinux_2_28-cp37:
-    <<: *tests-template
-    image: quay.io/pypa/manylinux_2_28_x86_64
-    command: .github/wheel-helpers/test-wheel-manylinux.sh cp37 /opt/python/cp37-cp37m/bin/python3
-
   wheels-manylinux_2_28-cp38:
     <<: *tests-template
     image: quay.io/pypa/manylinux_2_28_x86_64

--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -102,7 +102,7 @@ function runServiceTest() {
 
 
 if [ -z "${test_names}" ]; then
-    for test_name in mypy debian-10 fedora-38 fedora-39 fedora-missing-deps; do
+    for test_name in mypy debian-10 fedora-38 fedora-39 fedora-missing-deps ubuntu-20.04; do
 	if ! runTest "${test_name}"; then
 	    echo "Tests failed"
 	    exit 1

--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -102,7 +102,7 @@ function runServiceTest() {
 
 
 if [ -z "${test_names}" ]; then
-    for test_name in mypy debian-10 fedora-38 fedora-39 fedora-missing-deps ubuntu-20.04; do
+    for test_name in mypy fedora-38 fedora-39 fedora-missing-deps ubuntu-20.04; do
 	if ! runTest "${test_name}"; then
 	    echo "Tests failed"
 	    exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           - fedora-38
           - fedora-39
           - fedora-missing-deps
+          - ubuntu-20.04
           - lint
           - mypy
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
         # The names here should map to a valid service defined in
         # "../compose/ci.docker-compose.yml"
         test-name:
-          - debian-10
           - fedora-38
           - fedora-39
           - fedora-missing-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,6 @@ jobs:
         # The names here should map to a valid service defined in
         # "../compose/ci.docker-compose.yml"
         test-name:
-          - wheels-manylinux_2_28-cp37
           - wheels-manylinux_2_28-cp38
           - wheels-manylinux_2_28-cp39
           - wheels-manylinux_2_28-cp310

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,6 @@ jobs:
         # The names here should map to a valid service defined in
         # "../compose/ci.docker-compose.yml"
         test-name:
-          - wheels-manylinux_2_28-cp37
           - wheels-manylinux_2_28-cp38
           - wheels-manylinux_2_28-cp39
           - wheels-manylinux_2_28-cp310

--- a/doc/source/main_install.rst
+++ b/doc/source/main_install.rst
@@ -35,7 +35,7 @@ Runtime requirements
 
 BuildStream requires the following Python environment to run:
 
-- python3 >= 3.7
+- python3 >= 3.8
 - PyPI packages as specified in
   `requirements.in <https://github.com/apache/buildstream/blob/master/requirements/requirements.in>`_.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,9 @@ environment = { BST_BUNDLE_BUILDBOX = "1" }
 manylinux-x86_64-image = "manylinux_2_28"
 
 skip = [
-  # BuildStream supports Python >= 3.7
+  # BuildStream supports Python >= 3.8
   "cp36-*",
+  "cp37-*",
   # PyPy may work, but nobody is testing it so avoid distributing prebuilt binaries.
   "pp*",
   # Skipping this niche archicture ~halves overall build time.

--- a/requirements/dev-requirements.in
+++ b/requirements/dev-requirements.in
@@ -7,6 +7,3 @@ pytest-env
 pytest-xdist
 pytest-timeout
 pyftpdlib
-# isort is an indirect requirement, but it must be constrained
-# as 5.12 is not available for python 3.7
-isort < 5.12

--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,10 @@ if version.startswith("0+untagged"):
 # Python requirements
 ##################################################################
 REQUIRED_PYTHON_MAJOR = 3
-REQUIRED_PYTHON_MINOR = 7
+REQUIRED_PYTHON_MINOR = 8
 
 if sys.version_info[0] != REQUIRED_PYTHON_MAJOR or sys.version_info[1] < REQUIRED_PYTHON_MINOR:
-    print("BuildStream requires Python >= 3.7")
+    print("BuildStream requires Python >= 3.8")
     sys.exit(1)
 
 try:
@@ -368,10 +368,11 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Build Tools",
     ],
     description="A framework for modelling build pipelines in YAML",

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@
 # Tox global configuration
 #
 [tox]
-envlist = py{37,38,39,310,311,312}
+envlist = py{38,39,310,311,312}
 skip_missing_interpreters = true
 isolated_build = true
 
@@ -33,30 +33,30 @@ BST_PLUGINS_VERSION = ed65975aa3b0629a36112d474366ac86d4da8261
 [testenv]
 usedevelop =
     # This is required by Cython in order to get coverage for cython files.
-    py{37,38,39,310,311,312}-!nocover: True
+    py{38,39,310,311,312}-!nocover: True
 
 commands =
     # Running with coverage reporting enabled
-    py{37,38,39,310,311,312}-!plugins-!nocover: pytest --basetemp {envtmpdir} --cov=buildstream --cov-config .coveragerc {posargs}
+    py{38,39,310,311,312}-!plugins-!nocover: pytest --basetemp {envtmpdir} --cov=buildstream --cov-config .coveragerc {posargs}
     # Running with coverage reporting disabled
-    py{37,38,39,310,311,312}-!plugins-nocover: pytest --basetemp {envtmpdir} {posargs}
+    py{38,39,310,311,312}-!plugins-nocover: pytest --basetemp {envtmpdir} {posargs}
     # Running external plugins tests with coverage reporting enabled
-    py{37,38,39,310,311,312}-plugins-!nocover: pytest --basetemp {envtmpdir} --cov=buildstream --cov-config .coveragerc --plugins {posargs}
+    py{38,39,310,311,312}-plugins-!nocover: pytest --basetemp {envtmpdir} --cov=buildstream --cov-config .coveragerc --plugins {posargs}
     # Running external plugins tests with coverage disabled
-    py{37,38,39,310,311,312}-plugins-nocover: pytest --basetemp {envtmpdir} --plugins {posargs}
+    py{38,39,310,311,312}-plugins-nocover: pytest --basetemp {envtmpdir} --plugins {posargs}
 commands_post:
-    py{37,38,39,310,311,312}-!nocover: mkdir -p .coverage-reports
-    py{37,38,39,310,311,312}-!nocover: mv {envtmpdir}/.coverage {toxinidir}/.coverage-reports/.coverage.{env:COVERAGE_PREFIX:}{envname}
+    py{38,39,310,311,312}-!nocover: mkdir -p .coverage-reports
+    py{38,39,310,311,312}-!nocover: mv {envtmpdir}/.coverage {toxinidir}/.coverage-reports/.coverage.{env:COVERAGE_PREFIX:}{envname}
 deps =
-    py{37,38,39,310,311,312}: -rrequirements/requirements.txt
-    py{37,38,39,310,311,312}: -rrequirements/dev-requirements.txt
-    py{37,38,39,310,311,312}: git+https://github.com/apache/buildstream-plugins.git@{env:BST_PLUGINS_VERSION:{[config]BST_PLUGINS_VERSION}}
+    py{38,39,310,311,312}: -rrequirements/requirements.txt
+    py{38,39,310,311,312}: -rrequirements/dev-requirements.txt
+    py{38,39,310,311,312}: git+https://github.com/apache/buildstream-plugins.git@{env:BST_PLUGINS_VERSION:{[config]BST_PLUGINS_VERSION}}
 
     # Install local sample plugins for testing pip plugin origins
-    py{37,38,39,310,311,312}: {toxinidir}/tests/plugins/sample-plugins
+    py{38,39,310,311,312}: {toxinidir}/tests/plugins/sample-plugins
 
     # Install external plugins for plugin tests
-    py{37,38,39,310,311,312}-plugins: git+https://gitlab.com/buildstream/bst-plugins-experimental.git@{env:BST_PLUGINS_EXPERIMENTAL_VERSION:{[config]BST_PLUGINS_EXPERIMENTAL_VERSION}}#egg=bst_plugins_experimental[deb]
+    py{38,39,310,311,312}-plugins: git+https://gitlab.com/buildstream/bst-plugins-experimental.git@{env:BST_PLUGINS_EXPERIMENTAL_VERSION:{[config]BST_PLUGINS_EXPERIMENTAL_VERSION}}#egg=bst_plugins_experimental[deb]
 
     # Only require coverage and pytest-cov when using it
     !nocover: -rrequirements/cov-requirements.txt
@@ -84,21 +84,21 @@ passenv =
 # These keys are not inherited by any other sections
 #
 setenv =
-    py{37,38,39,310,311,312}: COVERAGE_FILE = {envtmpdir}/.coverage
-    py{37,38,39,310,311,312}: BST_TEST_HOME = {envtmpdir}
-    py{37,38,39,310,311,312}: BST_TEST_XDG_CACHE_HOME = {envtmpdir}/cache
-    py{37,38,39,310,311,312}: BST_TEST_XDG_CONFIG_HOME = {envtmpdir}/config
-    py{37,38,39,310,311,312}: BST_TEST_XDG_DATA_HOME = {envtmpdir}/share
+    py{38,39,310,311,312}: COVERAGE_FILE = {envtmpdir}/.coverage
+    py{38,39,310,311,312}: BST_TEST_HOME = {envtmpdir}
+    py{38,39,310,311,312}: BST_TEST_XDG_CACHE_HOME = {envtmpdir}/cache
+    py{38,39,310,311,312}: BST_TEST_XDG_CONFIG_HOME = {envtmpdir}/config
+    py{38,39,310,311,312}: BST_TEST_XDG_DATA_HOME = {envtmpdir}/share
 
     # This is required to run tests with python 3.7
     py37: SETUPTOOLS_ENABLE_FEATURES = "legacy-editable"
 
     # This is required to get coverage for Cython
-    py{37,38,39,310,311,312}-!nocover: BST_CYTHON_TRACE = 1
+    py{38,39,310,311,312}-!nocover: BST_CYTHON_TRACE = 1
     randomized: PYTEST_ADDOPTS="--random-order-bucket=global"
 
 allowlist_externals =
-    py{37,38,39,310,311,312}:
+    py{38,39,310,311,312}:
         mv
         mkdir
 


### PR DESCRIPTION
Python 3.7 is no longer maintained upstream since June 27, 2023 and many Python packages have dropped support for it.

Updating our dependencies is required to get pylint and mypy working on Python 3.12. However, not all of the updated dependencies are compatible with Python 3.7 anymore.

This replaces the Python 3.7-based Debian 10 with the Python 3.8-based Ubuntu 20.04 in CI to keep testing with the oldest supported version of Python.