### PR TITLE
sandbox: Add support for action cache updates via `remote-apis-socket`

### DIFF
--- a/.github/common.env
+++ b/.github/common.env
@@ -1,6 +1,6 @@
 # Shared common variables
 
-CI_IMAGE_VERSION=master-1869708273
+CI_IMAGE_VERSION=master-1938898146
 CI_TOXENV_MAIN=py39,py310,py311,py312,py313
 CI_TOXENV_PLUGINS=py39-plugins,py310-plugins,py311-plugins,py312-plugins,py313-plugins
 CI_TOXENV_ALL="${CI_TOXENV_MAIN},${CI_TOXENV_PLUGINS}"

--- a/doc/source/format_declaring.rst
+++ b/doc/source/format_declaring.rst
@@ -395,6 +395,7 @@ having implemented these options the same as buildstream.
    sandbox:
      remote-apis-socket:
        path: /run/reapi.sock
+       action-cache-enable-update: false
 
 Setting a path will add a UNIX socket to the sandbox that allows the use of
 `REAPI <https://github.com/bazelbuild/remote-apis>`_ clients such as
@@ -406,6 +407,15 @@ to speed up rebuilds of elements with only small changes.
 This is supported with and without :ref:`remote execution <user_config_remote_execution>`.
 With remote execution configured, this additionally enables scaling out of,
 e.g., compile commands across a cluster of build machines.
+
+Action cache updates from sandboxed REAPI clients are disabled by default to
+protect action cache integrity. However, if a trusted REAPI client doesn't
+support remote execution, action cache updates can be enabled by setting
+``action-cache-enable-update`` to ``true``.
+If a remote ``action-cache-service`` is configured without ``execution-service``
+in the :ref:`remote execution <user_config_remote_execution>` section,
+``push`` needs to be set to ``true`` to allow action cache updates to be pushed
+to the server.
 
 
 .. _format_dependencies:

--- a/src/buildstream/sandbox/_config.py
+++ b/src/buildstream/sandbox/_config.py
@@ -52,13 +52,15 @@ class SandboxConfig:
         build_arch: str,
         build_uid: Optional[int] = None,
         build_gid: Optional[int] = None,
-        remote_apis_socket_path: Optional[str] = None
+        remote_apis_socket_path: Optional[str] = None,
+        remote_apis_socket_action_cache_enable_update: bool = False
     ):
         self.build_os = build_os
         self.build_arch = build_arch
         self.build_uid = build_uid
         self.build_gid = build_gid
         self.remote_apis_socket_path = remote_apis_socket_path
+        self.remote_apis_socket_action_cache_enable_update = remote_apis_socket_action_cache_enable_update
 
     # to_dict():
     #
@@ -74,7 +76,7 @@ class SandboxConfig:
     # Returns:
     #    A dictionary representation of this SandboxConfig
     #
-    def to_dict(self) -> Dict[str, Union[str, int]]:
+    def to_dict(self) -> Dict[str, Union[str, int, bool]]:
 
         # Assign mandatory portions of the sandbox configuration
         #
@@ -82,7 +84,7 @@ class SandboxConfig:
         #     the sandbox configuration, as that would result in
         #     breaking cache key stability.
         #
-        sandbox_dict: Dict[str, Union[str, int]] = {"build-os": self.build_os, "build-arch": self.build_arch}
+        sandbox_dict: Dict[str, Union[str, int, bool]] = {"build-os": self.build_os, "build-arch": self.build_arch}
 
         # Assign optional portions of the sandbox configuration
         #
@@ -97,6 +99,8 @@ class SandboxConfig:
 
         if self.remote_apis_socket_path is not None:
             sandbox_dict["remote-apis-socket-path"] = self.remote_apis_socket_path
+            if self.remote_apis_socket_action_cache_enable_update:
+                sandbox_dict["remote-apis-socket-action-cache-enable-update"] = True
 
         return sandbox_dict
 
@@ -145,10 +149,14 @@ class SandboxConfig:
 
         remote_apis_socket = config.get_mapping("remote-apis-socket", default=None)
         if remote_apis_socket:
-            remote_apis_socket.validate_keys(["path"])
+            remote_apis_socket.validate_keys(["path", "action-cache-enable-update"])
             remote_apis_socket_path = remote_apis_socket.get_str("path")
+            remote_apis_socket_action_cache_enable_update = remote_apis_socket.get_bool(
+                "action-cache-enable-update", default=False
+            )
         else:
             remote_apis_socket_path = None
+            remote_apis_socket_action_cache_enable_update = False
 
         return cls(
             build_os=build_os,
@@ -156,4 +164,5 @@ class SandboxConfig:
             build_uid=build_uid,
             build_gid=build_gid,
             remote_apis_socket_path=remote_apis_socket_path,
+            remote_apis_socket_action_cache_enable_update=remote_apis_socket_action_cache_enable_update,
         )

--- a/src/buildstream/sandbox/_sandboxbuildboxrun.py
+++ b/src/buildstream/sandbox/_sandboxbuildboxrun.py
@@ -132,6 +132,8 @@ class SandboxBuildBoxRun(SandboxREAPI):
 
             if self.re_remote:
                 buildbox_command.append("--instance={}".format(self.re_remote.local_cas_instance_name))
+                if config.remote_apis_socket_action_cache_enable_update:
+                    buildbox_command.append("--nested-ac-enable-update")
 
             # Do not redirect stdout/stderr
             if "no-logs-capture" in self._capabilities:

--- a/tests/integration/project/elements/sandbox/remote-apis-socket-ac-update.bst
+++ b/tests/integration/project/elements/sandbox/remote-apis-socket-ac-update.bst
@@ -1,0 +1,14 @@
+kind: manual
+
+depends:
+  - filename: base.bst
+    type: build
+
+sandbox:
+  remote-apis-socket:
+    path: /tmp/reapi.sock
+    action-cache-enable-update: true
+
+config:
+  build-commands:
+    - test -S /tmp/reapi.sock

--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -83,6 +83,27 @@ def test_remote_apis_socket_with_action_cache(cli, tmpdir, datafiles):
         assert result.exit_code == 0
 
 
+# Test configuration with remote action cache for nested REAPI with updates enabled.
+@pytest.mark.skipif(not HAVE_SANDBOX, reason="Only available with a functioning sandbox")
+@pytest.mark.datafiles(DATA_DIR)
+def test_remote_apis_socket_with_action_cache_update(cli, tmpdir, datafiles):
+    project = str(datafiles)
+    element_name = "sandbox/remote-apis-socket-ac-update.bst"
+
+    with create_artifact_share(os.path.join(str(tmpdir), "remote")) as share:
+        cli.configure(
+            {
+                "remote-execution": {
+                    "storage-service": {"url": share.repo},
+                    "action-cache-service": {"url": share.repo, "push": True},
+                }
+            }
+        )
+
+        result = cli.run(project=project, args=["build", element_name])
+        assert result.exit_code == 0
+
+
 # Test configuration with cache storage-service and remote action cache for nested REAPI.
 @pytest.mark.skipif(not HAVE_SANDBOX, reason="Only available with a functioning sandbox")
 @pytest.mark.datafiles(DATA_DIR)


### PR DESCRIPTION
Action cache updates from sandboxed REAPI clients are disabled by default to protect action cache integrity. However, if a trusted REAPI client doesn't support remote execution, this branch allows action cache updates to be enabled by setting `action-cache-enable-update` to `true`. This requires an `action-cache-service` to be configured with `push` set to `true`.