### PR TITLE
sandbox: request remote execution output as a directory digest

### DIFF
--- a/src/buildstream/_artifactcache.py
+++ b/src/buildstream/_artifactcache.py
@@ -464,13 +464,13 @@ class ArtifactCache(AssetCache):
                 f.write(artifact.SerializeToString())
 
             if str(artifact.files):
-                self.cas._fetch_directory(remote, artifact.files)
+                self.cas.fetch_directory(remote, artifact.files)
 
             if pull_buildtrees:
                 if str(artifact.buildtree):
-                    self.cas._fetch_directory(remote, artifact.buildtree)
+                    self.cas.fetch_directory(remote, artifact.buildtree)
                 if str(artifact.buildroot):
-                    self.cas._fetch_directory(remote, artifact.buildroot)
+                    self.cas.fetch_directory(remote, artifact.buildroot)
 
             digests = [artifact.low_diversity_meta, artifact.high_diversity_meta]
             if str(artifact.public_data):

--- a/src/buildstream/_elementsourcescache.py
+++ b/src/buildstream/_elementsourcescache.py
@@ -295,7 +295,7 @@ class ElementSourcesCache(AssetCache):
             with utils.save_file_atomic(source_path, mode="wb") as f:
                 f.write(source.SerializeToString())
 
-            self.cas._fetch_directory(remote, source.files)
+            self.cas.fetch_directory(remote, source.files)
         except BlobNotFound:
             return False
         except CASRemoteError as e:

--- a/src/buildstream/_sourcecache.py
+++ b/src/buildstream/_sourcecache.py
@@ -131,7 +131,7 @@ class SourceCache(AssetCache):
 
             try:
                 # Fetch source blobs
-                self.cas._fetch_directory(remote, source_digest)
+                self.cas.fetch_directory(remote, source_digest)
 
                 source.info("Pulled source {} <- {}".format(display_key, remote))
                 return True


### PR DESCRIPTION
This gives us an output that is easier to manipulate given we're using buildbox-casd, and allows to avoid a whole class of bugs such as #1842 and #1961

The old code for handling the output as a Tree is kept for now as the remote execution spec recommends using it as a fallback