### PR TITLE
Support directory mtime to fix tests with recent buildbox-casd

### DIFF
--- a/src/buildstream/_cas/cascache.py
+++ b/src/buildstream/_cas/cascache.py
@@ -226,6 +226,11 @@ class CASCache:
             fullpath = os.path.join(dest, symlinknode.name)
             os.symlink(symlinknode.target, fullpath)
 
+        node_properties = directory.node_properties
+        if node_properties.HasField("mtime"):
+            mtime = utils._parse_protobuf_timestamp(node_properties.mtime)
+            utils._set_file_mtime(dest, mtime)
+
     # ensure_tree():
     #
     # Make sure all blobs referenced by the given directory tree are available

--- a/tests/internals/storage_vdir_import.py
+++ b/tests/internals/storage_vdir_import.py
@@ -76,6 +76,9 @@ def generate_import_root(rootdir, filelist):
             (dirnames, filename) = os.path.split(path)
             os.makedirs(os.path.join(rootdir, dirnames), exist_ok=True)
             os.symlink(content, os.path.join(rootdir, path))
+    # Set deterministic mtime for all directories
+    for (dirpath, _, _) in os.walk(rootdir):
+        _set_file_mtime(dirpath, MTIME)
 
 
 def generate_random_root(rootno, directory):
@@ -116,6 +119,9 @@ def generate_random_root(rootno, directory):
                 relative_link = os.path.relpath(symlink_destination, start=location)
                 os.symlink(relative_link, target)
         things.append(os.path.join(location, thingname))
+    # Set deterministic mtime for all directories
+    for (dirpath, _, _) in os.walk(rootdir):
+        _set_file_mtime(dirpath, MTIME)
 
 
 def file_contents(path):


### PR DESCRIPTION
This fixes test failures with recent versions of buildbox-casd, see [commit 85f0578f](https://gitlab.com/BuildGrid/buildbox/buildbox/-/commit/85f0578f) ("common: Support capturing directory mtime and mode").
