### PR TITLE
tar.py: Fix hardlink extraction with latest Python

### DIFF
--- a/src/buildstream/plugins/sources/tar.py
+++ b/src/buildstream/plugins/sources/tar.py
@@ -145,14 +145,14 @@ class TarSource(DownloadableFileSource):
                         base_dir = base_dir + os.sep
 
                 filter_function = functools.partial(self._extract_filter, base_dir)
+                filtered_members = []
+                for member in tar.getmembers():
+                    member = filter_function(member, directory)
+                    if member is not None:
+                        filtered_members.append(member)
                 if sys.version_info >= (3, 12):
-                    tar.extractall(path=directory, filter=filter_function)
+                    tar.extractall(path=directory, members=filtered_members, filter="tar")
                 else:
-                    filtered_members = []
-                    for member in tar.getmembers():
-                        member = filter_function(member, directory)
-                        if member is not None:
-                            filtered_members.append(member)
                     tar.extractall(path=directory, members=filtered_members)
 
         except (tarfile.TarError, OSError) as e:

--- a/tests/sources/tar/symlinks/target.bst
+++ b/tests/sources/tar/symlinks/target.bst
@@ -1,0 +1,5 @@
+kind: import
+description: The kind of this element is irrelevant.
+sources:
+- kind: tar
+  url: tmpdir:/contents.tar.gz


### PR DESCRIPTION
Recent Python security fixes to the tarfile module (included in 3.13.4 but also backported to older branches) require link targets to pass the specified filter function as well. This can result in hardlinked files to not be extracted when a `base-dir` is set.

This commit separates the filtering from the extraction to avoid this issue. Pass `filter="tar"` as Python 3.14+ will default to the too restrictive `filter="data"`.

https://github.com/python/cpython/pull/135037

Fixes #2029.