### PR TITLE
_sandboxreapi: check stdout and stderr exist when fetching action result

### DIFF
--- a/src/buildstream/sandbox/_sandboxreapi.py
+++ b/src/buildstream/sandbox/_sandboxreapi.py
@@ -184,8 +184,13 @@ class SandboxREAPI(Sandbox):
 
             raise SandboxError("Output directory structure had no digest attached.")
 
-        # Fetch stdout and stderr blobs
-        cascache.fetch_blobs(casremote, [action_result.stdout_digest, action_result.stderr_digest])
+        # Fetch stdout and stderr blobs, if they exist
+        blobs = []
+        for digest in [action_result.stdout_digest, action_result.stderr_digest]:
+            if digest.hash:
+                blobs.append(digest)
+        if blobs:
+            cascache.fetch_blobs(casremote, blobs)
 
     def _process_job_output(self, working_directory, output_directories, output_files, *, failure):
         # Reads the remote execution server response to an execution request.


### PR DESCRIPTION
Starting with b8e6876d760641c2b6ccc3e2578eba48d0a33332, action results generated by the buildbox-run sandbox may be pushed to the action cache, and they don't have stderr and stdout stored.