### PR TITLE
pluginoriginpip: allow prereleases

### DIFF
--- a/src/buildstream/_pluginfactory/pluginoriginpip.py
+++ b/src/buildstream/_pluginfactory/pluginoriginpip.py
@@ -72,7 +72,7 @@ class PluginOriginPip(PluginOrigin):
                 reason="package-not-found",
             ) from e
 
-        if dist.version not in package.specifier:
+        if not package.specifier.contains(dist.version, prereleases=True):
             raise PluginError(
                 "{}: Version conflict encountered while loading {} plugin '{}'".format(
                     self.provenance_node.get_provenance(), plugin_type, kind


### PR DESCRIPTION
This was a regression introduced by the move to use importlib and packaging instead of pkg_resources in 10b45216684a5de8f8770efbf1821f03f16b9e73.

This is the reason for the CI failures in buildstream-plugins-community https://gitlab.com/BuildStream/buildstream-plugins-community/-/issues/69