### PR TITLE
Fix GitHub workflow badge to show status

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ About
 .. image:: https://docs.buildstream.build/master/_static/release.svg
    :target: https://docs.buildstream.build/master/_static/release.html
 
-.. image:: https://img.shields.io/github/workflow/status/apache/buildstream/Merge%20actions
+.. image:: https://github.com/apache/buildstream/actions/workflows/merge.yml/badge.svg
    :alt: GitHub Workflow Status
    :target: https://github.com/apache/buildstream/actions/workflows/merge.yml
 


### PR DESCRIPTION
Updating the README workflow page to display the status of the merges workflow, as intended; using the [official GitHub status badge](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge) rather than the shields alternative.

![merges workflow](https://github.com/apache/buildstream/actions/workflows/merge.yml/badge.svg)

The workflow badge within the project README presently displays the issue link to breaking changes within the _shields_ project relating to this badge and direct to update (https://github.com/badges/shields/issues/8671).

![merges workflow](https://img.shields.io/github/workflow/status/apache/buildstream/Merge%20actions)

The updated shields API badge can alternatively be used.

![merges workflow](https://img.shields.io/github/actions/workflow/status/apache/buildstream/merge.yml)