### PR TITLE
fix link to docker install instructions

### DIFF
--- a/doc/source/additional_docker.rst
+++ b/doc/source/additional_docker.rst
@@ -23,7 +23,7 @@ which these integrations work.
 
 Run BuildStream inside Docker
 -----------------------------
-Refer to the `BuildStream inside Docker <https://buildstream.build/docker_install.html>`_
+Refer to the `BuildStream inside Docker <https://buildstream.build/install.html#container-images>`_
 documentation for instructions on how to run BuildStream as a Docker container.
 
 


### PR DESCRIPTION
Hopefully https://buildstream.build/install.html#container-images is the best place to point to. The previous link gives 404