### PR TITLE
Prefer better version matches

### DIFF
--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -409,7 +409,7 @@ def help_command(ctx, command):
 @click.option(
     "--min-version",
     type=click.STRING,
-    default="2.4",
+    default="2.5",
     show_default=True,
     help="The required format version",
 )

--- a/src/buildstream/source.py
+++ b/src/buildstream/source.py
@@ -1089,7 +1089,7 @@ class Source(Plugin):
         .. note::
 
            If your plugin uses :class:`.SourceFetcher` objects, you can implement
-           :func:`Source.collect_source_info() <buildstream.source.SourceFetcher.get_source_info>` instead.
+           :func:`Source.get_source_info() <buildstream.source.SourceFetcher.get_source_info>` instead.
 
         *Since: 2.5*
         """

--- a/src/buildstream/utils.py
+++ b/src/buildstream/utils.py
@@ -697,12 +697,17 @@ def save_file_atomic(
 
 # get_umask():
 #
-# Get the process's file mode creation mask without changing it.
+# 
 #
 # Returns:
-#     (int) The process's file mode creation mask.
+#     (int) 
 #
-def get_umask():
+def get_umask() -> int:
+    """
+    Get the process's file mode creation mask without changing it.
+
+    Returns: The process's file mode creation mask.
+    """
     return _UMASK
 
 

--- a/tests/frontend/show.py
+++ b/tests/frontend/show.py
@@ -594,7 +594,7 @@ def test_invalid_alias(cli, tmpdir, datafiles):
         (
             "tar.bst",
             "tar",
-            "https://flying-ponies.com/releases/pony-flight-1.2.3.tgz",
+            "https://flying-ponies.com/releases/1.2/pony-flight-1.2.3.tgz",
             "remote-file",
             "sha256",
             "9d0c936c78d0dfe3a67cae372c9a2330476ea87a2eec16b2daada64a664ca501",

--- a/tests/frontend/source-info/elements/tar.bst
+++ b/tests/frontend/source-info/elements/tar.bst
@@ -2,5 +2,5 @@ kind: import
 
 sources:
 - kind: tar
-  url: https://flying-ponies.com/releases/pony-flight-1.2.3.tgz
+  url: https://flying-ponies.com/releases/1.2/pony-flight-1.2.3.tgz
   ref: 9d0c936c78d0dfe3a67cae372c9a2330476ea87a2eec16b2daada64a664ca501


### PR DESCRIPTION
This fixes the issue of parsing typically formulated release tarball URLs.

Consider the URL `https://flying-ponies.com/releases/1.2/pony-flight-1.2.3.tgz`.

Without this change, we only get the version `1.2` (the directory where we put all of the `1.2` releases).

After this change, we get `1.2.3`.

This is achieved by explicitly supporting *optional groups* in the regex (which we already did, but in an not very specified way), and *preferring* more qualified matches by preferring *matches which had more groups present in the match* while iterating over all non-overlapping matches.

By causing the user to explicitly specify *groups* in the regex, we avoid the pitfall of relying on silly things like string length (where both strings "1.200" and "1.2.3" would be considered *equally qualified*).
