### PR TITLE
Fix tests after dependency updates

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ warn_no_return = True
 
 # Ignore missing stubs for third-party packages.
 # In future, these should be re-enabled if/when stubs for them become available.
-[mypy-copyreg,grpc,pluginbase,psutil,pyroaring,ruamel,multiprocessing.forkserver]
+[mypy-copyreg,grpc,pluginbase,psutil,pyroaring,ruamel,multiprocessing.forkserver,pkg_resources.extern]
 ignore_missing_imports=True
 
 # Ignore issues with generated files and vendored code

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ parentdir_prefix = BuildStream-
 
 [tool:pytest]
 addopts = --verbose --basetemp ./tmp --durations=20 --timeout=1800
+testpaths = tests
 norecursedirs = src tests/integration/project tests/plugins/loading tests/plugins/sample-plugins integration-cache tmp __pycache__ .eggs
 python_files = tests/*/*.py
 env =

--- a/src/buildstream/_pluginfactory/pluginoriginpip.py
+++ b/src/buildstream/_pluginfactory/pluginoriginpip.py
@@ -34,6 +34,13 @@ class PluginOriginPip(PluginOrigin):
 
         import pkg_resources
 
+        try:
+            # For setuptools >= 70
+            import packaging
+        except ImportError:
+            # For setuptools < 70
+            from pkg_resources.extern import packaging
+
         # Sources and elements are looked up in separate
         # entrypoint groups from the same package.
         #
@@ -66,7 +73,7 @@ class PluginOriginPip(PluginOrigin):
             # For setuptools < 49.0.0
             pkg_resources.RequirementParseError,
             # For setuptools >= 49.0.0
-            pkg_resources.extern.packaging.requirements.InvalidRequirement,
+            packaging.requirements.InvalidRequirement,
         ) as e:
             raise PluginError(
                 "{}: Malformed package-name '{}' encountered: {}".format(

--- a/src/buildstream/_testing/__init__.py
+++ b/src/buildstream/_testing/__init__.py
@@ -100,23 +100,10 @@ def sourcetests_collection_hook(session):
     """
 
     def should_collect_tests(config):
-        args = config.args
-        rootdir = config.rootdir
-        # When no args are supplied, pytest defaults the arg list to
-        # just include the session's root_dir. We want to collect
+        # When no args are supplied, pytest defaults the arg list to the
+        # value of the `testpaths` configuration option. We want to collect
         # tests as part of the default collection
-        if args == [str(rootdir)]:
-            return True
-
-        # If specific tests are passed, don't collect
-        # everything. Pytest will handle this correctly without
-        # modification.
-        if len(args) > 1 or rootdir not in args:
-            return False
-
-        # If in doubt, collect them, this will be an easier bug to
-        # spot and is less likely to result in bug not being found.
-        return True
+        return config.args_source != pytest.Config.ArgsSource.ARGS
 
     from . import _sourcetests
 

--- a/src/buildstream/_testing/runcli.py
+++ b/src/buildstream/_testing/runcli.py
@@ -549,7 +549,7 @@ class CliIntegration(Cli):
 
                 temp_project = os.path.join(scratchdir, "project.conf")
                 with open(temp_project, "w", encoding="utf-8") as f:
-                    yaml.safe_dump(project_config, f)
+                    _yaml.roundtrip_dump(project_config, f)
 
                 project_config = _yaml.load(temp_project, shortname="project.conf")
 


### PR DESCRIPTION
pytest 8 had breaking changes in test collection, which prevented the main test suite from being picked up in combination with our `sourcetests_collection_hook`.

This sets the pytest `testpaths` config to fix test collection and fixes a couple of issues that caused test failures.