### PR TITLE
source.py: Make SourceInfo.serialize() a public API.

### DIFF
--- a/src/buildstream/_frontend/widget.py
+++ b/src/buildstream/_frontend/widget.py
@@ -453,7 +453,7 @@ class LogLine(Widget):
 
                     serialized_sources = []
                     for s in source_infos:
-                        serialized = s._serialize()
+                        serialized = s.serialize()
                         serialized_sources.append(serialized)
 
                     all_source_infos += serialized_sources

--- a/src/buildstream/source.py
+++ b/src/buildstream/source.py
@@ -587,14 +587,12 @@ class SourceInfo:
         Additional plugin defined key/values
         """
 
-    # _serialize()
-    #
-    # Produce a dictionary object suitable to be dumped in YAML format
-    # in the `bst show` command line interface.
-    #
-    # Returns: A dictionary used to dump this out on the CLI with _yaml.roundtrip_dump_string()
-    #
-    def _serialize(self) -> Dict[str, Any]:
+    def serialize(self) -> Dict[str, Union[str, Dict[str, str]]]:
+        """Produce a dictionary object suitable for serialization into formats like json or yaml.
+
+        Returns: A dictionary object with strings as keys and values, except for the
+                 extra_data which, if present, is also a dictionary with strings as keys and values.
+        """
         #
         # WARNING: This return value produces output for an API stable interface.
         #


### PR DESCRIPTION
This serializes the `SourceInfo` into a regular simple dictionary object that can be easily serialized into formats like json or yaml.

While it was requested to make this public in some way, it is not particularly useful to make this serialize directly into a yaml string, since normally one will probably want to serialize a *list of SourceInfo* objects reported for a given *element*, in whatever data structure one would want to serialize this into.

For this reason, we export the current serialization which just converts the `SourceInfo` object into something that other serialization python libraries can reliably consume (simple dictionaries).
