### PR TITLE
_yaml: set a large 'width' value in the roundtrip yaml config

### DIFF
--- a/src/buildstream/_yaml.pyx
+++ b/src/buildstream/_yaml.pyx
@@ -389,6 +389,8 @@ yaml.RoundTripConstructor.add_constructor(u'tag:yaml.org,2002:timestamp',
 def prepare_roundtrip_yaml():
     yml = yaml.YAML()
     yml.preserve_quotes=True
+    # defaults to 80 if we don't set it
+    yml.width=9999
 
     # For each of YAML 1.1 and 1.2, force everything to be a plain string
 

--- a/tests/internals/yaml/roundtrip-test.yaml
+++ b/tests/internals/yaml/roundtrip-test.yaml
@@ -51,5 +51,7 @@ nullcheck: null
 
 timestamp: 2019-03-14
 
+long-string: Sometimes very long strings get truncated by ruamel-yaml because the default width is set to 80.
+
 # That is all
 


### PR DESCRIPTION
At some point, ruamel-yaml started line wrapping at 80 columns, breaking our 'roundtrip' promise