### PR TITLE
Expand cache config options and improve defaults

### DIFF
--- a/doc/source/using_config.rst
+++ b/doc/source/using_config.rst
@@ -130,8 +130,8 @@ toplevel of your configuration file, like so:
      # Keep 5% of disk space available
      reserved-disk-space: 5%
 
-     # Retain 50% of the cache on cleanup
-     low-watermark: 50%
+     # Retain 80% of the cache on cleanup
+     low-watermark: 80%
 
      # Avoid pulling large amounts of data we don't need locally
      pull-buildtrees: False
@@ -205,7 +205,7 @@ Attributes
 
   ``low-watermark`` is specified as a percentage of the effective cache quota
   as configured by ``quota`` and/or ``reserved-disk-space``. The default is
-  ``50%``, which means that when cleanup is triggered, 50% of the cache will
+  ``80%``, which means that when cleanup is triggered, 20% of the cache will
   be pruned by removing CAS objects that haven't been used recently.
 
 * ``pull-buildtrees``

--- a/doc/source/using_config.rst
+++ b/doc/source/using_config.rst
@@ -124,8 +124,11 @@ toplevel of your configuration file, like so:
    #
    cache:
 
-     # Allow using as much free space as possible
+     # Use as much space as possible
      quota: infinity
+
+     # Keep 5% of disk space available
+     reserved-disk-space: 5%
 
      # Avoid pulling large amounts of data we don't need locally
      pull-buildtrees: False
@@ -183,6 +186,15 @@ Attributes
 
     Percentage values are taken to represent a percentage of the partition
     size on the filesystem where the cache has been configured.
+
+* ``reserved-disk-space``
+
+  This controls how much disk space should remain available. If the amount
+  of available disk space falls below the specified value, unused cache
+  objects will be pruned even if the configured quota has not been exceeded.
+
+  ``reserved-disk-space`` can be specified in the same way as ``quota``, with
+  the exception of the special ``infinity`` value. The default is ``5%``.
 
 * ``pull-buildtrees``
 

--- a/doc/source/using_config.rst
+++ b/doc/source/using_config.rst
@@ -130,6 +130,9 @@ toplevel of your configuration file, like so:
      # Keep 5% of disk space available
      reserved-disk-space: 5%
 
+     # Retain 50% of the cache on cleanup
+     low-watermark: 50%
+
      # Avoid pulling large amounts of data we don't need locally
      pull-buildtrees: False
 
@@ -195,6 +198,15 @@ Attributes
 
   ``reserved-disk-space`` can be specified in the same way as ``quota``, with
   the exception of the special ``infinity`` value. The default is ``5%``.
+
+* ``low-watermark``
+
+  This controls how much of the cache should be retained on cleanup.
+
+  ``low-watermark`` is specified as a percentage of the effective cache quota
+  as configured by ``quota`` and/or ``reserved-disk-space``. The default is
+  ``50%``, which means that when cleanup is triggered, 50% of the cache will
+  be pruned by removing CAS objects that haven't been used recently.
 
 * ``pull-buildtrees``
 

--- a/src/buildstream/_cas/casdprocessmanager.py
+++ b/src/buildstream/_cas/casdprocessmanager.py
@@ -58,12 +58,24 @@ _REQUIRED_CASD_MICRO = 58
 #     log_dir (str): The directory for the logs
 #     log_level (LogLevel): Log level to give to buildbox-casd for logging
 #     cache_quota (int): User configured cache quota
+#     reserved (int): User configured reserved disk space
 #     remote_cache_spec (RemoteSpec): Optional remote cache server
 #     protect_session_blobs (bool): Disable expiry for blobs used in the current session
 #     messenger (Messenger): The messenger to report warnings through the UI
 #
 class CASDProcessManager:
-    def __init__(self, path, log_dir, log_level, cache_quota, remote_cache_spec, protect_session_blobs, messenger):
+    def __init__(
+        self,
+        path,
+        log_dir,
+        log_level,
+        cache_quota,
+        remote_cache_spec,
+        protect_session_blobs,
+        messenger,
+        *,
+        reserved=None
+    ):
         os.makedirs(path, exist_ok=True)
 
         self._log_dir = log_dir
@@ -81,6 +93,9 @@ class CASDProcessManager:
         if cache_quota is not None:
             casd_args.append("--quota-high={}".format(int(cache_quota)))
             casd_args.append("--quota-low={}".format(int(cache_quota / 2)))
+
+        if reserved is not None:
+            casd_args.append("--reserved={}".format(int(reserved)))
 
         if protect_session_blobs:
             casd_args.append("--protect-session-blobs")

--- a/src/buildstream/_cas/casdprocessmanager.py
+++ b/src/buildstream/_cas/casdprocessmanager.py
@@ -74,7 +74,8 @@ class CASDProcessManager:
         protect_session_blobs,
         messenger,
         *,
-        reserved=None
+        reserved=None,
+        low_watermark=None
     ):
         os.makedirs(path, exist_ok=True)
 
@@ -92,7 +93,9 @@ class CASDProcessManager:
 
         if cache_quota is not None:
             casd_args.append("--quota-high={}".format(int(cache_quota)))
-            casd_args.append("--quota-low={}".format(int(cache_quota / 2)))
+
+        if low_watermark is not None:
+            casd_args.append("--quota-low={}%".format(int(low_watermark * 100)))
 
         if reserved is not None:
             casd_args.append("--reserved={}".format(int(reserved)))

--- a/src/buildstream/_context.py
+++ b/src/buildstream/_context.py
@@ -188,6 +188,9 @@ class Context:
         # Reserved disk space for local cache in bytes
         self.config_cache_reserved: Optional[int] = None
 
+        # Low watermark for local cache (ratio relative to effective quota)
+        self.config_cache_low_watermark: Optional[float] = None
+
         # Remote cache server
         self.remote_cache_spec: Optional[RemoteSpec] = None
 
@@ -365,7 +368,9 @@ class Context:
         # We need to find the first existing directory in the path of our
         # casdir - the casdir may not have been created yet.
         cache = defaults.get_mapping("cache")
-        cache.validate_keys(["quota", "reserved-disk-space", "storage-service", "pull-buildtrees", "cache-buildtrees"])
+        cache.validate_keys(
+            ["quota", "reserved-disk-space", "low-watermark", "storage-service", "pull-buildtrees", "cache-buildtrees"]
+        )
 
         cas_volume = self.casdir
         while not os.path.exists(cas_volume):
@@ -395,6 +400,15 @@ class Context:
             raise LoadError(
                 "{}\nPlease specify the value in bytes or as a % of full disk space.\n"
                 "\nValid values are, for example: 2G 5%\n".format(str(e)),
+                LoadErrorReason.INVALID_DATA,
+            ) from e
+
+        low_watermark_string = cache.get_str("low-watermark")
+        try:
+            self.config_cache_low_watermark = utils._parse_percentage(low_watermark_string)
+        except utils.UtilError as e:
+            raise LoadError(
+                "{}\nPlease specify the value as a % of the cache quota.".format(str(e)),
                 LoadErrorReason.INVALID_DATA,
             ) from e
 
@@ -722,6 +736,7 @@ class Context:
                 protect_session_blobs=True,
                 messenger=self.messenger,
                 reserved=self.config_cache_reserved,
+                low_watermark=self.config_cache_low_watermark,
             )
         return self._casd
 

--- a/src/buildstream/data/userconfig.yaml
+++ b/src/buildstream/data/userconfig.yaml
@@ -38,6 +38,9 @@ cache:
   # Use as much space as possible
   quota: infinity
 
+  # Keep 5% of disk space available
+  reserved-disk-space: 5%
+
   # Whether to pull build trees when downloading element artifacts
   pull-buildtrees: False
 

--- a/src/buildstream/data/userconfig.yaml
+++ b/src/buildstream/data/userconfig.yaml
@@ -41,8 +41,8 @@ cache:
   # Keep 5% of disk space available
   reserved-disk-space: 5%
 
-  # Retain 50% of the cache on cleanup
-  low-watermark: 50%
+  # Retain 80% of the cache on cleanup
+  low-watermark: 80%
 
   # Whether to pull build trees when downloading element artifacts
   pull-buildtrees: False

--- a/src/buildstream/data/userconfig.yaml
+++ b/src/buildstream/data/userconfig.yaml
@@ -41,6 +41,9 @@ cache:
   # Keep 5% of disk space available
   reserved-disk-space: 5%
 
+  # Retain 50% of the cache on cleanup
+  low-watermark: 50%
+
   # Whether to pull build trees when downloading element artifacts
   pull-buildtrees: False
 

--- a/src/buildstream/utils.py
+++ b/src/buildstream/utils.py
@@ -832,6 +832,35 @@ def _parse_size(size, volume):
     return int(num) * 1024 ** units.index(unit)
 
 
+# _parse_percentage():
+#
+# Convert a string representing a percentage between 0% and 100% to a float.
+# E.g. "80%" -> 0.8.
+#
+# Arguments:
+#     percentage (str) The string to parse
+#
+# Returns:
+#     (float) The percentage as a float
+#
+# Raises:
+#     UtilError if the string is not a valid percentage.
+#
+def _parse_percentage(percentage):
+    if not percentage.endswith("%"):
+        raise UtilError("{} is not a valid percentage.".format(percentage))
+
+    try:
+        num = float(percentage[:-1])
+    except ValueError:
+        raise UtilError("{} is not a valid percentage.".format(percentage))
+
+    if num < 0 or num > 100:
+        raise UtilError("{} is not between 0% and 100%.".format(percentage))
+
+    return num / 100
+
+
 # _pretty_size()
 #
 # Converts a number of bytes into a string representation in KiB, MiB, GiB, TiB

--- a/tests/artifactcache/expiry.py
+++ b/tests/artifactcache/expiry.py
@@ -136,7 +136,7 @@ def test_expiry_order(cli, datafiles):
     element_path = "elements"
     checkout = os.path.join(project, "workspace")
 
-    cli.configure({"cache": {"quota": 9000000}})
+    cli.configure({"cache": {"quota": 9000000, "low-watermark": "50%"}})
 
     # Create an artifact
     create_element_size("dep.bst", project, element_path, [], 2000000)


### PR DESCRIPTION
* Add `reserved-disk-space` config option to the `cache` section
    BuildStream has been relying on buildbox-casd's default for this, which is currently set at 2 GB. This adds a config option and sets the default to 5% of the size of the filesystem as it doesn't seem reasonable to fill up the filesystem more than 95% by default.
* Add `low-watermark` config option to the `cache` section
    BuildStream currently uses a hard-coded value of 50% for the low watermark. This adds a config option but doesn't change the default. This requires [buildbox-casd 1.2.17+](https://gitlab.com/BuildGrid/buildbox/buildbox/-/merge_requests/669) to be effective. Older versions of buildbox-casd will continue to use 50% as low watermark.
* Change the default `low-watermark` of the cache from 50% to 80%
    Pruning half the cache when hitting the cache quota seems excessive as a default value, resulting in a lower cache hit rate.