### PR TITLE
Additional source provenance in SourceInfo

### DIFF
--- a/src/buildstream/_loader/metasource.py
+++ b/src/buildstream/_loader/metasource.py
@@ -26,14 +26,17 @@ class MetaSource:
     #    element_index: The index of the source in the owning element's source list
     #    element_kind: The kind of the owning element
     #    kind: The kind of the source
+    #    directory: A subdirectory where to stage the source
+    #    provenance: The user provided provenance information (e.g. homepage, issue tracking, etc).
     #    config: The configuration data for the source
     #    first_pass: This source will be used with first project pass configuration (used for junctions).
     #
-    def __init__(self, element_name, element_index, element_kind, kind, config, directory, first_pass):
+    def __init__(self, element_name, element_index, element_kind, kind, directory, provenance, config, first_pass):
         self.element_name = element_name
         self.element_index = element_index
         self.element_kind = element_kind
         self.kind = kind
-        self.config = config
         self.directory = directory
+        self.provenance = provenance
+        self.config = config
         self.first_pass = first_pass

--- a/src/buildstream/_loader/types.py
+++ b/src/buildstream/_loader/types.py
@@ -40,3 +40,4 @@ class Symbol:
     JUNCTION = "junction"
     SANDBOX = "sandbox"
     STRICT = "strict"
+    PROVENANCE = "provenance"

--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -90,7 +90,7 @@ from .plugin import Plugin
 from .sandbox import _SandboxFlags, SandboxCommandError
 from .sandbox._config import SandboxConfig
 from .sandbox._sandboxremote import SandboxRemote
-from .types import _Scope, _CacheBuildTrees, _KeyStrength, OverlapAction, _DisplayKey
+from .types import _Scope, _CacheBuildTrees, _KeyStrength, OverlapAction, _DisplayKey, _SourceProvenance
 from ._artifact import Artifact
 from ._elementproxy import ElementProxy
 from ._elementsources import ElementSources
@@ -2584,8 +2584,9 @@ class Element(Plugin):
                 0,
                 self.get_kind(),
                 "workspace",
-                Node.from_dict(workspace_node),
                 None,
+                None,
+                Node.from_dict(workspace_node),
                 load_element.first_pass,
             )
             meta_sources.append(meta)
@@ -2606,8 +2607,23 @@ class Element(Plugin):
                 directory = source.get_str(Symbol.DIRECTORY, default=None)
                 if directory:
                     del source[Symbol.DIRECTORY]
+
+                # Provenance is optional
+                provenance_node = source.get_mapping(Symbol.PROVENANCE, default=None)
+                provenance = None
+                if provenance_node:
+                    del source[Symbol.PROVENANCE]
+                    provenance = _SourceProvenance.new_from_node(provenance_node)
+
                 meta_source = MetaSource(
-                    self.name, index, self.get_kind(), kind.as_str(), source, directory, load_element.first_pass
+                    self.name,
+                    index,
+                    self.get_kind(),
+                    kind.as_str(),
+                    directory,
+                    provenance,
+                    source,
+                    load_element.first_pass,
                 )
                 meta_sources.append(meta_source)
 

--- a/src/buildstream/types.py
+++ b/src/buildstream/types.py
@@ -384,6 +384,42 @@ class _SourceMirror:
         return cls(name, aliases)
 
 
+# _SourceProvenance()
+#
+# A simple object describing user provided source provenance information
+#
+# Args:
+#    homepage: The project homepage URL
+#    issue_tracker: The project issue reporting URL
+#
+class _SourceProvenance:
+    def __init__(self, homepage: Optional[str], issue_tracker: Optional[str]):
+        self.homepage: Optional[str] = homepage
+        self.issue_tracker: Optional[str] = issue_tracker
+
+    # new_from_node():
+    #
+    # Creates a _SourceProvenance() from a YAML loaded node.
+    #
+    # Args:
+    #    node: The configuration node describing the spec.
+    #
+    # Returns:
+    #    The described _SourceProvenance instance.
+    #
+    # Raises:
+    #    LoadError: If the node is malformed.
+    #
+    @classmethod
+    def new_from_node(cls, node: MappingNode) -> "_SourceProvenance":
+        node.validate_keys(["homepage", "issue-tracker"])
+
+        homepage: Optional[str] = node.get_str("homepage", None)
+        issue_tracker: Optional[str] = node.get_str("issue-tracker", None)
+
+        return cls(homepage, issue_tracker)
+
+
 ########################################
 #           Type aliases               #
 ########################################

--- a/tests/frontend/show.py
+++ b/tests/frontend/show.py
@@ -580,7 +580,7 @@ def test_invalid_alias(cli, tmpdir, datafiles):
 
 @pytest.mark.datafiles(os.path.join(DATA_DIR, "source-info"))
 @pytest.mark.parametrize(
-    "target, expected_kind, expected_url, expected_medium, expected_version_type, expected_version, expected_guess_version",
+    "target, expected_kind, expected_url, expected_medium, expected_version_type, expected_version, expected_guess_version, expected_homepage, expected_issue_tracker",
     [
         (
             "local.bst",
@@ -589,6 +589,8 @@ def test_invalid_alias(cli, tmpdir, datafiles):
             "local",
             "cas-digest",
             "9391a5943daf287b46520c4289d41cab5f6b33e643f7661bcf620de7f02c1c9b/82",
+            None,
+            None,
             None,
         ),
         (
@@ -599,6 +601,8 @@ def test_invalid_alias(cli, tmpdir, datafiles):
             "sha256",
             "9d0c936c78d0dfe3a67cae372c9a2330476ea87a2eec16b2daada64a664ca501",
             "1.2.3",
+            None,
+            None,
         ),
         (
             "tar-no-micro.bst",
@@ -608,6 +612,8 @@ def test_invalid_alias(cli, tmpdir, datafiles):
             "sha256",
             "9d0c936c78d0dfe3a67cae372c9a2330476ea87a2eec16b2daada64a664ca501",
             "1.2",
+            None,
+            None,
         ),
         (
             "tar-custom-version.bst",
@@ -617,6 +623,8 @@ def test_invalid_alias(cli, tmpdir, datafiles):
             "sha256",
             "9d0c936c78d0dfe3a67cae372c9a2330476ea87a2eec16b2daada64a664ca501",
             "2.4.93",
+            None,
+            None,
         ),
         (
             "tar-explicit.bst",
@@ -626,6 +634,8 @@ def test_invalid_alias(cli, tmpdir, datafiles):
             "sha256",
             "9d0c936c78d0dfe3a67cae372c9a2330476ea87a2eec16b2daada64a664ca501",
             "3.2.1",
+            None,
+            None,
         ),
         (
             "testsource.bst",
@@ -635,9 +645,30 @@ def test_invalid_alias(cli, tmpdir, datafiles):
             "pony-age",
             "1234567",
             "12",
+            None,
+            None,
+        ),
+        (
+            "user-provenance.bst",
+            "tar",
+            "https://flying-ponies.com/releases/1.2/pony-flight-1.2.3.tgz",
+            "remote-file",
+            "sha256",
+            "9d0c936c78d0dfe3a67cae372c9a2330476ea87a2eec16b2daada64a664ca501",
+            "1.2.3",
+            "https://flying-ponies.com/index.html",
+            "https://bugs.flying-ponies.com/issues",
         ),
     ],
-    ids=["local", "tar-full-version", "tar-no-micro", "tar-custom-version", "tar-explicit", "testsource"],
+    ids=[
+        "local",
+        "tar-full-version",
+        "tar-no-micro",
+        "tar-custom-version",
+        "tar-explicit",
+        "testsource",
+        "user-provenance",
+    ],
 )
 def test_source_info(
     cli,
@@ -649,6 +680,8 @@ def test_source_info(
     expected_version_type,
     expected_version,
     expected_guess_version,
+    expected_homepage,
+    expected_issue_tracker,
 ):
     project = str(datafiles)
     result = cli.run(project=project, silent=True, args=["show", "--format", "%{name}:\n%{source-info}", target])
@@ -664,9 +697,10 @@ def test_source_info(
     assert source_info.get_str("version-type") == expected_version_type
     assert source_info.get_str("version") == expected_version
 
-    guess_version = source_info.get_str("version-guess", None)
-    if guess_version or expected_guess_version:
-        assert guess_version == expected_guess_version
+    # Optional fields
+    assert source_info.get_str("version-guess", None) == expected_guess_version
+    assert source_info.get_str("homepage", None) == expected_homepage
+    assert source_info.get_str("issue-tracker", None) == expected_issue_tracker
 
 
 @pytest.mark.datafiles(os.path.join(DATA_DIR, "source-info"))

--- a/tests/frontend/source-info/elements/user-provenance.bst
+++ b/tests/frontend/source-info/elements/user-provenance.bst
@@ -1,0 +1,9 @@
+kind: import
+
+sources:
+- kind: tar
+  url: https://flying-ponies.com/releases/1.2/pony-flight-1.2.3.tgz
+  ref: 9d0c936c78d0dfe3a67cae372c9a2330476ea87a2eec16b2daada64a664ca501
+  provenance:
+    homepage: https://flying-ponies.com/index.html
+    issue-tracker: https://bugs.flying-ponies.com/issues


### PR DESCRIPTION
With the recent addition of SourceInfo etc, we are closer to generating automated SBoMs,
and to a reasonable degree, everything that should be delegated to plugins has been delegated
via the `Source.collect_source_info()` and `SourceFetcher.get_source_info()` abstract methods, and
the utility function `utils.guess_version()` for version guessing.

This leaves some information which only users can explicitly provide in their buildstream projects,
notably, it is relevant for SBoM generation and compliance purposes, to include information such
as the project *homepage* URL, and an existing *issue tracking* URL.

It is presumed that these cannot be realistically guessed by plugin implementations, and that
project authors would have to provide these in some form.

This patch adds some source level provenance information which users can use to contribute to
the SourceInfo.
