### PR TITLE
Add the digest-environment dependency configuration

### DIFF
--- a/src/buildstream/_artifactcache.py
+++ b/src/buildstream/_artifactcache.py
@@ -303,6 +303,10 @@ class ArtifactCache(AssetCache):
                 except FileNotFoundError:
                     pass
 
+            if artifact_proto.buildsandbox:
+                for subsandbox_digest in artifact_proto.buildsandbox.subsandbox_digests:
+                    self.cas._send_directory(remote, subsandbox_digest)
+
             digests = [artifact_digest, artifact_proto.low_diversity_meta, artifact_proto.high_diversity_meta]
 
             if str(artifact_proto.public_data):
@@ -361,6 +365,9 @@ class ArtifactCache(AssetCache):
             referenced_directories.append(artifact_proto.sources)
         if artifact_proto.buildroot:
             referenced_directories.append(artifact_proto.buildroot)
+        if artifact_proto.buildsandbox:
+            for subsandbox_digest in artifact_proto.buildsandbox.subsandbox_digests:
+                referenced_directories.append(subsandbox_digest)
 
         referenced_blobs = [artifact_proto.low_diversity_meta, artifact_proto.high_diversity_meta] + [
             log_file.digest for log_file in artifact_proto.logs
@@ -419,6 +426,9 @@ class ArtifactCache(AssetCache):
                     self.cas.fetch_directory(remote, artifact.buildtree)
                 if str(artifact.buildroot):
                     self.cas.fetch_directory(remote, artifact.buildroot)
+                if artifact.buildsandbox:
+                    for subsandbox_digest in artifact.buildsandbox.subsandbox_digests:
+                        self.cas.fetch_directory(remote, subsandbox_digest)
 
             digests = [artifact.low_diversity_meta, artifact.high_diversity_meta]
             if str(artifact.public_data):

--- a/src/buildstream/_elementproxy.py
+++ b/src/buildstream/_elementproxy.py
@@ -104,9 +104,10 @@ class ElementProxy(PluginProxy):
         owner = cast("Element", self._owner)
         element = cast("Element", self._plugin)
 
-        assert owner._overlap_collector is not None, "Attempted to stage artifacts outside of Element.stage()"
+        overlap_collector = owner._overlap_collectors.get(sandbox)
+        assert overlap_collector is not None, "Attempted to stage artifacts outside of Element.stage()"
 
-        with owner._overlap_collector.session(action, path):
+        with overlap_collector.session(action, path):
             result = element._stage_artifact(
                 sandbox, path=path, action=action, include=include, exclude=exclude, orphans=orphans, owner=owner
             )

--- a/src/buildstream/_protos/buildstream/v2/artifact.proto
+++ b/src/buildstream/_protos/buildstream/v2/artifact.proto
@@ -85,4 +85,11 @@ message Artifact {
 
   // digest of a directory
   build.bazel.remote.execution.v2.Digest buildroot = 17;  // optional
+
+  message SandboxState {
+    repeated build.bazel.remote.execution.v2.Command.EnvironmentVariable environment = 1;
+    string working_directory = 2;
+    repeated build.bazel.remote.execution.v2.Digest subsandbox_digests = 3;
+  };
+  SandboxState buildsandbox = 18;  // optional
 }

--- a/src/buildstream/_protos/buildstream/v2/artifact_pb2.py
+++ b/src/buildstream/_protos/buildstream/v2/artifact_pb2.py
@@ -26,7 +26,7 @@ from buildstream._protos.build.bazel.remote.execution.v2 import remote_execution
 from buildstream._protos.google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1d\x62uildstream/v2/artifact.proto\x12\x0e\x62uildstream.v2\x1a\x36\x62uild/bazel/remote/execution/v2/remote_execution.proto\x1a\x1cgoogle/api/annotations.proto\"\x89\x07\n\x08\x41rtifact\x12\x0f\n\x07version\x18\x01 \x01(\x05\x12\x15\n\rbuild_success\x18\x02 \x01(\x08\x12\x13\n\x0b\x62uild_error\x18\x03 \x01(\t\x12\x1b\n\x13\x62uild_error_details\x18\x04 \x01(\t\x12\x12\n\nstrong_key\x18\x05 \x01(\t\x12\x10\n\x08weak_key\x18\x06 \x01(\t\x12\x16\n\x0ewas_workspaced\x18\x07 \x01(\x08\x12\x36\n\x05\x66iles\x18\x08 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\x37\n\nbuild_deps\x18\t \x03(\x0b\x32#.buildstream.v2.Artifact.Dependency\x12<\n\x0bpublic_data\x18\n \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12.\n\x04logs\x18\x0b \x03(\x0b\x32 .buildstream.v2.Artifact.LogFile\x12:\n\tbuildtree\x18\x0c \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\x38\n\x07sources\x18\r \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\x43\n\x12low_diversity_meta\x18\x0e \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\x44\n\x13high_diversity_meta\x18\x0f \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\x12\n\nstrict_key\x18\x10 \x01(\t\x12:\n\tbuildroot\x18\x11 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x1a\x63\n\nDependency\x12\x14\n\x0cproject_name\x18\x01 \x01(\t\x12\x14\n\x0c\x65lement_name\x18\x02 \x01(\t\x12\x11\n\tcache_key\x18\x03 \x01(\t\x12\x16\n\x0ewas_workspaced\x18\x04 \x01(\x08\x1aP\n\x07LogFile\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x37\n\x06\x64igest\x18\x02 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digestb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1d\x62uildstream/v2/artifact.proto\x12\x0e\x62uildstream.v2\x1a\x36\x62uild/bazel/remote/execution/v2/remote_execution.proto\x1a\x1cgoogle/api/annotations.proto\"\x8a\t\n\x08\x41rtifact\x12\x0f\n\x07version\x18\x01 \x01(\x05\x12\x15\n\rbuild_success\x18\x02 \x01(\x08\x12\x13\n\x0b\x62uild_error\x18\x03 \x01(\t\x12\x1b\n\x13\x62uild_error_details\x18\x04 \x01(\t\x12\x12\n\nstrong_key\x18\x05 \x01(\t\x12\x10\n\x08weak_key\x18\x06 \x01(\t\x12\x16\n\x0ewas_workspaced\x18\x07 \x01(\x08\x12\x36\n\x05\x66iles\x18\x08 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\x37\n\nbuild_deps\x18\t \x03(\x0b\x32#.buildstream.v2.Artifact.Dependency\x12<\n\x0bpublic_data\x18\n \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12.\n\x04logs\x18\x0b \x03(\x0b\x32 .buildstream.v2.Artifact.LogFile\x12:\n\tbuildtree\x18\x0c \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\x38\n\x07sources\x18\r \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\x43\n\x12low_diversity_meta\x18\x0e \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\x44\n\x13high_diversity_meta\x18\x0f \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12\x12\n\nstrict_key\x18\x10 \x01(\t\x12:\n\tbuildroot\x18\x11 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x12;\n\x0c\x62uildsandbox\x18\x12 \x01(\x0b\x32%.buildstream.v2.Artifact.SandboxState\x1a\x63\n\nDependency\x12\x14\n\x0cproject_name\x18\x01 \x01(\t\x12\x14\n\x0c\x65lement_name\x18\x02 \x01(\t\x12\x11\n\tcache_key\x18\x03 \x01(\t\x12\x16\n\x0ewas_workspaced\x18\x04 \x01(\x08\x1aP\n\x07LogFile\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x37\n\x06\x64igest\x18\x02 \x01(\x0b\x32\'.build.bazel.remote.execution.v2.Digest\x1a\xc1\x01\n\x0cSandboxState\x12Q\n\x0b\x65nvironment\x18\x01 \x03(\x0b\x32<.build.bazel.remote.execution.v2.Command.EnvironmentVariable\x12\x19\n\x11working_directory\x18\x02 \x01(\t\x12\x43\n\x12subsandbox_digests\x18\x03 \x03(\x0b\x32\'.build.bazel.remote.execution.v2.Digestb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -34,9 +34,11 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'buildstream.v2.artifact_pb2
 if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
   _globals['_ARTIFACT']._serialized_start=136
-  _globals['_ARTIFACT']._serialized_end=1041
-  _globals['_ARTIFACT_DEPENDENCY']._serialized_start=860
-  _globals['_ARTIFACT_DEPENDENCY']._serialized_end=959
-  _globals['_ARTIFACT_LOGFILE']._serialized_start=961
-  _globals['_ARTIFACT_LOGFILE']._serialized_end=1041
+  _globals['_ARTIFACT']._serialized_end=1298
+  _globals['_ARTIFACT_DEPENDENCY']._serialized_start=921
+  _globals['_ARTIFACT_DEPENDENCY']._serialized_end=1020
+  _globals['_ARTIFACT_LOGFILE']._serialized_start=1022
+  _globals['_ARTIFACT_LOGFILE']._serialized_end=1102
+  _globals['_ARTIFACT_SANDBOXSTATE']._serialized_start=1105
+  _globals['_ARTIFACT_SANDBOXSTATE']._serialized_end=1298
 # @@protoc_insertion_point(module_scope)

--- a/src/buildstream/_protos/buildstream/v2/artifact_pb2.pyi
+++ b/src/buildstream/_protos/buildstream/v2/artifact_pb2.pyi
@@ -8,7 +8,7 @@ from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Map
 DESCRIPTOR: _descriptor.FileDescriptor
 
 class Artifact(_message.Message):
-    __slots__ = ("version", "build_success", "build_error", "build_error_details", "strong_key", "weak_key", "was_workspaced", "files", "build_deps", "public_data", "logs", "buildtree", "sources", "low_diversity_meta", "high_diversity_meta", "strict_key", "buildroot")
+    __slots__ = ("version", "build_success", "build_error", "build_error_details", "strong_key", "weak_key", "was_workspaced", "files", "build_deps", "public_data", "logs", "buildtree", "sources", "low_diversity_meta", "high_diversity_meta", "strict_key", "buildroot", "buildsandbox")
     class Dependency(_message.Message):
         __slots__ = ("project_name", "element_name", "cache_key", "was_workspaced")
         PROJECT_NAME_FIELD_NUMBER: _ClassVar[int]
@@ -27,6 +27,15 @@ class Artifact(_message.Message):
         name: str
         digest: _remote_execution_pb2.Digest
         def __init__(self, name: _Optional[str] = ..., digest: _Optional[_Union[_remote_execution_pb2.Digest, _Mapping]] = ...) -> None: ...
+    class SandboxState(_message.Message):
+        __slots__ = ("environment", "working_directory", "subsandbox_digests")
+        ENVIRONMENT_FIELD_NUMBER: _ClassVar[int]
+        WORKING_DIRECTORY_FIELD_NUMBER: _ClassVar[int]
+        SUBSANDBOX_DIGESTS_FIELD_NUMBER: _ClassVar[int]
+        environment: _containers.RepeatedCompositeFieldContainer[_remote_execution_pb2.Command.EnvironmentVariable]
+        working_directory: str
+        subsandbox_digests: _containers.RepeatedCompositeFieldContainer[_remote_execution_pb2.Digest]
+        def __init__(self, environment: _Optional[_Iterable[_Union[_remote_execution_pb2.Command.EnvironmentVariable, _Mapping]]] = ..., working_directory: _Optional[str] = ..., subsandbox_digests: _Optional[_Iterable[_Union[_remote_execution_pb2.Digest, _Mapping]]] = ...) -> None: ...
     VERSION_FIELD_NUMBER: _ClassVar[int]
     BUILD_SUCCESS_FIELD_NUMBER: _ClassVar[int]
     BUILD_ERROR_FIELD_NUMBER: _ClassVar[int]
@@ -44,6 +53,7 @@ class Artifact(_message.Message):
     HIGH_DIVERSITY_META_FIELD_NUMBER: _ClassVar[int]
     STRICT_KEY_FIELD_NUMBER: _ClassVar[int]
     BUILDROOT_FIELD_NUMBER: _ClassVar[int]
+    BUILDSANDBOX_FIELD_NUMBER: _ClassVar[int]
     version: int
     build_success: bool
     build_error: str
@@ -61,4 +71,5 @@ class Artifact(_message.Message):
     high_diversity_meta: _remote_execution_pb2.Digest
     strict_key: str
     buildroot: _remote_execution_pb2.Digest
-    def __init__(self, version: _Optional[int] = ..., build_success: bool = ..., build_error: _Optional[str] = ..., build_error_details: _Optional[str] = ..., strong_key: _Optional[str] = ..., weak_key: _Optional[str] = ..., was_workspaced: bool = ..., files: _Optional[_Union[_remote_execution_pb2.Digest, _Mapping]] = ..., build_deps: _Optional[_Iterable[_Union[Artifact.Dependency, _Mapping]]] = ..., public_data: _Optional[_Union[_remote_execution_pb2.Digest, _Mapping]] = ..., logs: _Optional[_Iterable[_Union[Artifact.LogFile, _Mapping]]] = ..., buildtree: _Optional[_Union[_remote_execution_pb2.Digest, _Mapping]] = ..., sources: _Optional[_Union[_remote_execution_pb2.Digest, _Mapping]] = ..., low_diversity_meta: _Optional[_Union[_remote_execution_pb2.Digest, _Mapping]] = ..., high_diversity_meta: _Optional[_Union[_remote_execution_pb2.Digest, _Mapping]] = ..., strict_key: _Optional[str] = ..., buildroot: _Optional[_Union[_remote_execution_pb2.Digest, _Mapping]] = ...) -> None: ...
+    buildsandbox: Artifact.SandboxState
+    def __init__(self, version: _Optional[int] = ..., build_success: bool = ..., build_error: _Optional[str] = ..., build_error_details: _Optional[str] = ..., strong_key: _Optional[str] = ..., weak_key: _Optional[str] = ..., was_workspaced: bool = ..., files: _Optional[_Union[_remote_execution_pb2.Digest, _Mapping]] = ..., build_deps: _Optional[_Iterable[_Union[Artifact.Dependency, _Mapping]]] = ..., public_data: _Optional[_Union[_remote_execution_pb2.Digest, _Mapping]] = ..., logs: _Optional[_Iterable[_Union[Artifact.LogFile, _Mapping]]] = ..., buildtree: _Optional[_Union[_remote_execution_pb2.Digest, _Mapping]] = ..., sources: _Optional[_Union[_remote_execution_pb2.Digest, _Mapping]] = ..., low_diversity_meta: _Optional[_Union[_remote_execution_pb2.Digest, _Mapping]] = ..., high_diversity_meta: _Optional[_Union[_remote_execution_pb2.Digest, _Mapping]] = ..., strict_key: _Optional[str] = ..., buildroot: _Optional[_Union[_remote_execution_pb2.Digest, _Mapping]] = ..., buildsandbox: _Optional[_Union[Artifact.SandboxState, _Mapping]] = ...) -> None: ...

--- a/src/buildstream/buildelement.py
+++ b/src/buildstream/buildelement.py
@@ -219,6 +219,7 @@ class BuildElement(Element):
     def configure_dependencies(self, dependencies):
 
         self.__layout = {}  # pylint: disable=attribute-defined-outside-init
+        self.__digest_environment = {}  # pylint: disable=attribute-defined-outside-init
 
         # FIXME: Currently this forcefully validates configurations
         #        for all BuildElement subclasses so they are unable to
@@ -227,9 +228,18 @@ class BuildElement(Element):
         for dep in dependencies:
             # Determine the location to stage each element, default is "/"
             location = "/"
+
             if dep.config:
-                dep.config.validate_keys(["location"])
-                location = dep.config.get_str("location")
+                dep.config.validate_keys(["digest-environment", "location"])
+
+                location = dep.config.get_str("location", "/")
+
+                digest_var_name = dep.config.get_str("digest-environment", None)
+
+                if digest_var_name is not None:
+                    element_list = self.__digest_environment.setdefault(digest_var_name, [])
+                    element_list.append((dep.element, dep.path))
+
             try:
                 element_list = self.__layout[location]
             except KeyError:
@@ -268,6 +278,16 @@ class BuildElement(Element):
             }
             dictionary["layout"] = layout_key
 
+        # Specify the layout in the key, if buildstream is to generate an environment
+        # variable with the digest
+        #
+        if self.__digest_environment:
+            sorted_envs = sorted(self.__digest_environment)
+            digest_key = {
+                env: [dependency_path for _, dependency_path in self.__digest_environment[env]] for env in sorted_envs
+            }
+            dictionary["digest-enviornment"] = digest_key
+
         return dictionary
 
     def configure_sandbox(self, sandbox):
@@ -286,7 +306,20 @@ class BuildElement(Element):
         sandbox.set_work_directory(command_dir)
 
         # Setup environment
-        sandbox.set_environment(self.get_environment())
+        env = self.get_environment()
+
+        # Add "CAS digest" environment variables
+        sorted_envs = sorted(self.__digest_environment)
+        for digest_variable in sorted_envs:
+            element_list = [element for element, _ in self.__digest_environment[digest_variable]]
+            with self.timed_activity(
+                f"Staging dependencies for '{digest_variable}' in subsandbox", silent_nested=True
+            ), self.subsandbox(sandbox) as subsandbox:
+                self.stage_dependency_artifacts(subsandbox, element_list)
+                digest = subsandbox.get_virtual_directory()._get_digest()
+            env[digest_variable] = "{}/{}".format(digest.hash, digest.size_bytes)
+
+        sandbox.set_environment(env)
 
     def stage(self, sandbox):
 

--- a/src/buildstream/buildelement.py
+++ b/src/buildstream/buildelement.py
@@ -76,6 +76,31 @@ an alternative location while staging some elements in the sandbox root.
     directories before subdirectories.
 
 
+`digest-environment` for dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The BuildElement supports the ``digest-environment`` :term:`dependency configuration <Dependency configuration>`,
+which sets the specified environment variable in the build sandbox to the CAS digest
+corresponding to a directory that contains all dependencies that are configured
+with the same ``digest-environment``.
+
+This is useful for REAPI clients in the sandbox such as `recc <https://buildgrid.gitlab.io/recc>`_,
+see ``remote-apis-socket`` in the :ref:`sandbox configuration <format_sandbox>`.
+
+**Example:**
+
+Here is an example of how to set the environment variable `GCC_DIGEST` to the
+CAS digest of a directory that contains ``gcc.bst`` and its runtime dependencies.
+The ``libpony.bst`` dependency will not be included in that CAS directory.
+
+.. code:: yaml
+
+   build-depends:
+   - baseproject.bst:gcc.bst
+     config:
+       digest-environment: GCC_DIGEST
+   - libpony.bst
+
+
 Location for running commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ``command-subdir`` variable sets where commands will be executed,

--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -828,6 +828,21 @@ class Element(Plugin):
 
         sandbox._clean_directory(build_root)
 
+    @contextmanager
+    def subsandbox(self, sandbox: "Sandbox") -> Iterator["Sandbox"]:
+        """A context manager for a subsandbox.
+
+        Args:
+           sandbox: The main build sandbox
+
+        This allows an element to use a secondary sandbox for manipulating
+        artifacts without affecting the main build sandbox. The subsandbox
+        is initially empty.
+        """
+        subsandbox = sandbox._create_subsandbox()
+        with self.__collect_overlaps(subsandbox):
+            yield subsandbox
+
     #############################################################
     #            Private Methods used in BuildStream            #
     #############################################################

--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -1440,18 +1440,25 @@ class Element(Plugin):
         # pylint: disable-next=contextmanager-generator-missing-cleanup
         with self.__sandbox(config=self.__sandbox_config, allow_remote=False) as sandbox:
 
-            # Configure always comes first, and we need it.
-            self.__configure_sandbox(sandbox)
-
             if usebuildtree:
+                # Configure the sandbox from artifact metadata
+                self.__artifact.configure_sandbox(sandbox)
+
                 # Use the cached buildroot directly
                 buildrootvdir = self.__artifact.get_buildroot()
                 sandbox_vroot = sandbox.get_virtual_directory()
                 sandbox_vroot._import_files_internal(buildrootvdir, collect_result=False)
             elif shell and scope == _Scope.BUILD:
+                self.__configure_sandbox(sandbox)
                 # Stage what we need
                 self.__stage(sandbox)
             else:
+                # Runtime shell or `bst artifact checkout`
+
+                # Don't call `configure_sandbox()` as that may attempt to construct subsandboxes
+                # with build dependencies and we're not setting up a build sandbox.
+                sandbox.set_environment(self.get_environment())
+
                 # Stage deps in the sandbox root
                 with self.timed_activity("Staging dependencies", silent_nested=True), self.__collect_overlaps(sandbox):
                     self._stage_dependency_artifacts(sandbox, scope)
@@ -1787,6 +1794,7 @@ class Element(Plugin):
                 variables=self.__variables,
                 environment=self.__environment,
                 sandboxconfig=self.__sandbox_config,
+                buildsandbox=sandbox if buildrootvdir else None,
             )
 
         if collect is not None and collectvdir is None:

--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -1663,11 +1663,6 @@ class Element(Plugin):
         # Assert call ordering
         assert not self._cached_success()
 
-        # Print the environment at the beginning of the log file.
-        env_dump = _yaml.roundtrip_dump_string(self.get_environment())
-
-        self.log("Build environment for element {}".format(self.name), detail=env_dump)
-
         context = self._get_context()
         with self._output_file() as output_file:
 
@@ -1693,6 +1688,11 @@ class Element(Plugin):
 
                 # Step 1 - Configure
                 self.__configure_sandbox(sandbox)
+
+                # Print the environment at the beginning of the log file.
+                env_dump = _yaml.roundtrip_dump_string(sandbox._get_configured_environment() or self.get_environment())
+                self.log("Build environment for element {}".format(self.name), detail=env_dump)
+
                 # Step 2 - Stage
                 self.__stage(sandbox)
                 try:
@@ -2037,7 +2037,7 @@ class Element(Plugin):
     def _shell(self, scope=None, *, mounts=None, isolate=False, prompt=None, command=None, usebuildtree=False):
 
         with self._prepare_sandbox(scope, shell=True, usebuildtree=usebuildtree) as sandbox:
-            environment = self.get_environment()
+            environment = sandbox._get_configured_environment() or self.get_environment()
             environment = copy.copy(environment)
             flags = _SandboxFlags.INTERACTIVE | _SandboxFlags.ROOT_READ_ONLY
 

--- a/src/buildstream/sandbox/_sandboxremote.py
+++ b/src/buildstream/sandbox/_sandboxremote.py
@@ -174,9 +174,17 @@ class SandboxRemote(SandboxREAPI):
                 "Uploading input root", element_name=self._get_element_name()
             ):
                 # Determine blobs missing on remote
+                root_digests = [action.input_root_digest]
+
+                # Add virtual directories for subsandboxes
+                for subsandbox in self._get_subsandboxes():
+                    vdir = subsandbox.get_virtual_directory()
+                    root_digests.append(vdir._get_digest())
+
+                missing_blobs = []
                 try:
-                    input_root_digest = action.input_root_digest
-                    missing_blobs = list(cascache.missing_blobs_for_directory(input_root_digest, remote=casremote))
+                    for root_digest in root_digests:
+                        missing_blobs.extend(cascache.missing_blobs_for_directory(root_digest, remote=casremote))
                 except grpc.RpcError as e:
                     raise SandboxError("Failed to determine missing blobs: {}".format(e)) from e
 

--- a/src/buildstream/sandbox/sandbox.py
+++ b/src/buildstream/sandbox/sandbox.py
@@ -438,6 +438,16 @@ class Sandbox:
 
         return env
 
+    # _get_configured_environment()
+    #
+    # Return the environment exactly as configured with `set_environment()`,
+    # or `None` if `set_environment()` has not been called.
+    #
+    # Returns
+    #   (Dict[str, str]): The configured environment
+    def _get_configured_environment(self):
+        return self.__env
+
     # _get_work_directory()
     #
     # Fetches the working directory for running commands

--- a/src/buildstream/sandbox/sandbox.py
+++ b/src/buildstream/sandbox/sandbox.py
@@ -85,13 +85,18 @@ class Sandbox:
         self.__env = None  # type: Optional[Dict[str, str]]
         self.__mount_sources = {}  # type: Dict[str, str]
         self.__allow_run = True
+        self.__subsandboxes = []  # type: List[Sandbox]
 
         # Plugin element full name for logging
         plugin = kwargs.get("plugin", None)
         if plugin:
             self.__element_name = plugin._get_full_name()
         else:
-            self.__element_name = None
+            parent = kwargs.get("parent", None)
+            if parent:
+                self.__element_name = parent._get_element_name()
+            else:
+                self.__element_name = None
 
         # Configuration from kwargs common to all subclasses
         self.__config = kwargs["config"]
@@ -567,6 +572,28 @@ class Sandbox:
     #
     def _disable_run(self):
         self.__allow_run = False
+
+    # _create_subsandbox()
+    #
+    # Create an empty sandbox
+    #
+    # This allows an element to use a secondary sandbox for manipulating artifacts
+    # that does not affect the build sandbox.
+    #
+    def _create_subsandbox(self, **kwargs):
+        sub = Sandbox(
+            self.__context,
+            self.__project,
+            parent=self,
+            stdout=self.__stdout,
+            stderr=self.__stderr,
+            config=self.__config,
+        )
+        self.__subsandboxes.append(sub)
+        return sub
+
+    def _get_subsandboxes(self):
+        return self.__subsandboxes
 
 
 # SandboxFlags()

--- a/tests/integration/digest-environment.py
+++ b/tests/integration/digest-environment.py
@@ -1,0 +1,158 @@
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# Pylint doesn't play well with fixtures and dependency injection from pytest
+# pylint: disable=redefined-outer-name
+
+import os
+import shutil
+
+import pytest
+
+from buildstream._testing import cli_integration as cli  # pylint: disable=unused-import
+from buildstream._testing._utils.site import HAVE_SANDBOX
+
+from tests.testutils import create_artifact_share
+
+pytestmark = pytest.mark.integration
+
+
+DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project")
+
+
+# Test that the digest environment variable is set correctly during a build
+@pytest.mark.skipif(not HAVE_SANDBOX, reason="Only available with a functioning sandbox")
+@pytest.mark.datafiles(DATA_DIR)
+def test_build_checkout_base(cli, datafiles):
+    project = str(datafiles)
+    element_name = "digest-environment/base.bst"
+
+    result = cli.run(project=project, args=["build", element_name])
+    assert result.exit_code == 0
+
+    result = cli.run(project=project, args=["artifact", "checkout", element_name])
+    assert result.exit_code == 0
+
+
+# Test that the digest environment variable is not affected by unrelated build dependencies
+@pytest.mark.skipif(not HAVE_SANDBOX, reason="Only available with a functioning sandbox")
+@pytest.mark.datafiles(DATA_DIR)
+def test_build_base_plus_extra_dep(cli, datafiles):
+    project = str(datafiles)
+    element_name = "digest-environment/base-plus-extra-dep.bst"
+
+    result = cli.run(project=project, args=["build", element_name])
+    assert result.exit_code == 0
+
+
+# Test that multiple dependencies can be merged into a single digest environment variable
+@pytest.mark.skipif(not HAVE_SANDBOX, reason="Only available with a functioning sandbox")
+@pytest.mark.datafiles(DATA_DIR)
+def test_build_merge(cli, datafiles):
+    project = str(datafiles)
+    element_name = "digest-environment/merge.bst"
+
+    result = cli.run(project=project, args=["build", element_name])
+    assert result.exit_code == 0
+
+
+# Test that multiple digest environment variables can be configured in a single element
+@pytest.mark.skipif(not HAVE_SANDBOX, reason="Only available with a functioning sandbox")
+@pytest.mark.datafiles(DATA_DIR)
+def test_build_two(cli, datafiles):
+    project = str(datafiles)
+    element_name = "digest-environment/two.bst"
+
+    result = cli.run(project=project, args=["build", element_name])
+    assert result.exit_code == 0
+
+
+# Test that the digest environment variable is also set in a build shell
+@pytest.mark.skipif(not HAVE_SANDBOX, reason="Only available with a functioning sandbox")
+@pytest.mark.datafiles(DATA_DIR)
+def test_build_shell(cli, datafiles):
+    project = str(datafiles)
+    element_name = "digest-environment/base.bst"
+
+    # Ensure artifacts of build dependencies are available for build shell
+    result = cli.run(project=project, args=["build", "--deps", "build", element_name])
+    assert result.exit_code == 0
+
+    result = cli.run(project=project, args=["shell", "--build", element_name, "--", "sh", "-c", "echo $BASE_DIGEST"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "63450d93eab71f525d08378fe50960aff92b0ec8f1b0be72b2ac4b8259d09833/1227"
+
+
+# Test that the digest environment variable is also set in a build shell staged from a buildtree
+@pytest.mark.skipif(not HAVE_SANDBOX, reason="Only available with a functioning sandbox")
+@pytest.mark.datafiles(DATA_DIR)
+def test_build_shell_buildtree(cli, datafiles):
+    project = str(datafiles)
+    element_name = "digest-environment/base-buildtree.bst"
+
+    # Generate buildtree
+    result = cli.run(project=project, args=["--cache-buildtrees", "always", "build", element_name])
+    assert result.exit_code == 0
+
+    result = cli.run(
+        project=project,
+        args=["shell", "--build", "--use-buildtree", element_name, "--", "sh", "-c", "echo $BASE_DIGEST"],
+    )
+    assert result.exit_code == 0
+    assert result.output.strip() == "63450d93eab71f525d08378fe50960aff92b0ec8f1b0be72b2ac4b8259d09833/1227"
+
+
+# Test that buildtree push works for elements with a digest environment variable
+@pytest.mark.skipif(not HAVE_SANDBOX, reason="Only available with a functioning sandbox")
+@pytest.mark.datafiles(DATA_DIR)
+def test_pushed_buildtree(cli, tmpdir, datafiles):
+    project = str(datafiles)
+    element_name = "digest-environment/merge.bst"
+
+    with create_artifact_share(os.path.join(str(tmpdir), "share")) as share:
+        cli.configure(
+            {
+                "artifacts": {"servers": [{"url": share.repo, "push": True}]},
+                "cachedir": str(tmpdir),
+                "cache": {"cache-buildtrees": "always"},
+            }
+        )
+
+        # Generate buildtree
+        result = cli.run(project=project, args=["build", element_name])
+        assert result.exit_code == 0
+
+        assert cli.get_element_state(project, element_name) == "cached"
+        assert share.get_artifact(cli.get_artifact_name(project, "test", element_name))
+
+        # Clear the local cache to make sure everything can and will be pulled from the remote
+        shutil.rmtree(os.path.join(str(tmpdir), "cas"))
+        shutil.rmtree(os.path.join(str(tmpdir), "artifacts"))
+
+        result = cli.run(
+            project=project,
+            args=[
+                "--pull-buildtrees",
+                "shell",
+                "--build",
+                "--use-buildtree",
+                element_name,
+                "--",
+                "sh",
+                "-c",
+                "echo $MERGED_DIGEST",
+            ],
+        )
+        assert result.exit_code == 0
+        assert result.output.strip() == "469369597f4faa56c4b8338d6a948c8c1d4f29e6ea8f4d4d261cac4182bcef48/1389"

--- a/tests/integration/project/elements/digest-environment/base-buildtree.bst
+++ b/tests/integration/project/elements/digest-environment/base-buildtree.bst
@@ -1,0 +1,12 @@
+kind: manual
+
+depends:
+  - filename: base.bst
+    type: build
+    config:
+      digest-environment: BASE_DIGEST
+
+config:
+  build-commands:
+    - env
+    - test "$BASE_DIGEST" = "63450d93eab71f525d08378fe50960aff92b0ec8f1b0be72b2ac4b8259d09833/1227"

--- a/tests/integration/project/elements/digest-environment/base-plus-extra-dep.bst
+++ b/tests/integration/project/elements/digest-environment/base-plus-extra-dep.bst
@@ -1,0 +1,14 @@
+kind: manual
+
+depends:
+  - filename: base.bst
+    type: build
+    config:
+      digest-environment: BASE_DIGEST
+  - filename: manual/import-file.bst
+    type: build
+
+config:
+  build-commands:
+    - env
+    - test "$BASE_DIGEST" = "63450d93eab71f525d08378fe50960aff92b0ec8f1b0be72b2ac4b8259d09833/1227"

--- a/tests/integration/project/elements/digest-environment/base.bst
+++ b/tests/integration/project/elements/digest-environment/base.bst
@@ -1,0 +1,12 @@
+kind: manual
+
+depends:
+  - filename: base.bst
+    type: build
+    config:
+      digest-environment: BASE_DIGEST
+
+config:
+  build-commands:
+    - env
+    - test "$BASE_DIGEST" = "63450d93eab71f525d08378fe50960aff92b0ec8f1b0be72b2ac4b8259d09833/1227"

--- a/tests/integration/project/elements/digest-environment/merge.bst
+++ b/tests/integration/project/elements/digest-environment/merge.bst
@@ -1,0 +1,16 @@
+kind: manual
+
+depends:
+  - filename: base.bst
+    type: build
+    config:
+      digest-environment: MERGED_DIGEST
+  - filename: manual/import-file.bst
+    type: build
+    config:
+      digest-environment: MERGED_DIGEST
+
+config:
+  build-commands:
+    - env
+    - test "$MERGED_DIGEST" = "469369597f4faa56c4b8338d6a948c8c1d4f29e6ea8f4d4d261cac4182bcef48/1389"

--- a/tests/integration/project/elements/digest-environment/two.bst
+++ b/tests/integration/project/elements/digest-environment/two.bst
@@ -1,0 +1,17 @@
+kind: manual
+
+depends:
+  - filename: base.bst
+    type: build
+    config:
+      digest-environment: BASE_DIGEST
+  - filename: manual/import-file.bst
+    type: build
+    config:
+      digest-environment: IMPORT_DIGEST
+
+config:
+  build-commands:
+    - env
+    - test "$BASE_DIGEST" = "63450d93eab71f525d08378fe50960aff92b0ec8f1b0be72b2ac4b8259d09833/1227"
+    - test "$IMPORT_DIGEST" = "eec5ed9053acb296a8e7a30ab7ee173abf4f7392b8228ba7644cd5b51a5cfdeb/162"


### PR DESCRIPTION
This allows setting an environment variable inside the sandbox to the CAS digest of one or more dependencies.

This us useful when communicating with the nested remote execution endpoint, but could also be used independently.

This PR replaced #1991.