### PR TITLE
Fix `bst artifact list-content --long` with symlinks 

### DIFF
--- a/src/buildstream/_frontend/widget.py
+++ b/src/buildstream/_frontend/widget.py
@@ -1040,7 +1040,7 @@ class LogLine(Widget):
                     + "{}".format(filename)
                 )
             elif filestat.file_type == FileType.SYMLINK:
-                target = directory.readlink(*filename.split(os.path.sep))
+                target = directory.readlink(filename)
                 return (
                     "lrwxrwxrwx  link   {}".format(size)
                     + "{} ".format(" " * (max_v_len - len(size)))

--- a/tests/frontend/artifact_list_contents/elements/import-bin.bst
+++ b/tests/frontend/artifact_list_contents/elements/import-bin.bst
@@ -1,0 +1,4 @@
+kind: import
+sources:
+- kind: local
+  path: files/bin-files

--- a/tests/frontend/artifact_list_contents/elements/import-links.bst
+++ b/tests/frontend/artifact_list_contents/elements/import-links.bst
@@ -1,0 +1,4 @@
+kind: import
+sources:
+- kind: local
+  path: files/files-and-links

--- a/tests/frontend/artifact_list_contents/elements/target.bst
+++ b/tests/frontend/artifact_list_contents/elements/target.bst
@@ -1,0 +1,8 @@
+kind: stack
+description: |
+
+  Main stack target for the bst build test
+
+depends:
+- import-bin.bst
+- import-links.bst

--- a/tests/frontend/artifact_list_contents/files/bin-files/usr/bin/hello
+++ b/tests/frontend/artifact_list_contents/files/bin-files/usr/bin/hello
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "Hello !"

--- a/tests/frontend/artifact_list_contents/files/files-and-links/basicfile
+++ b/tests/frontend/artifact_list_contents/files/files-and-links/basicfile
@@ -1,0 +1,1 @@
+file contents

--- a/tests/frontend/artifact_list_contents/project.conf
+++ b/tests/frontend/artifact_list_contents/project.conf
@@ -1,0 +1,10 @@
+# Project config for frontend build test
+name: test
+min-version: 2.0
+element-path: elements
+
+plugins:
+- origin: pip
+  package-name: sample-plugins
+  sources:
+  - git


### PR DESCRIPTION
The `bst artifact list-contents` command has been broken for a long time when inspecting artifacts which contain symlinks and given the `--long` option, resulting in a BUG message and stack trace.
