### PR TITLE
ci: Run tests on Fedora 40 and Debian 11

### DIFF
--- a/.github/common.env
+++ b/.github/common.env
@@ -1,6 +1,6 @@
 # Shared common variables
 
-CI_IMAGE_VERSION=master-1361451963
+CI_IMAGE_VERSION=master-1408971201
 CI_TOXENV_MAIN=py38,py39,py310,py311,py312
 CI_TOXENV_PLUGINS=py38-plugins,py39-plugins,py310-plugins,py311-plugins,py312-plugins
 CI_TOXENV_ALL="${CI_TOXENV_MAIN},${CI_TOXENV_PLUGINS}"

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 
 x-tests-template: &tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:39-${CI_IMAGE_VERSION:-latest}
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:40-${CI_IMAGE_VERSION:-latest}
     command: tox -vvvvv -- --color=yes --integration
     environment:
       TOXENV: ${CI_TOXENV_ALL}
@@ -22,13 +22,9 @@ x-tests-template: &tests-template
 
 services:
 
-  fedora-38:
+  fedora-40:
     <<: *tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:38-${CI_IMAGE_VERSION:-latest}
-
-  fedora-39:
-    <<: *tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:39-${CI_IMAGE_VERSION:-latest}
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:40-${CI_IMAGE_VERSION:-latest}
 
   ubuntu-20.04:
     <<: *tests-template

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -22,6 +22,10 @@ x-tests-template: &tests-template
 
 services:
 
+  debian-11:
+    <<: *tests-template
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-debian:11-${CI_IMAGE_VERSION:-latest}
+
   fedora-40:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:40-${CI_IMAGE_VERSION:-latest}

--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -102,7 +102,7 @@ function runServiceTest() {
 
 
 if [ -z "${test_names}" ]; then
-    for test_name in mypy fedora-38 fedora-39 fedora-missing-deps ubuntu-20.04; do
+    for test_name in mypy fedora-40 fedora-missing-deps ubuntu-20.04; do
 	if ! runTest "${test_name}"; then
 	    echo "Tests failed"
 	    exit 1

--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -102,7 +102,7 @@ function runServiceTest() {
 
 
 if [ -z "${test_names}" ]; then
-    for test_name in mypy fedora-40 fedora-missing-deps ubuntu-20.04; do
+    for test_name in mypy debian-11 fedora-40 fedora-missing-deps ubuntu-20.04; do
 	if ! runTest "${test_name}"; then
 	    echo "Tests failed"
 	    exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         # The names here should map to a valid service defined in
         # "../compose/ci.docker-compose.yml"
         test-name:
+          - debian-11
           - fedora-40
           - fedora-missing-deps
           - ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,7 @@ jobs:
         # The names here should map to a valid service defined in
         # "../compose/ci.docker-compose.yml"
         test-name:
-          - fedora-38
-          - fedora-39
+          - fedora-40
           - fedora-missing-deps
           - ubuntu-20.04
           - lint


### PR DESCRIPTION
Fedora 40 is the current stable release of Fedora. Debian 11 uses Python 3.9, which is not covered by any other CI images.