### PR TITLE
tests/testutils/casd.py: Set cache quota

### DIFF
--- a/tests/testutils/casd.py
+++ b/tests/testutils/casd.py
@@ -20,7 +20,13 @@ from buildstream._cas import CASCache, CASDProcessManager, CASLogLevel
 @contextmanager
 def casd_cache(path, messenger=None):
     casd = CASDProcessManager(
-        str(path), os.path.join(str(path), "..", "logs", "_casd"), CASLogLevel.WARNING, None, None, True, None
+        str(path),
+        os.path.join(str(path), "..", "logs", "_casd"),
+        CASLogLevel.WARNING,
+        16 * 1024 * 1024,
+        None,
+        True,
+        None,
     )
     try:
         cascache = CASCache(str(path), casd=casd)


### PR DESCRIPTION
This fixes `test_cache_usage_monitor` with recent versions of buildbox-casd that no longer track the disk usage of blobs if no absolute quota is configured.

https://gitlab.com/BuildGrid/buildbox/buildbox/-/merge_requests/670

Example of test failure: https://gitlab.com/BuildStream/buildstream-docker-images/-/jobs/8443036863