### PR TITLE
requirements: Relax protobuf version constraint

### DIFF
--- a/doc/source/hacking/grpc_protocols.rst
+++ b/doc/source/hacking/grpc_protocols.rst
@@ -36,6 +36,3 @@ To actually regenerate the code::
 
   ./setup.py build_grpc
 
-The ``requirements/requirements.in`` file needs to be updated to match the
-protobuf version requirements of the ``grpcio-tools`` version used to
-generate the code.

--- a/doc/source/hacking/grpc_protocols.rst
+++ b/doc/source/hacking/grpc_protocols.rst
@@ -27,12 +27,9 @@ git repository to avoid depending on grpcio-tools for user installations.
 Regenerating code
 ~~~~~~~~~~~~~~~~~
 When ``.proto`` files are modified, the corresponding Python code needs to
-be regenerated.  As a prerequisite for code generation you need to install
-``grpcio-tools`` using pip or some other mechanism::
+be regenerated::
 
-  pip3 install --user grpcio-tools
+  tox -e build-grpc
 
-To actually regenerate the code::
-
-  ./setup.py build_grpc
-
+This installs the correct version of ``grpcio-tools`` and regenerates the
+protobuf and grpc code.

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -4,7 +4,7 @@ Jinja2 >= 2.10
 importlib_metadata >= 3.6; python_version < "3.10"
 packaging
 pluginbase
-protobuf <6.0dev,>=5.29
+protobuf <9,>=5.29
 psutil
 ruamel.yaml >= 0.16.7
 ruamel.yaml.clib >= 0.1.2

--- a/setup.py
+++ b/setup.py
@@ -202,12 +202,6 @@ class BuildGRPC(Command):
                     with open(path, "w", encoding="utf-8") as f:
                         f.write(code)
 
-        print(
-            "\n"
-            "NOTE: Please update requirements/requirements.in to match the protobuf\n"
-            "requirement in the grpcio-tools version you used."
-        )
-
 
 def get_cmdclass():
     cmdclass = {

--- a/tox.ini
+++ b/tox.ini
@@ -258,3 +258,14 @@ deps =
 # installed by the base environment.
 [testenv:.package]
 deps =
+
+
+#
+# Regenerate protobuf and grpc code
+#
+[testenv:build-grpc]
+skip_install = True
+commands = python setup.py build_grpc
+deps =
+    grpcio-tools==1.69.0  # Requires protobuf >= 5.29
+    Cython


### PR DESCRIPTION
All generated code since 3.20.0 will be supported until at least 8.x.y.

https://protobuf.dev/support/cross-version-runtime-guarantee/
https://github.com/protocolbuffers/protobuf/commit/1af7fd407c85c9c1f34b6ca8441cfb3a72d4f5ea