### PR TITLE
ci: Add Debian 12 and 13 and update images

### DIFF
--- a/.github/common.env
+++ b/.github/common.env
@@ -1,6 +1,6 @@
 # Shared common variables
 
-CI_IMAGE_VERSION=master-1938898146
+CI_IMAGE_VERSION=master-2011999263
 CI_TOXENV_MAIN=py39,py310,py311,py312,py313
 CI_TOXENV_PLUGINS=py39-plugins,py310-plugins,py311-plugins,py312-plugins,py313-plugins
 CI_TOXENV_ALL="${CI_TOXENV_MAIN},${CI_TOXENV_PLUGINS}"

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -26,6 +26,14 @@ services:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-debian:11-${CI_IMAGE_VERSION:-latest}
 
+  debian-12:
+    <<: *tests-template
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-debian:12-${CI_IMAGE_VERSION:-latest}
+
+  debian-13:
+    <<: *tests-template
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-debian:13-${CI_IMAGE_VERSION:-latest}
+
   fedora-41:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:41-${CI_IMAGE_VERSION:-latest}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         # "../compose/ci.docker-compose.yml"
         test-name:
           - debian-11
+          - debian-12
+          - debian-13
           - fedora-41
           - fedora-42
           - fedora-missing-deps


### PR DESCRIPTION
Add Debian 12 and 13 and update BuildBox to 1.3.31.

Debian 12 extends test coverage to Python 3.11. It is supported until June 10, 2028, which covers the full upstream Python 3.11 support period.

Debian 13 provides long-term test coverage of Python 3.13. It is supported until June 30, 2030, which covers the full upstream Python 3.13 support period.