### PR TITLE
_stream: Only query cache for the requested elements

### DIFF
--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -649,7 +649,7 @@ def show(app, elements, deps, except_, order, format_):
 
         # Don't spend time interrogating the cache if we don't need to show element state
         if need_state:
-            app.stream.query_cache(dependencies)
+            app.stream.query_cache(dependencies, need_state=True)
 
         if order == "alpha":
             dependencies = sorted(dependencies)

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -190,13 +190,16 @@ class Stream:
     #    sources_of_cached_elements (bool): True to query the source cache for elements with a cached artifact
     #    only_sources (bool): True to only query the source cache
     #
-    def query_cache(self, elements, *, sources_of_cached_elements=False, only_sources=False):
+    def query_cache(self, elements, *, sources_of_cached_elements=False, only_sources=False, need_state=False):
         # It doesn't make sense to combine these flags
         assert not sources_of_cached_elements or not only_sources
 
         with self._context.messenger.simple_task("Query cache", silent_nested=True) as task:
-            # Enqueue complete build plan as this is required to determine `buildable` status.
-            plan = list(_pipeline.dependencies(elements, _Scope.ALL))
+            if need_state:
+                # Enqueue complete build plan as this is required to determine `buildable` status.
+                plan = list(_pipeline.dependencies(elements, _Scope.ALL))
+            else:
+                plan = elements
 
             if self._context.remote_cache_spec:
                 # Parallelize cache queries if a remote cache is configured


### PR DESCRIPTION
query_cache() used to query the cache for the elements passed and all their (build and runtime) dependencies. This is wasteful since most of the time, we don't need all this cache querying. And for the cases we need, it is the job of the query_cache() caller to include the dependencies they need.

As it turns out, this is only needed by `bst show` to be able to figure out the cache key in all circumsances.

This commit makes this behaviour optional, and only enables it from `bst show`.
