### PR TITLE
scheduler: Stop scheduling from the imperative queue when asked to quit

### DIFF
--- a/src/buildstream/_testing/runcli.py
+++ b/src/buildstream/_testing/runcli.py
@@ -632,7 +632,14 @@ class TestArtifact:
 
         normal_name = element_name.replace(os.sep, "-")
         cache_dir = os.path.splitext(os.path.join(cache_dir, "test", normal_name))[0]
-        shutil.rmtree(cache_dir)
+
+        # Don't cause a failure here if the artifact is not there, we use this in integration
+        # tests where the cache is shared and we just want to clean up some artifacts
+        # regardless of whether they have already been built or not.
+        try:
+            shutil.rmtree(cache_dir)
+        except FileNotFoundError:
+            pass
 
     # is_cached():
     #

--- a/tests/integration/cached-fail/elements/base-also-fail.bst
+++ b/tests/integration/cached-fail/elements/base-also-fail.bst
@@ -1,0 +1,9 @@
+kind: script
+
+build-depends:
+- base.bst
+
+config:
+  commands:
+  - touch %{install-root}/foo
+  - false

--- a/tests/integration/cached-fail/elements/base-fail.bst
+++ b/tests/integration/cached-fail/elements/base-fail.bst
@@ -1,0 +1,9 @@
+kind: script
+
+build-depends:
+- base.bst
+
+config:
+  commands:
+  - touch %{install-root}/foo
+  - false

--- a/tests/integration/cached-fail/elements/base-success.bst
+++ b/tests/integration/cached-fail/elements/base-success.bst
@@ -1,0 +1,8 @@
+kind: script
+
+build-depends:
+- base.bst
+
+config:
+  commands:
+  - touch %{install-root}/foo

--- a/tests/integration/cached-fail/elements/base.bst
+++ b/tests/integration/cached-fail/elements/base.bst
@@ -1,0 +1,17 @@
+kind: import
+
+description: |
+  Alpine Linux base for tests
+
+  Generated using the `tests/integration-tests/base/generate-base.sh` script.
+
+sources:
+  - kind: tar
+    base-dir: ''
+    (?):
+    - arch == "x86-64":
+        ref: 3eb559250ba82b64a68d86d0636a6b127aa5f6d25d3601a79f79214dc9703639
+        url: "alpine:integration-tests-base.v1.x86_64.tar.xz"
+    - arch == "aarch64":
+        ref: 431fb5362032ede6f172e70a3258354a8fd71fcbdeb1edebc0e20968c792329a
+        url: "alpine:integration-tests-base.v1.aarch64.tar.xz"

--- a/tests/integration/cached-fail/elements/depends-on-base-fail-expect-foo.bst
+++ b/tests/integration/cached-fail/elements/depends-on-base-fail-expect-foo.bst
@@ -1,0 +1,9 @@
+kind: script
+
+build-depends:
+- base.bst
+- base-fail.bst
+
+config:
+  commands:
+  - test -e /foo

--- a/tests/integration/cached-fail/elements/depends-on-two-failures.bst
+++ b/tests/integration/cached-fail/elements/depends-on-two-failures.bst
@@ -1,0 +1,9 @@
+kind: script
+
+build-depends:
+- base-fail.bst
+- base-also-fail.bst
+
+config:
+  commands:
+  - test -e /foo

--- a/tests/integration/cached-fail/project.conf
+++ b/tests/integration/cached-fail/project.conf
@@ -1,0 +1,37 @@
+# Project config for frontend build test
+name: test
+min-version: 2.0
+element-path: elements
+
+aliases:
+  alpine: https://bst-integration-test-images.ams3.cdn.digitaloceanspaces.com/
+  project_dir: file://{project_dir}
+
+plugins:
+- origin: pip
+  package-name: sample-plugins
+  elements:
+  - autotools
+
+options:
+  linux:
+    type: bool
+    description: Whether to expect a linux platform
+    default: True
+  arch:
+    type: arch
+    description: Current architecture
+    variable: build_arch
+    values:
+      - x86-64
+      - aarch64
+
+environment:
+  TEST_VAR: pony
+
+split-rules:
+  test:
+    - |
+      /tests
+    - |
+      /tests/*


### PR DESCRIPTION
For instance, we shouldn't schedule new build jobs when asked to quit. However, not considering the build queue at all would miss pushing newly built elements.

What this commit does is:
* Pull elements forward through all queues (including the ones we no longer need)
* Only schedule jobs after the imperative queue

This means that elements in the build queue (or any imperative queue) will still get passed to the following queues, but no new build jobs get scheduled.

Fixes https://github.com/apache/buildstream/issues/1787