### PR TITLE
Fix artifact metadata for `remote-apis-socket`

### DIFF
--- a/src/buildstream/sandbox/_config.py
+++ b/src/buildstream/sandbox/_config.py
@@ -76,7 +76,7 @@ class SandboxConfig:
     # Returns:
     #    A dictionary representation of this SandboxConfig
     #
-    def to_dict(self) -> Dict[str, Union[str, int, bool]]:
+    def to_dict(self) -> Dict[str, Union[str, int, Dict]]:
 
         # Assign mandatory portions of the sandbox configuration
         #
@@ -84,7 +84,7 @@ class SandboxConfig:
         #     the sandbox configuration, as that would result in
         #     breaking cache key stability.
         #
-        sandbox_dict: Dict[str, Union[str, int, bool]] = {"build-os": self.build_os, "build-arch": self.build_arch}
+        sandbox_dict: Dict[str, Union[str, int, Dict]] = {"build-os": self.build_os, "build-arch": self.build_arch}
 
         # Assign optional portions of the sandbox configuration
         #
@@ -98,9 +98,10 @@ class SandboxConfig:
             sandbox_dict["build-gid"] = self.build_gid
 
         if self.remote_apis_socket_path is not None:
-            sandbox_dict["remote-apis-socket-path"] = self.remote_apis_socket_path
+            reapi_socket_dict: Dict[str, Union[str, bool]] = {"path": self.remote_apis_socket_path}
             if self.remote_apis_socket_action_cache_enable_update:
-                sandbox_dict["remote-apis-socket-action-cache-enable-update"] = True
+                reapi_socket_dict["action-cache-enable-update"] = True
+            sandbox_dict["remote-apis-socket"] = reapi_socket_dict
 
         return sandbox_dict
 

--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -61,6 +61,11 @@ def test_remote_apis_socket(cli, datafiles):
     result = cli.run(project=project, args=["build", element_name])
     assert result.exit_code == 0
 
+    # Verify that loading the artifact succeeds
+    artifact_name = cli.get_artifact_name(project, "test", element_name)
+    result = cli.run(project=project, args=["artifact", "show", artifact_name])
+    assert result.exit_code == 0
+
 
 # Test configuration with remote action cache for nested REAPI.
 @pytest.mark.skipif(not HAVE_SANDBOX, reason="Only available with a functioning sandbox")
@@ -101,6 +106,11 @@ def test_remote_apis_socket_with_action_cache_update(cli, tmpdir, datafiles):
         )
 
         result = cli.run(project=project, args=["build", element_name])
+        assert result.exit_code == 0
+
+        # Verify that loading the artifact succeeds
+        artifact_name = cli.get_artifact_name(project, "test", element_name)
+        result = cli.run(project=project, args=["artifact", "show", artifact_name])
         assert result.exit_code == 0
 
 


### PR DESCRIPTION
Fixes commit e587aa21b2f7a565db9b13eeb836638643c015d4.