### PR TITLE
cascache: fix pushing with remote cache

### DIFF
--- a/src/buildstream/_cas/cascache.py
+++ b/src/buildstream/_cas/cascache.py
@@ -702,7 +702,7 @@ class CASCache:
         batch.send()
 
     def _send_directory(self, remote, digest):
-        required_blobs = self.required_blobs_for_directory(digest)
+        required_blobs = list(self.required_blobs_for_directory(digest))
 
         # Upload any blobs missing on the server.
         # buildbox-casd will call FindMissingBlobs before the actual upload


### PR DESCRIPTION
CASCache.send_blobs() expects to be able to iterate twice on the passed digests (though it only does so when using a remote cache). Make sure to pass a list rather than a generator.