### PR TITLE
Update Buildbarn docker images

### DIFF
--- a/.github/compose/buildbarn-config/asset.jsonnet
+++ b/.github/compose/buildbarn-config/asset.jsonnet
@@ -1,32 +1,49 @@
 {
-  fetcher: {
-    caching: {
-      fetcher: {
-        // We should never be fetching anything which is not already returned by the caching fetcher.
-        'error': {
-          code: 5,
-          message: "Asset Not Found",
-        }
-      }
-    }
-  },
-
-  assetStore: {
-    circular: {
-      directory: '/storage',
-      offsetFileSizeBytes: 1024 * 1024,
-      offsetCacheSize: 1000,
-      dataFileSizeBytes: 100 * 1024 * 1024,
-      dataAllocationChunkSizeBytes: 1048576,
-      instances: [''],
+  contentAddressableStorage: {
+    grpc: {
+      address: 'localhost:7982',
     },
   },
-  httpListenAddress: ':1111',
+  fetcher: {
+    // We should never be fetching anything which is not already returned by the caching fetcher.
+    'error': {
+      code: 5,
+      message: "Asset Not Found",
+    }
+  },
+  assetCache: {
+    blobAccess: {
+      'local': {
+        keyLocationMapOnBlockDevice: {
+          file: {
+            path: '/storage/key_location_map',
+            sizeBytes: 1024 * 1024,
+          },
+        },
+        keyLocationMapMaximumGetAttempts: 8,
+        keyLocationMapMaximumPutAttempts: 32,
+        oldBlocks: 8,
+        currentBlocks: 24,
+        newBlocks: 1,
+        blocksOnBlockDevice: {
+          source: {
+            file: {
+              path: '/storage/blocks',
+              sizeBytes: 100 * 1024 * 1024,
+            },
+          },
+          spareBlocks: 3,
+        },
+      },
+    },
+  },
   grpcServers: [{
     listenAddresses: [':7981'],
     authenticationPolicy: { allow: {} },
   }],
   allowUpdatesForInstances: [''],
   maximumMessageSizeBytes: 16 * 1024 * 1024,
+  fetchAuthorizer: { allow: {} },
+  pushAuthorizer: { allow: {} },
 }
 

--- a/.github/compose/buildbarn-config/storage.jsonnet
+++ b/.github/compose/buildbarn-config/storage.jsonnet
@@ -1,26 +1,42 @@
 {
-  blobstore: {
-    contentAddressableStorage: {
-      circular: {
-        directory: '/cas',
-        offsetFileSizeBytes: 16 * 1024 * 1024,
-        offsetCacheSize: 10000,
-        dataFileSizeBytes: 10 * 1024 * 1024 * 1024,
-        dataAllocationChunkSizeBytes: 16 * 1024 * 1024,
+  contentAddressableStorage: {
+    backend: {
+      'local': {
+        keyLocationMapOnBlockDevice: {
+          file: {
+            path: '/cas/key_location_map',
+            sizeBytes: 16 * 1024 * 1024,
+          },
+        },
+        keyLocationMapMaximumGetAttempts: 16,
+        keyLocationMapMaximumPutAttempts: 64,
+        oldBlocks: 8,
+        currentBlocks: 24,
+        newBlocks: 3,
+        blocksOnBlockDevice: {
+          source: {
+            file: {
+              path: '/cas/blocks',
+              sizeBytes: 10 * 1024 * 1024 * 1024,
+            },
+          },
+          spareBlocks: 3,
+        },
       },
     },
-    actionCache: {
-      'error': {
-          code: 12, # UNIMPLEMENTED
-          message: "AC requests are not supported for this endpoint.",
-        }
-    },
+    getAuthorizer: { allow: {} },
+    putAuthorizer: { allow: {} },
+    findMissingAuthorizer: { allow: {} },
   },
-  httpListenAddress: ':6981',
+  global: { diagnosticsHttpServer: {
+    httpServers: [{
+      listenAddresses: [':6981'],
+      authenticationPolicy: { allow: {} },
+    }],
+  } },
   grpcServers: [{
     listenAddresses: [':7982'],
     authenticationPolicy: { allow: {} },
   }],
-  allowAcUpdatesForInstanceNamePrefixes: [''],
   maximumMessageSizeBytes: 16 * 1024 * 1024,
 }

--- a/.github/compose/ci.buildbarn.yml
+++ b/.github/compose/ci.buildbarn.yml
@@ -19,11 +19,9 @@
 #  - docker-compose -f ci.buildbarn.yml up
 #  - docker-compose -f ci.buildbarn.yml down
 
-version: '3.4'
-
 services:
   bb-asset:
-    image: buildbarn/bb-remote-asset:20200903T103837Z-90136c4
+    image: ghcr.io/buildbarn/bb-remote-asset:20241031T230517Z-4926e8e
     command: /config/asset.jsonnet
     restart: unless-stopped
     ports:
@@ -37,7 +35,7 @@ services:
       target: /config
 
   bb-storage:
-    image: buildbarn/bb-storage:20200816T115912Z-d83e1f0
+    image: ghcr.io/buildbarn/bb-storage:20241121T154059Z-f5a181e
     command: /config/storage.jsonnet
     restart: unless-stopped
     ports:


### PR DESCRIPTION
The old docker images are no longer available. The configuration is updated to work with the new version.