### PR TITLE
Add new abstract methods for reporting source provenance

### DIFF
--- a/doc/source/hacking/writing_documentation.rst
+++ b/doc/source/hacking/writing_documentation.rst
@@ -112,9 +112,11 @@ into the ``setup.py``, as such, whenever the frontend command line
 interface changes, the static man pages should be regenerated and
 committed with that.
 
-To do this, run the following from the the toplevel directory of BuildStream::
+To do this, make sure you know the version you are generating the docs
+for, which should usually be the *next* ``major.minor`` version of BuildStream,
+and then run the following from the the toplevel directory of BuildStream::
 
-  tox -e man
+  tox -e man -- <version>
 
 And commit the result, ensuring that you have added anything in
 the ``man/`` subdirectory, which will be automatically included

--- a/man/bst-artifact-checkout.1
+++ b/man/bst-artifact-checkout.1
@@ -1,4 +1,4 @@
-.TH "BST ARTIFACT CHECKOUT" "1" "2024-08-08" "" "bst artifact checkout Manual"
+.TH "BST ARTIFACT CHECKOUT" "1" "2025-04-24" "2.5" "bst artifact checkout Manual"
 .SH NAME
 bst\-artifact\-checkout \- Checkout contents of an artifact
 .SH SYNOPSIS
@@ -7,9 +7,9 @@ bst\-artifact\-checkout \- Checkout contents of an artifact
 .SH DESCRIPTION
 Checkout contents of an artifact
 .PP
-    When this command is executed from a workspace directory, the default
-    is to checkout the artifact of the workspace element.
-    
+When this command is executed from a workspace directory, the default
+is to checkout the artifact of the workspace element.
+.PP
 .SH OPTIONS
 .TP
 \fB\-f,\fP \-\-force

--- a/man/bst-artifact-delete.1
+++ b/man/bst-artifact-delete.1
@@ -1,4 +1,4 @@
-.TH "BST ARTIFACT DELETE" "1" "2024-08-08" "" "bst artifact delete Manual"
+.TH "BST ARTIFACT DELETE" "1" "2025-04-24" "2.5" "bst artifact delete Manual"
 .SH NAME
 bst\-artifact\-delete \- Remove artifacts from the local cache
 .SH SYNOPSIS

--- a/man/bst-artifact-list-contents.1
+++ b/man/bst-artifact-list-contents.1
@@ -1,4 +1,4 @@
-.TH "BST ARTIFACT LIST-CONTENTS" "1" "2024-08-08" "" "bst artifact list-contents Manual"
+.TH "BST ARTIFACT LIST-CONTENTS" "1" "2025-04-24" "2.5" "bst artifact list-contents Manual"
 .SH NAME
 bst\-artifact\-list-contents \- List the contents of an artifact
 .SH SYNOPSIS
@@ -7,9 +7,9 @@ bst\-artifact\-list-contents \- List the contents of an artifact
 .SH DESCRIPTION
 List the contents of an artifact.
 .PP
-    Note that 'artifacts' can be element names, which must end in '.bst',
-    or artifact references, which must be in the format `<project_name>/<element>/<key>`.
-    
+Note that 'artifacts' can be element names, which must end in '.bst',
+or artifact references, which must be in the format `<project_name>/<element>/<key>`.
+.PP
 .SH OPTIONS
 .TP
 \fB\-l,\fP \-\-long

--- a/man/bst-artifact-log.1
+++ b/man/bst-artifact-log.1
@@ -1,4 +1,4 @@
-.TH "BST ARTIFACT LOG" "1" "2024-08-08" "" "bst artifact log Manual"
+.TH "BST ARTIFACT LOG" "1" "2025-04-24" "2.5" "bst artifact log Manual"
 .SH NAME
 bst\-artifact\-log \- Show logs of artifacts
 .SH SYNOPSIS

--- a/man/bst-artifact-pull.1
+++ b/man/bst-artifact-pull.1
@@ -1,4 +1,4 @@
-.TH "BST ARTIFACT PULL" "1" "2024-08-08" "" "bst artifact pull Manual"
+.TH "BST ARTIFACT PULL" "1" "2025-04-24" "2.5" "bst artifact pull Manual"
 .SH NAME
 bst\-artifact\-pull \- Pull a built artifact
 .SH SYNOPSIS
@@ -7,25 +7,25 @@ bst\-artifact\-pull \- Pull a built artifact
 .SH DESCRIPTION
 Pull a built artifact from the configured remote artifact cache.
 .PP
-    Specifying no elements will result in pulling the default targets
-    of the project. If no default targets are configured, all project
-    elements will be pulled.
+Specifying no elements will result in pulling the default targets
+of the project. If no default targets are configured, all project
+elements will be pulled.
 .PP
-    When this command is executed from a workspace directory, the default
-    is to pull the workspace element.
+When this command is executed from a workspace directory, the default
+is to pull the workspace element.
 .PP
-    By default the artifact will be pulled one of the configured caches
-    if possible, following the usual priority order. If the `--artifact-remote`
-    flag is given, only the specified cache will be queried.
+By default the artifact will be pulled one of the configured caches
+if possible, following the usual priority order. If the `--artifact-remote`
+flag is given, only the specified cache will be queried.
 .PP
-    Specify `--deps` to control which artifacts to pull:
+Specify `--deps` to control which artifacts to pull:
 .PP
-    
-        none:  No dependencies, just the element itself
-        run:   Runtime dependencies, including the element itself
-        build: Build time dependencies, excluding the element itself
-        all:   All dependencies
-    
+
+    none:  No dependencies, just the element itself
+    run:   Runtime dependencies, including the element itself
+    build: Build time dependencies, excluding the element itself
+    all:   All dependencies
+.PP
 .SH OPTIONS
 .TP
 \fB\-d,\fP \-\-deps [build|none|run|all]

--- a/man/bst-artifact-push.1
+++ b/man/bst-artifact-push.1
@@ -1,4 +1,4 @@
-.TH "BST ARTIFACT PUSH" "1" "2024-08-08" "" "bst artifact push Manual"
+.TH "BST ARTIFACT PUSH" "1" "2025-04-24" "2.5" "bst artifact push Manual"
 .SH NAME
 bst\-artifact\-push \- Push a built artifact
 .SH SYNOPSIS
@@ -7,25 +7,25 @@ bst\-artifact\-push \- Push a built artifact
 .SH DESCRIPTION
 Push built artifacts to a remote artifact cache, possibly pulling them first.
 .PP
-    Specifying no elements will result in pushing the default targets
-    of the project. If no default targets are configured, all project
-    elements will be pushed.
+Specifying no elements will result in pushing the default targets
+of the project. If no default targets are configured, all project
+elements will be pushed.
 .PP
-    When this command is executed from a workspace directory, the default
-    is to push the workspace element.
+When this command is executed from a workspace directory, the default
+is to push the workspace element.
 .PP
-    If bst has been configured to include build trees on artifact pulls,
-    an attempt will be made to pull any required build trees to avoid the
-    skipping of partial artifacts being pushed.
+If bst has been configured to include build trees on artifact pulls,
+an attempt will be made to pull any required build trees to avoid the
+skipping of partial artifacts being pushed.
 .PP
-    Specify `--deps` to control which artifacts to push:
+Specify `--deps` to control which artifacts to push:
 .PP
-    
-        none:  No dependencies, just the element itself
-        run:   Runtime dependencies, including the element itself
-        build: Build time dependencies, excluding the element itself
-        all:   All dependencies
-    
+
+    none:  No dependencies, just the element itself
+    run:   Runtime dependencies, including the element itself
+    build: Build time dependencies, excluding the element itself
+    all:   All dependencies
+.PP
 .SH OPTIONS
 .TP
 \fB\-d,\fP \-\-deps [build|none|run|all]

--- a/man/bst-artifact-show.1
+++ b/man/bst-artifact-show.1
@@ -1,4 +1,4 @@
-.TH "BST ARTIFACT SHOW" "1" "2024-08-08" "" "bst artifact show Manual"
+.TH "BST ARTIFACT SHOW" "1" "2025-04-24" "2.5" "bst artifact show Manual"
 .SH NAME
 bst\-artifact\-show \- Show the cached state of artifacts
 .SH SYNOPSIS

--- a/man/bst-artifact.1
+++ b/man/bst-artifact.1
@@ -1,4 +1,4 @@
-.TH "BST ARTIFACT" "1" "2024-08-08" "" "bst artifact Manual"
+.TH "BST ARTIFACT" "1" "2025-04-24" "2.5" "bst artifact Manual"
 .SH NAME
 bst\-artifact \- Manipulate cached artifacts.
 .SH SYNOPSIS
@@ -7,34 +7,34 @@ bst\-artifact \- Manipulate cached artifacts.
 .SH DESCRIPTION
 Manipulate cached artifacts
 .PP
-    Some subcommands take artifact references as arguments. Artifacts
-    can be specified in two ways:
+Some subcommands take artifact references as arguments. Artifacts
+can be specified in two ways:
 .PP
-    
-    - artifact refs: triples of the form <project name>/<element name>/<cache key>
-    - element names
+
+- artifact refs: triples of the form <project name>/<element name>/<cache key>
+- element names
 .PP
-    When elements are given, the artifact is looked up by observing the element
-    and it's current cache key.
+When elements are given, the artifact is looked up by observing the element
+and it's current cache key.
 .PP
-    The commands also support shell-style wildcard expansion: `?` matches a
-    single character, `*` matches zero or more characters but does not match the `/`
-    path separator, and `**` matches zero or more characters including `/` path separators.
+The commands also support shell-style wildcard expansion: `?` matches a
+single character, `*` matches zero or more characters but does not match the `/`
+path separator, and `**` matches zero or more characters including `/` path separators.
 .PP
-    If the wildcard expression ends with `.bst`, then it will be used to search
-    element names found in the project, otherwise, it will be used to search artifacts
-    that are present in the local artifact cache.
+If the wildcard expression ends with `.bst`, then it will be used to search
+element names found in the project, otherwise, it will be used to search artifacts
+that are present in the local artifact cache.
 .PP
-    Some example arguments are:
+Some example arguments are:
 .PP
-    
-    - `myproject/hello/8276376b077eda104c812e6ec2f488c7c9eea211ce572c83d734c10bf241209f`
-    - `myproject/he*/827637*`
-    - `core/*.bst` (all elements in the core directory)
-    - `**.bst` (all elements)
-    - `myproject/**` (all artifacts from myproject)
-    - `myproject/myelement/*` (all cached artifacts for a specific element)
-    
+
+- `myproject/hello/8276376b077eda104c812e6ec2f488c7c9eea211ce572c83d734c10bf241209f`
+- `myproject/he*/827637*`
+- `core/*.bst` (all elements in the core directory)
+- `**.bst` (all elements)
+- `myproject/**` (all artifacts from myproject)
+- `myproject/myelement/*` (all cached artifacts for a specific element)
+.PP
 .SH COMMANDS
 .PP
 \fBshow\fP

--- a/man/bst-build.1
+++ b/man/bst-build.1
@@ -1,4 +1,4 @@
-.TH "BST BUILD" "1" "2024-08-08" "" "bst build Manual"
+.TH "BST BUILD" "1" "2025-04-24" "2.5" "bst build Manual"
 .SH NAME
 bst\-build \- Build elements in a pipeline
 .SH SYNOPSIS
@@ -7,23 +7,23 @@ bst\-build \- Build elements in a pipeline
 .SH DESCRIPTION
 Build elements in a pipeline
 .PP
-    Specifying no elements will result in building the default targets
-    of the project. If no default targets are configured, all project
-    elements will be built.
+Specifying no elements will result in building the default targets
+of the project. If no default targets are configured, all project
+elements will be built.
 .PP
-    When this command is executed from a workspace directory, the default
-    is to build the workspace element.
+When this command is executed from a workspace directory, the default
+is to build the workspace element.
 .PP
-    Specify `--deps` to control which dependencies must be built:
+Specify `--deps` to control which dependencies must be built:
 .PP
-    
-        none:  No dependencies, just the element itself
-        build: Build time dependencies, excluding the element itself
-        all:   All dependencies
+
+    none:  No dependencies, just the element itself
+    build: Build time dependencies, excluding the element itself
+    all:   All dependencies
 .PP
-    Dependencies that are consequently required to build the requested
-    elements will be built on demand.
-    
+Dependencies that are consequently required to build the requested
+elements will be built on demand.
+.PP
 .SH OPTIONS
 .TP
 \fB\-d,\fP \-\-deps [none|build|all]

--- a/man/bst-help.1
+++ b/man/bst-help.1
@@ -1,4 +1,4 @@
-.TH "BST HELP" "1" "2024-08-08" "" "bst help Manual"
+.TH "BST HELP" "1" "2025-04-24" "2.5" "bst help Manual"
 .SH NAME
 bst\-help \- Print usage information
 .SH SYNOPSIS

--- a/man/bst-init.1
+++ b/man/bst-init.1
@@ -1,4 +1,4 @@
-.TH "BST INIT" "1" "2024-08-08" "" "bst init Manual"
+.TH "BST INIT" "1" "2025-04-24" "2.5" "bst init Manual"
 .SH NAME
 bst\-init \- Initialize a new BuildStream project
 .SH SYNOPSIS
@@ -7,19 +7,19 @@ bst\-init \- Initialize a new BuildStream project
 .SH DESCRIPTION
 Initialize a new BuildStream project
 .PP
-    Creates a new BuildStream project.conf in the project
-    directory.
+Creates a new BuildStream project.conf in the project
+directory.
 .PP
-    Unless `--project-name` is specified, this will be an
-    interactive session.
-    
+Unless `--project-name` is specified, this will be an
+interactive session.
+.PP
 .SH OPTIONS
 .TP
 \fB\-\-project\-name\fP TEXT
 The project name to use
 .TP
 \fB\-\-min\-version\fP TEXT
-The required format version  [default: 2.3]
+The required format version  [default: 2.4]
 .TP
 \fB\-\-element\-path\fP PATH
 The subdirectory to store elements in  [default: elements]

--- a/man/bst-shell.1
+++ b/man/bst-shell.1
@@ -1,4 +1,4 @@
-.TH "BST SHELL" "1" "2024-08-08" "" "bst shell Manual"
+.TH "BST SHELL" "1" "2025-04-24" "2.5" "bst shell Manual"
 .SH NAME
 bst\-shell \- Shell into an element's sandbox environment
 .SH SYNOPSIS
@@ -7,25 +7,25 @@ bst\-shell \- Shell into an element's sandbox environment
 .SH DESCRIPTION
 Run a command in the target element's sandbox environment
 .PP
-    When this command is executed from a workspace directory, the default
-    is to shell into the workspace element.
+When this command is executed from a workspace directory, the default
+is to shell into the workspace element.
 .PP
-    This will stage a temporary sysroot for running the target
-    element, assuming it has already been built and all required
-    artifacts are in the local cache.
+This will stage a temporary sysroot for running the target
+element, assuming it has already been built and all required
+artifacts are in the local cache.
 .PP
-    Use '--' to separate a command from the options to bst,
-    otherwise bst may respond to them instead. e.g.
+Use '--' to separate a command from the options to bst,
+otherwise bst may respond to them instead. e.g.
 .PP
-    
-        bst shell example.bst -- df -h
+
+    bst shell example.bst -- df -h
 .PP
-    Use the --build option to create a temporary sysroot for
-    building the element instead.
+Use the --build option to create a temporary sysroot for
+building the element instead.
 .PP
-    If no COMMAND is specified, the default is to attempt
-    to run an interactive shell.
-    
+If no COMMAND is specified, the default is to attempt
+to run an interactive shell.
+.PP
 .SH OPTIONS
 .TP
 \fB\-b,\fP \-\-build

--- a/man/bst-show.1
+++ b/man/bst-show.1
@@ -1,4 +1,4 @@
-.TH "BST SHOW" "1" "2024-08-08" "" "bst show Manual"
+.TH "BST SHOW" "1" "2025-04-24" "2.5" "bst show Manual"
 .SH NAME
 bst\-show \- Show elements in the pipeline
 .SH SYNOPSIS
@@ -7,59 +7,60 @@ bst\-show \- Show elements in the pipeline
 .SH DESCRIPTION
 Show elements in the pipeline
 .PP
-    Specifying no elements will result in showing the default targets
-    of the project. If no default targets are configured, all project
-    elements will be shown.
+Specifying no elements will result in showing the default targets
+of the project. If no default targets are configured, all project
+elements will be shown.
 .PP
-    When this command is executed from a workspace directory, the default
-    is to show the workspace element.
+When this command is executed from a workspace directory, the default
+is to show the workspace element.
 .PP
-    By default this will show all of the dependencies of the
-    specified target element.
+By default this will show all of the dependencies of the
+specified target element.
 .PP
-    Specify ``--deps`` to control which elements to show:
+Specify ``--deps`` to control which elements to show:
 .PP
-    
-        none:  No dependencies, just the element itself
-        run:   Runtime dependencies, including the element itself
-        build: Build time dependencies, excluding the element itself
-        all:   All dependencies
+
+    none:  No dependencies, just the element itself
+    run:   Runtime dependencies, including the element itself
+    build: Build time dependencies, excluding the element itself
+    all:   All dependencies
 .PP
-    **FORMAT**
+**FORMAT**
 .PP
-    The ``--format`` option controls what should be printed for each element,
-    the following symbols can be used in the format string:
+The ``--format`` option controls what should be printed for each element,
+the following symbols can be used in the format string:
 .PP
-    
-        %{name}           The element name
-        %{description}    The element description, on a single line (Since: 2.3)
-        %{key}            The abbreviated cache key (if all sources are consistent)
-        %{full-key}       The full cache key (if all sources are consistent)
-        %{state}          cached, buildable, waiting, inconsistent or junction
-        %{config}         The element configuration
-        %{vars}           Variable configuration
-        %{env}            Environment settings
-        %{public}         Public domain data
-        %{workspaced}     If the element is workspaced
-        %{workspace-dirs} A list of workspace directories
-        %{deps}           A list of all dependencies
-        %{build-deps}     A list of build dependencies
-        %{runtime-deps}   A list of runtime dependencies
+
+    %{name}           The element name
+    %{description}    The element description, on a single line (Since: 2.3)
+    %{key}            The abbreviated cache key (if all sources are consistent)
+    %{full-key}       The full cache key (if all sources are consistent)
+    %{state}          cached, buildable, waiting, inconsistent or junction
+    %{config}         The element configuration
+    %{vars}           Variable configuration
+    %{env}            Environment settings
+    %{public}         Public domain data
+    %{workspaced}     If the element is workspaced
+    %{workspace-dirs} A list of workspace directories
+    %{deps}           A list of all dependencies
+    %{build-deps}     A list of build dependencies
+    %{runtime-deps}   A list of runtime dependencies
+    %{source-info}    Source provenance information
 .PP
-    The value of the %{symbol} without the leading '%' character is understood
-    as a pythonic formatting string, so python formatting features apply,
-    example:
+The value of the %{symbol} without the leading '%' character is understood
+as a pythonic formatting string, so python formatting features apply,
+example:
 .PP
-    
-        bst show target.bst --format \
-            'Name: %{name: ^20} Key: %{key: ^8} State: %{state}'
+
+    bst show target.bst --format \
+        'Name: %{name: ^20} Key: %{key: ^8} State: %{state}'
 .PP
-    If you want to use a newline in a format string in bash, use the '$' modifier:
+If you want to use a newline in a format string in bash, use the '$' modifier:
 .PP
-    
-        bst show target.bst --format \
-            $'---------- %{name} ----------\n%{vars}'
-    
+
+    bst show target.bst --format \
+        $'---------- %{name} ----------\n%{vars}'
+.PP
 .SH OPTIONS
 .TP
 \fB\-\-except\fP PATH

--- a/man/bst-source-checkout.1
+++ b/man/bst-source-checkout.1
@@ -1,4 +1,4 @@
-.TH "BST SOURCE CHECKOUT" "1" "2024-08-08" "" "bst source checkout Manual"
+.TH "BST SOURCE CHECKOUT" "1" "2025-04-24" "2.5" "bst source checkout Manual"
 .SH NAME
 bst\-source\-checkout \- Checkout sources of an element
 .SH SYNOPSIS
@@ -7,9 +7,9 @@ bst\-source\-checkout \- Checkout sources of an element
 .SH DESCRIPTION
 Checkout sources of an element to the specified location
 .PP
-    When this command is executed from a workspace directory, the default
-    is to checkout the sources of the workspace element.
-    
+When this command is executed from a workspace directory, the default
+is to checkout the sources of the workspace element.
+.PP
 .SH OPTIONS
 .TP
 \fB\-f,\fP \-\-force

--- a/man/bst-source-fetch.1
+++ b/man/bst-source-fetch.1
@@ -1,4 +1,4 @@
-.TH "BST SOURCE FETCH" "1" "2024-08-08" "" "bst source fetch Manual"
+.TH "BST SOURCE FETCH" "1" "2025-04-24" "2.5" "bst source fetch Manual"
 .SH NAME
 bst\-source\-fetch \- Fetch sources in a pipeline
 .SH SYNOPSIS
@@ -7,24 +7,24 @@ bst\-source\-fetch \- Fetch sources in a pipeline
 .SH DESCRIPTION
 Fetch sources required to build the pipeline
 .PP
-    Specifying no elements will result in fetching the default targets
-    of the project. If no default targets are configured, all project
-    elements will be fetched.
+Specifying no elements will result in fetching the default targets
+of the project. If no default targets are configured, all project
+elements will be fetched.
 .PP
-    When this command is executed from a workspace directory, the default
-    is to fetch the workspace element.
+When this command is executed from a workspace directory, the default
+is to fetch the workspace element.
 .PP
-    By default this will only try to fetch sources for the specified
-    elements.
+By default this will only try to fetch sources for the specified
+elements.
 .PP
-    Specify `--deps` to control which sources to fetch:
+Specify `--deps` to control which sources to fetch:
 .PP
-    
-        none:  No dependencies, just the element itself
-        run:   Runtime dependencies, including the element itself
-        build: Build time dependencies, excluding the element itself
-        all:   All dependencies
-    
+
+    none:  No dependencies, just the element itself
+    run:   Runtime dependencies, including the element itself
+    build: Build time dependencies, excluding the element itself
+    all:   All dependencies
+.PP
 .SH OPTIONS
 .TP
 \fB\-\-except\fP PATH

--- a/man/bst-source-push.1
+++ b/man/bst-source-push.1
@@ -1,4 +1,4 @@
-.TH "BST SOURCE PUSH" "1" "2024-08-08" "" "bst source push Manual"
+.TH "BST SOURCE PUSH" "1" "2025-04-24" "2.5" "bst source push Manual"
 .SH NAME
 bst\-source\-push \- Push sources in a pipeline
 .SH SYNOPSIS
@@ -7,24 +7,24 @@ bst\-source\-push \- Push sources in a pipeline
 .SH DESCRIPTION
 Push sources required to build the pipeline
 .PP
-    Specifying no elements will result in pushing the sources of the default
-    targets of the project. If no default targets are configured, sources of
-    all project elements will be pushed.
+Specifying no elements will result in pushing the sources of the default
+targets of the project. If no default targets are configured, sources of
+all project elements will be pushed.
 .PP
-    When this command is executed from a workspace directory, the default
-    is to push the sources of the workspace element.
+When this command is executed from a workspace directory, the default
+is to push the sources of the workspace element.
 .PP
-    By default this will only try to push sources for the specified
-    elements.
+By default this will only try to push sources for the specified
+elements.
 .PP
-    Specify `--deps` to control which sources to fetch:
+Specify `--deps` to control which sources to fetch:
 .PP
-    
-        none:  No dependencies, just the element itself
-        run:   Runtime dependencies, including the element itself
-        build: Build time dependencies, excluding the element itself
-        all:   All dependencies
-    
+
+    none:  No dependencies, just the element itself
+    run:   Runtime dependencies, including the element itself
+    build: Build time dependencies, excluding the element itself
+    all:   All dependencies
+.PP
 .SH OPTIONS
 .TP
 \fB\-\-except\fP PATH

--- a/man/bst-source-track.1
+++ b/man/bst-source-track.1
@@ -1,4 +1,4 @@
-.TH "BST SOURCE TRACK" "1" "2024-08-08" "" "bst source track Manual"
+.TH "BST SOURCE TRACK" "1" "2025-04-24" "2.5" "bst source track Manual"
 .SH NAME
 bst\-source\-track \- Track new source references
 .SH SYNOPSIS
@@ -6,26 +6,26 @@ bst\-source\-track \- Track new source references
 [OPTIONS] [ELEMENTS]...
 .SH DESCRIPTION
 Consults the specified tracking branches for new versions available
-    to build and updates the project with any newly available references.
+to build and updates the project with any newly available references.
 .PP
-    Specifying no elements will result in tracking the default targets
-    of the project. If no default targets are configured, all project
-    elements will be tracked.
+Specifying no elements will result in tracking the default targets
+of the project. If no default targets are configured, all project
+elements will be tracked.
 .PP
-    When this command is executed from a workspace directory, the default
-    is to track the workspace element.
+When this command is executed from a workspace directory, the default
+is to track the workspace element.
 .PP
-    If no default is declared, all elements in the project will be tracked
+If no default is declared, all elements in the project will be tracked
 .PP
-    By default this will track just the specified element, but you can also
-    update a whole tree of dependencies in one go.
+By default this will track just the specified element, but you can also
+update a whole tree of dependencies in one go.
 .PP
-    Specify `--deps` to control which sources to track:
+Specify `--deps` to control which sources to track:
 .PP
-    
-        none:  No dependencies, just the specified elements
-        all:   All dependencies of all specified elements
-    
+
+    none:  No dependencies, just the specified elements
+    all:   All dependencies of all specified elements
+.PP
 .SH OPTIONS
 .TP
 \fB\-\-except\fP PATH

--- a/man/bst-source.1
+++ b/man/bst-source.1
@@ -1,4 +1,4 @@
-.TH "BST SOURCE" "1" "2024-08-08" "" "bst source Manual"
+.TH "BST SOURCE" "1" "2025-04-24" "2.5" "bst source Manual"
 .SH NAME
 bst\-source \- Manipulate sources for an element
 .SH SYNOPSIS

--- a/man/bst-workspace-close.1
+++ b/man/bst-workspace-close.1
@@ -1,4 +1,4 @@
-.TH "BST WORKSPACE CLOSE" "1" "2024-08-08" "" "bst workspace close Manual"
+.TH "BST WORKSPACE CLOSE" "1" "2025-04-24" "2.5" "bst workspace close Manual"
 .SH NAME
 bst\-workspace\-close \- Close workspaces
 .SH SYNOPSIS

--- a/man/bst-workspace-list.1
+++ b/man/bst-workspace-list.1
@@ -1,4 +1,4 @@
-.TH "BST WORKSPACE LIST" "1" "2024-08-08" "" "bst workspace list Manual"
+.TH "BST WORKSPACE LIST" "1" "2025-04-24" "2.5" "bst workspace list Manual"
 .SH NAME
 bst\-workspace\-list \- List open workspaces
 .SH SYNOPSIS

--- a/man/bst-workspace-open.1
+++ b/man/bst-workspace-open.1
@@ -1,4 +1,4 @@
-.TH "BST WORKSPACE OPEN" "1" "2024-08-08" "" "bst workspace open Manual"
+.TH "BST WORKSPACE OPEN" "1" "2025-04-24" "2.5" "bst workspace open Manual"
 .SH NAME
 bst\-workspace\-open \- Open a new workspace
 .SH SYNOPSIS

--- a/man/bst-workspace-reset.1
+++ b/man/bst-workspace-reset.1
@@ -1,4 +1,4 @@
-.TH "BST WORKSPACE RESET" "1" "2024-08-08" "" "bst workspace reset Manual"
+.TH "BST WORKSPACE RESET" "1" "2025-04-24" "2.5" "bst workspace reset Manual"
 .SH NAME
 bst\-workspace\-reset \- Reset a workspace to its original state
 .SH SYNOPSIS

--- a/man/bst-workspace.1
+++ b/man/bst-workspace.1
@@ -1,4 +1,4 @@
-.TH "BST WORKSPACE" "1" "2024-08-08" "" "bst workspace Manual"
+.TH "BST WORKSPACE" "1" "2025-04-24" "2.5" "bst workspace Manual"
 .SH NAME
 bst\-workspace \- Manipulate developer workspaces
 .SH SYNOPSIS

--- a/man/bst.1
+++ b/man/bst.1
@@ -1,4 +1,4 @@
-.TH "BST" "1" "2024-08-08" "" "bst Manual"
+.TH "BST" "1" "2025-04-24" "2.5" "bst Manual"
 .SH NAME
 bst \- Build and manipulate BuildStream projects
 .SH SYNOPSIS
@@ -7,9 +7,9 @@ bst \- Build and manipulate BuildStream projects
 .SH DESCRIPTION
 Build and manipulate BuildStream projects
 .PP
-    Most of the main options override options in the
-    user preferences configuration file.
-    
+Most of the main options override options in the
+user preferences configuration file.
+.PP
 .SH OPTIONS
 .TP
 \fB\-\-version\fP

--- a/src/buildstream/__init__.py
+++ b/src/buildstream/__init__.py
@@ -31,7 +31,15 @@ if "_BST_COMPLETION" not in os.environ:
     from .types import CoreWarnings, OverlapAction, FastEnum, SourceRef
     from .node import MappingNode, Node, ProvenanceInformation, ScalarNode, SequenceNode
     from .plugin import Plugin
-    from .source import Source, SourceError, SourceFetcher
+    from .source import (
+        Source,
+        SourceError,
+        SourceImplError,
+        SourceFetcher,
+        SourceInfo,
+        SourceInfoMedium,
+        SourceVersionType,
+    )
     from .sourcemirror import SourceMirror, SourceMirrorError
     from .downloadablefilesource import DownloadableFileSource
     from .element import Element, ElementError, DependencyConfiguration

--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -613,6 +613,7 @@ def show(app, elements, deps, except_, order, format_):
         %{deps}           A list of all dependencies
         %{build-deps}     A list of build dependencies
         %{runtime-deps}   A list of runtime dependencies
+        %{source-info}    Source provenance information
 
     The value of the %{symbol} without the leading '%' character is understood
     as a pythonic formatting string, so python formatting features apply,

--- a/src/buildstream/plugins/sources/remote.py
+++ b/src/buildstream/plugins/sources/remote.py
@@ -41,8 +41,16 @@ remote - stage files from remote urls
    # Specify the ref. It's a sha256sum of the file you download.
    ref: 6c9f6f68a131ec6381da82f2bff978083ed7f4f7991d931bfa767b7965ebc94b
 
-See :ref:`built-in functionality doumentation <core_source_builtins>` for
-details on common configuration options for sources.
+See :ref:`built-in base class functionality doumentation <core_source_builtins>`
+and :ref:`built-in downloadable file source functionality doumentation <core_downloadable_source_builtins>`
+for details on common configuration options applicable to this source.
+
+
+Reporting :class:`.SourceInfo`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The remote source does not override any of the DownloadableFileSource reporting functionality and
+as such, behaves as described in the :ref:`default reporting of SourceInfo <core_downloadable_source_info>`
+documentation.
 """
 import os
 from buildstream import DownloadableFileSource, SourceError, utils

--- a/src/buildstream/plugins/sources/tar.py
+++ b/src/buildstream/plugins/sources/tar.py
@@ -48,8 +48,16 @@ tar - stage files from tar archives
    # to an empty string.
    base-dir: '*'
 
-See :ref:`built-in functionality doumentation <core_source_builtins>` for
-details on common configuration options for sources.
+See :ref:`built-in base class functionality doumentation <core_source_builtins>`
+and :ref:`built-in downloadable file source functionality doumentation <core_downloadable_source_builtins>`
+for details on common configuration options applicable to this source.
+
+
+Reporting :class:`.SourceInfo`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The tar source does not override any of the DownloadableFileSource reporting functionality and
+as such, behaves as described in the :ref:`default reporting of SourceInfo <core_downloadable_source_info>`
+documentation.
 """
 
 import functools

--- a/src/buildstream/source.py
+++ b/src/buildstream/source.py
@@ -262,6 +262,12 @@ class SourceError(BstError):
 
 @dataclass
 class AliasSubstitution:
+    """AliasSubstitution()
+    An opaque data structure which may be passed through
+    :func:`SourceFetcher.fetch() <buildstream.source.SourceFetcher.fetch>` and in such cases
+    must be provided to :func:`Source.translate_url() <buildstream.source.Source.translate_url>`.
+    """
+
     _effective_alias: str
     _mirror: Union[SourceMirror, str]
 
@@ -293,8 +299,9 @@ class SourceFetcher:
 
         Args:
            alias_override: The alias to use instead of the default one
-               defined by the :ref:`aliases <project_source_aliases>` field
-               in the project's config.
+               defined by the :ref:`aliases <project_source_aliases>` field in the
+               project's config. If provided, it must be used when calling
+               :func:`Source.translate_url() <buildstream.source.Source.translate_url>`.
 
         Raises:
            :class:`.SourceError`

--- a/tests/frontend/source-info/elements/extradata.bst
+++ b/tests/frontend/source-info/elements/extradata.bst
@@ -1,0 +1,4 @@
+kind: import
+
+sources:
+- kind: extradata

--- a/tests/frontend/source-info/elements/local.bst
+++ b/tests/frontend/source-info/elements/local.bst
@@ -1,0 +1,5 @@
+kind: import
+
+sources:
+- kind: local
+  path: files/testfile

--- a/tests/frontend/source-info/elements/tar-custom-version.bst
+++ b/tests/frontend/source-info/elements/tar-custom-version.bst
@@ -1,0 +1,8 @@
+kind: import
+
+sources:
+- kind: tar
+  version-guess-pattern: >-
+    (\d+)_(\d+)_(\d+)
+  url: https://flying-ponies.com/releases/pony_v2_4_93.tgz
+  ref: 9d0c936c78d0dfe3a67cae372c9a2330476ea87a2eec16b2daada64a664ca501

--- a/tests/frontend/source-info/elements/tar-explicit.bst
+++ b/tests/frontend/source-info/elements/tar-explicit.bst
@@ -1,0 +1,7 @@
+kind: import
+
+sources:
+- kind: tar
+  url: https://flying-ponies.com/releases/9d0c936c78/pony-flight-release.tgz
+  ref: 9d0c936c78d0dfe3a67cae372c9a2330476ea87a2eec16b2daada64a664ca501
+  version: 3.2.1

--- a/tests/frontend/source-info/elements/tar-no-micro.bst
+++ b/tests/frontend/source-info/elements/tar-no-micro.bst
@@ -1,0 +1,6 @@
+kind: import
+
+sources:
+- kind: tar
+  url: https://flying-ponies.com/releases/pony-flight-1.2.tgz
+  ref: 9d0c936c78d0dfe3a67cae372c9a2330476ea87a2eec16b2daada64a664ca501

--- a/tests/frontend/source-info/elements/tar.bst
+++ b/tests/frontend/source-info/elements/tar.bst
@@ -1,0 +1,6 @@
+kind: import
+
+sources:
+- kind: tar
+  url: https://flying-ponies.com/releases/pony-flight-1.2.3.tgz
+  ref: 9d0c936c78d0dfe3a67cae372c9a2330476ea87a2eec16b2daada64a664ca501

--- a/tests/frontend/source-info/elements/testsource.bst
+++ b/tests/frontend/source-info/elements/testsource.bst
@@ -1,0 +1,4 @@
+kind: import
+
+sources:
+- kind: testsource

--- a/tests/frontend/source-info/elements/unimplemented.bst
+++ b/tests/frontend/source-info/elements/unimplemented.bst
@@ -1,0 +1,4 @@
+kind: import
+
+sources:
+- kind: unimplemented

--- a/tests/frontend/source-info/files/testfile
+++ b/tests/frontend/source-info/files/testfile
@@ -1,0 +1,1 @@
+The perverted pink pony mounts the unwilling hippopotamus

--- a/tests/frontend/source-info/plugins/extradata.py
+++ b/tests/frontend/source-info/plugins/extradata.py
@@ -1,0 +1,43 @@
+from buildstream import Source
+
+
+class ExtraData(Source):
+    BST_MIN_VERSION = "2.0"
+
+    def configure(self, node):
+        pass
+
+    def preflight(self):
+        pass
+
+    def get_unique_key(self):
+        return {}
+
+    def load_ref(self, node):
+        pass
+
+    def get_ref(self):
+        return {}
+
+    def set_ref(self, ref, node):
+        pass
+
+    def is_cached(self):
+        return False
+
+    def collect_source_info(self):
+        return [
+            self.create_source_info(
+                "http://ponyfarm.com/ponies",
+                "pony-ride",
+                "pony-age",
+                "1234567",
+                version_guess="12",
+                extra_data={"pony": "green"},
+            )
+        ]
+
+
+# Plugin entry point
+def setup():
+    return ExtraData

--- a/tests/frontend/source-info/plugins/testsource.py
+++ b/tests/frontend/source-info/plugins/testsource.py
@@ -1,0 +1,38 @@
+from buildstream import Source
+
+
+class Sample(Source):
+    BST_MIN_VERSION = "2.0"
+
+    def configure(self, node):
+        pass
+
+    def preflight(self):
+        pass
+
+    def get_unique_key(self):
+        return {}
+
+    def load_ref(self, node):
+        pass
+
+    def get_ref(self):
+        return {}
+
+    def set_ref(self, ref, node):
+        pass
+
+    def is_cached(self):
+        return False
+
+    def collect_source_info(self):
+        return [
+            self.create_source_info(
+                "http://ponyfarm.com/ponies", "pony-ride", "pony-age", "1234567", version_guess="12"
+            )
+        ]
+
+
+# Plugin entry point
+def setup():
+    return Sample

--- a/tests/frontend/source-info/plugins/unimplemented.py
+++ b/tests/frontend/source-info/plugins/unimplemented.py
@@ -1,0 +1,31 @@
+from buildstream import Source
+
+
+class Unimplemented(Source):
+    BST_MIN_VERSION = "2.0"
+
+    def configure(self, node):
+        pass
+
+    def preflight(self):
+        pass
+
+    def get_unique_key(self):
+        return {}
+
+    def load_ref(self, node):
+        pass
+
+    def get_ref(self):
+        return {}
+
+    def set_ref(self, ref, node):
+        pass
+
+    def is_cached(self):
+        return False
+
+
+# Plugin entry point
+def setup():
+    return Unimplemented

--- a/tests/frontend/source-info/project.conf
+++ b/tests/frontend/source-info/project.conf
@@ -1,0 +1,16 @@
+# Project config for bst show source-info test
+name: test
+min-version: 2.0
+element-path: elements
+
+plugins:
+- origin: pip
+  package-name: sample-plugins
+  sources:
+  - git
+- origin: local
+  path: plugins
+  sources:
+  - extradata
+  - testsource
+  - unimplemented

--- a/tox.ini
+++ b/tox.ini
@@ -208,16 +208,21 @@ passenv =
 allowlist_externals =
     make
 
+
 #
 # (re-)Generating man pages
 #
 [testenv:man]
 commands =
-    python3 setup.py --command-packages=click_man.commands man_pages
+    # We set the version to 0, because click-man would now
+    # otherwise want to pull a hardcoded version from pyproject.toml
+    # that somehow gets magically transported to the EntryPoint.version
+    click-man --man-version {posargs} --target man bst
 deps =
-    click-man >= 0.3.0
-    Cython
+    click-man >= 0.5.0
     -rrequirements/requirements.txt
+    -rrequirements/dev-requirements.txt
+    Cython
 
 
 #


### PR DESCRIPTION
This is an initial implementation for the proposal up at: https://lists.apache.org/thread/q6gxjpld2vb1c9rqlsv24m12c087snc4

Some thoughts about this approach:

* This prioritizes machine readability and standardization of source provenance and version information

  Sources have a lot of freedom in how they implement things, and so we may very well need to expand on the types and constants added here, such as `SourceInfoMedium`, `SourceVersionType`, etc.

  The idea here is to have greater certainty about how sources are obtained, even if this cannot be covered by all currently existing source implementations (e.g. I didn't initially add a `bzr` medium for which we have a plugin, or a `cvs` medium for which we do not yet have a plugin).

  Aspirationally, forcing this data to be precise can allow adjacent tooling to do useful things.

* This drops the freeform "public data" mentioned in the proposal discussion

   My rationale for this choice in this branch, is that ultimately we want a data with a constant shape, and if for examlpe, we want the user to be able to override or assist a source with determining the reported *"version"*, then the `Source` implementation already has everything it needs to do so:
    * it can add additional configuration keys for the user to configure
    * it has the power to implement `collect_source_info()` however it wants.

* This does not yet attempt to cover the concept of *tracking* information

  I would like to consider this, but we should think carefully about how this can be useful. For instance, some git plugins have different interpretations of what their "tracking" strings mean, sometimes following a branch head, sometimes looking for the latest tag in history which matches a given regular expression.

  If we export this tracking information, it should probably be useful for external tooling to figure out how to do the tracking and come to the same conclusion, otherwise it is unclear what this is useful for.

* This does not cover the CVE information

   While the SourceInfo objects representing a source's provenance is a list, I believe that the CVE information continues to be a per-element concept.

  For example, when we have applied security patches to a module, those security patches are, themselves, sources, with provenance of being revisioned in the local project
