### PR TITLE
scriptelement: Fix time logging of integration commands

### DIFF
--- a/src/buildstream/scriptelement.py
+++ b/src/buildstream/scriptelement.py
@@ -233,7 +233,7 @@ class ScriptElement(Element):
             root_list = self.__layout.get("/", None)
             if root_list:
                 element_list = [element for element, _ in root_list]
-                with sandbox.batch(), self.timed_activity("Integrating sandbox", silent_nested=True):
+                with self.timed_activity("Integrating sandbox", silent_nested=True), sandbox.batch():
                     for dep in self.dependencies(element_list):
                         dep.integrate(sandbox)
 


### PR DESCRIPTION
sandbox.batch() needs to happen within the timed_activity for it to count the time it needs to run the command