### PR TITLE
node.pyx: Support loading 0/1 as boolean values

### DIFF
--- a/src/buildstream/node.pyx
+++ b/src/buildstream/node.pyx
@@ -329,8 +329,8 @@ cdef class ScalarNode(Node):
         else:
             provenance = self.get_provenance()
             path = provenance._toplevel._find(self)[-1]
-            raise LoadError("{}: Value of '{}' is not of the expected type '{}'"
-                            .format(provenance, path, bool.__name__, self.value),
+            raise LoadError("{}: Value of '{}' is not of the expected type 'boolean'"
+                            .format(provenance, path),
                             LoadErrorReason.INVALID_DATA)
 
     cpdef object as_enum(self, object constraint):

--- a/src/buildstream/node.pyx
+++ b/src/buildstream/node.pyx
@@ -306,8 +306,8 @@ cdef class ScalarNode(Node):
     cpdef bint as_bool(self) except *:
         """Get the value of the node as a boolean.
 
-        .. note:: BuildStream treats the values 'True' and 'true' as True,
-                  and the values 'False' and 'false' as False.  Any other
+        .. note:: BuildStream treats the values 'True', 'true' and '1' as True,
+                  and the values 'False', 'false' and '0' as False.  Any other
                   string values (such as the valid YAML 'TRUE' or 'FALSE'
                   will be considered as an error)
 
@@ -322,9 +322,9 @@ cdef class ScalarNode(Node):
             return self.value
 
         # Don't coerce strings to booleans, this makes "False" strings evaluate to True
-        if self.value in ('True', 'true'):
+        if self.value in ('True', 'true', '1'):
             return True
-        elif self.value in ('False', 'false'):
+        elif self.value in ('False', 'false', '0'):
             return False
         else:
             provenance = self.get_provenance()

--- a/tests/format/option-exports/element.bst
+++ b/tests/format/option-exports/element.bst
@@ -1,1 +1,5 @@
-kind: manual
+kind: config
+
+config:
+  animal: "%{exported-enum}"
+  sleepy: "%{exported-bool}"

--- a/tests/format/option-exports/plugins/config.py
+++ b/tests/format/option-exports/plugins/config.py
@@ -1,0 +1,26 @@
+from buildstream import Element, FastEnum
+
+
+class AnimalEnum(FastEnum):
+    PONY = "pony"
+    HORSY = "horsy"
+    ZEBRY = "zebry"
+
+
+class Config(Element):
+    BST_MIN_VERSION = "2.0"
+
+    def configure(self, node):
+        self.animal = node.get_enum("animal", AnimalEnum)
+        self.sleepy = node.get_bool("sleepy")
+
+    def preflight(self):
+        pass
+
+    def get_unique_key(self):
+        return {}
+
+
+# Plugin entry point
+def setup():
+    return Config

--- a/tests/format/option-exports/project.conf
+++ b/tests/format/option-exports/project.conf
@@ -1,6 +1,12 @@
 name: test
 min-version: 2.0
 
+plugins:
+  - origin: local
+    path: plugins
+    elements:
+    - config
+
 options:
 
   bool_export:

--- a/tests/integration/pullbuildtrees.py
+++ b/tests/integration/pullbuildtrees.py
@@ -179,7 +179,7 @@ def test_pullbuildtrees(cli2, tmpdir, datafiles):
 
 # Ensure that only valid pull-buildtrees boolean options make it through the loading
 # process.
-@pytest.mark.parametrize("value,success", [(True, True), (False, True), ("pony", False), ("1", False)])
+@pytest.mark.parametrize("value,success", [(True, True), (False, True), ("pony", False), ("2", False), ("1", True)])
 @pytest.mark.datafiles(DATA_DIR)
 def test_invalid_cache_pullbuildtrees(cli, datafiles, value, success):
     project = str(datafiles)


### PR DESCRIPTION
It turns out that since OptionBool.get_value() is serializing boolean values as "0"/"1", we must support this in node parsing.

This is because we should be able to use option value exporting to values, which can subsequently be specified in plugin configuration which wants to use `MappingNode.get_bool()`.

Fixes #2006
