### PR TITLE
buildelement: Add the digest-environment config property

### DIFF
--- a/src/buildstream/sandbox/_sandboxremote.py
+++ b/src/buildstream/sandbox/_sandboxremote.py
@@ -261,9 +261,17 @@ class SandboxRemote(SandboxREAPI):
                 "Uploading input root", element_name=self._get_element_name()
             ):
                 # Determine blobs missing on remote
+                root_digests = [action.input_root_digest]
+
+                # Add virtual directories for subsandboxes
+                for subsandbox in self._get_subsandboxes():
+                    vdir = subsandbox.get_virtual_directory()
+                    root_digests.append(vdir._get_digest())
+
+                missing_blobs = []
                 try:
-                    input_root_digest = action.input_root_digest
-                    missing_blobs = list(cascache.missing_blobs_for_directory(input_root_digest, remote=casremote))
+                    for root_digest in root_digests:
+                        missing_blobs.extend(cascache.missing_blobs_for_directory(root_digest, remote=casremote))
                 except grpc.RpcError as e:
                     raise SandboxError("Failed to determine missing blobs: {}".format(e)) from e
 

--- a/src/buildstream/sandbox/sandbox.py
+++ b/src/buildstream/sandbox/sandbox.py
@@ -85,13 +85,18 @@ class Sandbox:
         self.__env = None  # type: Optional[Dict[str, str]]
         self.__mount_sources = {}  # type: Dict[str, str]
         self.__allow_run = True
+        self.__subsandboxes = []
 
         # Plugin element full name for logging
         plugin = kwargs.get("plugin", None)
         if plugin:
             self.__element_name = plugin._get_full_name()
         else:
-            self.__element_name = None
+            parent = kwargs.get("parent", None)
+            if parent:
+                self.__element_name = parent._get_element_name()
+            else:
+                self.__element_name = None
 
         # Configuration from kwargs common to all subclasses
         self.__config = kwargs["config"]
@@ -263,6 +268,24 @@ class Sandbox:
                 self.__batch = None
 
             batch.execute()
+
+    def create_subsandbox(self, **kwargs):
+        """Create an empty sandbox
+
+        This allows an element to use a secondary sandbox for manipulating artifacts
+        that does not affect the build sandbox
+        """
+
+        sub = Sandbox(
+            self.__context,
+            self.__project,
+            parent=self,
+            stdout=self.__stdout,
+            stderr=self.__stderr,
+            config=self.__config,
+        )
+        self.__subsandboxes.append(sub)
+        return sub
 
     #####################################################
     #    Abstract Methods for Sandbox implementations   #
@@ -564,6 +587,9 @@ class Sandbox:
     #
     def _disable_run(self):
         self.__allow_run = False
+
+    def _get_subsandboxes(self):
+        return self.__subsandboxes
 
 
 # SandboxFlags()


### PR DESCRIPTION
This allows setting an environment variable inside the sandbox to the CAS
digest of one or more dependencies.

Fixes https://github.com/apache/buildstream/issues/1984