### PR TITLE
_context: use artifact caches from the parent project for junctions

### DIFF
--- a/src/buildstream/_context.py
+++ b/src/buildstream/_context.py
@@ -767,6 +767,13 @@ class Context:
 
         # If there are any project recommendations, append them at the end
         project_remotes = getattr(project, project_attribute)
+
+        junction = project.junction
+        while junction:
+            parent_project = junction._get_project()
+            project_remotes = getattr(parent_project, project_attribute) + project_remotes
+            junction = parent_project.junction
+
         remotes = list(utils._deduplicate(remotes + project_remotes))
 
         return remotes

--- a/src/buildstream/_context.py
+++ b/src/buildstream/_context.py
@@ -807,6 +807,13 @@ class Context:
 
         # If there are any project recommendations, append them at the end
         project_remotes = getattr(project, project_attribute)
+
+        junction = project.junction
+        while junction:
+            parent_project = junction._get_project()
+            project_remotes = getattr(parent_project, project_attribute) + project_remotes
+            junction = parent_project.junction
+
         remotes = list(utils._deduplicate(remotes + project_remotes))
 
         return remotes

--- a/tests/artifactcache/junctions.py
+++ b/tests/artifactcache/junctions.py
@@ -69,7 +69,7 @@ def test_push_pull(cli, tmpdir, datafiles):
         # In the parent project's cache
         assert_shared(cli, share, project, "target.bst", project_name="parent")
         assert_shared(cli, share, project, "app.bst", project_name="parent")
-        assert_not_shared(cli, share, base_project, "base-element.bst", project_name="base")
+        assert_shared(cli, share, base_project, "base-element.bst", project_name="base")
 
         # In the junction project's cache
         assert_not_shared(cli, base_share, project, "target.bst", project_name="parent")

--- a/tests/artifactcache/junctions.py
+++ b/tests/artifactcache/junctions.py
@@ -68,7 +68,7 @@ def test_push_pull(cli, tmpdir, datafiles):
         # In the parent project's cache
         assert_shared(cli, share, project, "target.bst", project_name="parent")
         assert_shared(cli, share, project, "app.bst", project_name="parent")
-        assert_not_shared(cli, share, base_project, "base-element.bst", project_name="base")
+        assert_shared(cli, share, base_project, "base-element.bst", project_name="base")
 
         # In the junction project's cache
         assert_not_shared(cli, base_share, project, "target.bst", project_name="parent")


### PR DESCRIPTION
This makes a junction use the artifact cache of the parent project before the ones defined for the junction

This was originally done in 24c0de16faec2b8b9bd6a03504ce951dc49afbe2, but regressed at some point

Fixes https://github.com/apache/buildstream/issues/1839