### PR TITLE
tests/frontend/show_artifact_cas_digest.py: Simplification / correction of dependencies test

### DIFF
--- a/tests/frontend/show_artifact_cas_digest_project/elements/dependencies.bst
+++ b/tests/frontend/show_artifact_cas_digest_project/elements/dependencies.bst
@@ -3,4 +3,4 @@ sources:
 - kind: local
   path: files/basic-files
 depends:
-- import-symlinks.bst
+- import-basic-files.bst


### PR DESCRIPTION
This test needs to check that the CAS digest of the toplevel and the dependencies are the same CAS digest when both of these elements produce the same content.

Also removed a lot of unneeded checks from the test, making the test clearer.

This is a follow up on #1994
