### PR TITLE
casserver.py: Fix error handling in `ByteStream.Read()`

### DIFF
--- a/src/buildstream/_cas/casserver.py
+++ b/src/buildstream/_cas/casserver.py
@@ -135,10 +135,9 @@ class _ByteStreamServicer(bytestream_pb2_grpc.ByteStreamServicer):
     def Read(self, request, context):
         self.logger.debug("Reading %s", request.resource_name)
         try:
-            ret = self.bytestream.Read(request)
+            yield from self.bytestream.Read(request)
         except grpc.RpcError as err:
             context.abort(err.code(), err.details())
-        return ret
 
     def Write(self, request_iterator, context):
         # Note that we can't easily give more information because the


### PR DESCRIPTION
This proxy server is only used in tests, so this doesn't affect any real use of BuildStream.

This fixes a failure in `tests/sourcecache/fetch.py::test_source_pull_partial_fallback_fetch` with https://gitlab.com/BuildGrid/buildbox/buildbox/-/merge_requests/865.