### PR TITLE
Sync the protobuf version requirements with grpcio-tools

### DIFF
--- a/doc/source/hacking/grpc_protocols.rst
+++ b/doc/source/hacking/grpc_protocols.rst
@@ -36,3 +36,6 @@ To actually regenerate the code::
 
   ./setup.py build_grpc
 
+The ``requirements/requirements.in`` file needs to be updated to match the
+protobuf version requirements of the ``grpcio-tools`` version used to
+generate the code.

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -4,7 +4,7 @@ Jinja2 >= 2.10
 importlib_metadata >= 3.6; python_version < "3.10"
 packaging
 pluginbase
-protobuf >= 3.19
+protobuf <6.0dev,>=5.26.1
 psutil
 ruamel.yaml >= 0.16.7
 ruamel.yaml.clib >= 0.1.2

--- a/setup.py
+++ b/setup.py
@@ -202,6 +202,12 @@ class BuildGRPC(Command):
                     with open(path, "w", encoding="utf-8") as f:
                         f.write(code)
 
+        print(
+            "\n"
+            "NOTE: Please update requirements/requirements.in to match the protobuf\n"
+            "requirement in the grpcio-tools version you used."
+        )
+
 
 def get_cmdclass():
     cmdclass = {


### PR DESCRIPTION
This avoids warnings when using latest 6.x versions of protobuf. I tried to also add notes so this isn't forgotten in the future.

See alse https://github.com/grpc/grpc/issues/37609