### PR TITLE
sandbox: Do not silently drop platform properties

### DIFF
--- a/src/buildstream/sandbox/_sandboxbuildboxrun.py
+++ b/src/buildstream/sandbox/_sandboxbuildboxrun.py
@@ -238,6 +238,3 @@ class SandboxBuildBoxRun(SandboxREAPI):
 
             if returncode != 0:
                 raise SandboxError("buildbox-run failed with returncode {}".format(returncode))
-
-    def _supported_platform_properties(self):
-        return {"OSFamily", "ISA", "unixUID", "unixGID", "network"}

--- a/src/buildstream/sandbox/_sandboxreapi.py
+++ b/src/buildstream/sandbox/_sandboxreapi.py
@@ -131,10 +131,6 @@ class SandboxREAPI(Sandbox):
         if flags & _SandboxFlags.NETWORK_ENABLED:
             platform_dict["network"] = "on"
 
-        # Remove unsupported platform properties from the dict
-        supported_properties = self._supported_platform_properties()
-        platform_dict = {key: value for (key, value) in platform_dict.items() if key in supported_properties}
-
         # Create Platform message with properties sorted by name in code point order
         platform = remote_execution_pb2.Platform()
         for key, value in sorted(platform_dict.items()):
@@ -202,9 +198,6 @@ class SandboxREAPI(Sandbox):
 
     def _execute_action(self, action, flags):
         raise ImplError("Sandbox of type '{}' does not implement _execute_action()".format(type(self).__name__))
-
-    def _supported_platform_properties(self):
-        return {"OSFamily", "ISA"}
 
 
 # _SandboxREAPIBatch()


### PR DESCRIPTION
For remote execution, there is currently no way to determine what platform properties are supported. Silently dropping platform properties that may or may not be supported can result in build behavior differences or confusing errors.

This code was originally added before the `build-uid` and `build-gid` sandbox configuration was made optional to not break remote execution. However, now that the corresponding platform properties are only set if requested by the project or element, it's better to fail the build than to ignore the setting.