### PR TITLE
ci: Update images

### DIFF
--- a/.github/common.env
+++ b/.github/common.env
@@ -1,6 +1,6 @@
 # Shared common variables
 
-CI_IMAGE_VERSION=master-1558808360
+CI_IMAGE_VERSION=master-1869708273
 CI_TOXENV_MAIN=py39,py310,py311,py312,py313
 CI_TOXENV_PLUGINS=py39-plugins,py310-plugins,py311-plugins,py312-plugins,py313-plugins
 CI_TOXENV_ALL="${CI_TOXENV_MAIN},${CI_TOXENV_PLUGINS}"

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 
 x-tests-template: &tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:40-${CI_IMAGE_VERSION:-latest}
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:41-${CI_IMAGE_VERSION:-latest}
     command: tox -vvvvv -- --color=yes --integration
     environment:
       TOXENV: ${CI_TOXENV_ALL}
@@ -26,13 +26,13 @@ services:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-debian:11-${CI_IMAGE_VERSION:-latest}
 
-  fedora-40:
-    <<: *tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:40-${CI_IMAGE_VERSION:-latest}
-
   fedora-41:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:41-${CI_IMAGE_VERSION:-latest}
+
+  fedora-42:
+    <<: *tests-template
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:42-${CI_IMAGE_VERSION:-latest}
 
   ubuntu-22.04:
     <<: *tests-template

--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -102,7 +102,7 @@ function runServiceTest() {
 
 
 if [ -z "${test_names}" ]; then
-    for test_name in mypy debian-11 fedora-40 fedora-41 fedora-missing-deps ubuntu-22.04; do
+    for test_name in mypy debian-11 fedora-41 fedora-42 fedora-missing-deps ubuntu-22.04; do
 	if ! runTest "${test_name}"; then
 	    echo "Tests failed"
 	    exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
         # "../compose/ci.docker-compose.yml"
         test-name:
           - debian-11
-          - fedora-40
           - fedora-41
+          - fedora-42
           - fedora-missing-deps
           - ubuntu-22.04
           - lint

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -9,7 +9,7 @@ pytest-timeout==2.3.1
 pyftpdlib==2.0.1
 setuptools==75.6.0
 ## The following requirements were added by pip freeze:
-astroid==3.3.5
+astroid==3.3.7
 dill==0.3.9
 execnet==2.1.1
 iniconfig==2.0.0


### PR DESCRIPTION
Drop Fedora 40, add Fedora 42, and update BuildBox to 1.3.21.

https://gitlab.com/BuildStream/buildstream-docker-images/-/merge_requests/230