### PR TITLE
Fix check to enable action cache updates

### DIFF
--- a/src/buildstream/sandbox/_sandboxbuildboxrun.py
+++ b/src/buildstream/sandbox/_sandboxbuildboxrun.py
@@ -132,8 +132,8 @@ class SandboxBuildBoxRun(SandboxREAPI):
 
             if self.re_remote:
                 buildbox_command.append("--instance={}".format(self.re_remote.local_cas_instance_name))
-                if config.remote_apis_socket_action_cache_enable_update:
-                    buildbox_command.append("--nested-ac-enable-update")
+            if config.remote_apis_socket_action_cache_enable_update:
+                buildbox_command.append("--nested-ac-enable-update")
 
             # Do not redirect stdout/stderr
             if "no-logs-capture" in self._capabilities:


### PR DESCRIPTION
The check was previously ignored if the user didn't have remote execution / action cache configured.