### PR TITLE
Update default min-version for bst init to 2.4

### DIFF
--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -409,7 +409,7 @@ def help_command(ctx, command):
 @click.option(
     "--min-version",
     type=click.STRING,
-    default="2.3",
+    default="2.4",
     show_default=True,
     help="The required format version",
 )


### PR DESCRIPTION
A test fails without this now that the first 2.4 tag has been created:

```FAILED tests/frontend/init.py::test_defaults - AssertionError: assert '2.3' == '2.4'```