### PR TITLE
cascache.py: Use `UploadTree` with `storage-service`, if available

### DIFF
--- a/src/buildstream/_artifact.py
+++ b/src/buildstream/_artifact.py
@@ -339,7 +339,7 @@ class Artifact:
 
         buildroot_digest = self._get_field_digest("buildroot")
         if buildroot_digest:
-            return self._cas.contains_directory(buildroot_digest, with_files=True)
+            return self._cas.contains_directory(buildroot_digest)
         else:
             return False
 
@@ -371,7 +371,7 @@ class Artifact:
 
         buildtree_digest = self._get_field_digest("buildtree")
         if buildtree_digest:
-            return self._cas.contains_directory(buildtree_digest, with_files=True)
+            return self._cas.contains_directory(buildtree_digest)
         else:
             return False
 
@@ -400,7 +400,7 @@ class Artifact:
 
         sources_digest = self._get_field_digest("sources")
         if sources_digest:
-            return self._cas.contains_directory(sources_digest, with_files=True)
+            return self._cas.contains_directory(sources_digest)
         else:
             return False
 
@@ -602,7 +602,7 @@ class Artifact:
             return False
 
         # Check whether 'files' subdirectory is available, with or without file contents
-        if str(artifact.files) and not self._cas.contains_directory(artifact.files, with_files=True):
+        if str(artifact.files) and not self._cas.contains_directory(artifact.files):
             self._cached = False
             return False
 

--- a/src/buildstream/_cas/cascache.py
+++ b/src/buildstream/_cas/cascache.py
@@ -124,16 +124,15 @@ class CASCache:
 
     # contains_directory():
     #
-    # Check whether the specified directory and subdirectories are in the cache,
-    # i.e non dangling.
+    # Check whether the specified directory, subdirectories and files are in the
+    # cache, i.e non dangling.
     #
     # Args:
     #     digest (Digest): The directory digest to check
-    #     with_files (bool): Whether to check files as well
     #
     # Returns: True if the directory is available in the local cache
     #
-    def contains_directory(self, digest, *, with_files):
+    def contains_directory(self, digest):
         local_cas = self.get_local_cas()
 
         # Without a remote cache, `FetchTree` simply checks the local cache.
@@ -141,7 +140,7 @@ class CASCache:
         request.root_digest.CopyFrom(digest)
         # Always fetch Directory protos as they are needed to enumerate subdirectories and files.
         # Don't implicitly fetch file blobs from the remote cache as we don't need them.
-        request.fetch_file_blobs = with_files and not self._remote_cache
+        request.fetch_file_blobs = not self._remote_cache
 
         try:
             local_cas.FetchTree(request)

--- a/src/buildstream/_elementsources.py
+++ b/src/buildstream/_elementsources.py
@@ -308,7 +308,7 @@ class ElementSources:
             self._cached = False
             return False
 
-        if not cas.contains_directory(source_proto.files, with_files=True):
+        if not cas.contains_directory(source_proto.files):
             self._cached = False
             return False
 

--- a/src/buildstream/_sourcecache.py
+++ b/src/buildstream/_sourcecache.py
@@ -58,7 +58,7 @@ class SourceCache(AssetCache):
 
         # check files
         source_proto = self._get_source(ref)
-        return self.cas.contains_directory(source_proto.files, with_files=True)
+        return self.cas.contains_directory(source_proto.files)
 
     # commit()
     #


### PR DESCRIPTION
Cache query is currently relatively slow when `storage-service` is enabled as the tree traversals are handled by Python code. Calling `UploadTree` moves that logic to buildbox-casd, which is significantly faster.

In local tests I've seen a 2-4x improvement of the cache query speed.

The corresponding buildbox-casd change is pending in https://gitlab.com/BuildGrid/buildbox/buildbox/-/merge_requests/757. The current code is kept as fallback path, i.e., current/older versions of buildbox-casd continue to be supported, without the optimization.