### PR TITLE
ci: Drop Fedora 41

### DIFF
--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 
 x-tests-template: &tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:41-${CI_IMAGE_VERSION:-latest}
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:42-${CI_IMAGE_VERSION:-latest}
     command: tox -vvvvv -- --color=yes --integration
     environment:
       TOXENV: ${CI_TOXENV_ALL}
@@ -33,10 +33,6 @@ services:
   debian-13:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-debian:13-${CI_IMAGE_VERSION:-latest}
-
-  fedora-41:
-    <<: *tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:41-${CI_IMAGE_VERSION:-latest}
 
   fedora-42:
     <<: *tests-template

--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -102,7 +102,7 @@ function runServiceTest() {
 
 
 if [ -z "${test_names}" ]; then
-    for test_name in mypy debian-11 fedora-41 fedora-42 fedora-missing-deps ubuntu-22.04; do
+    for test_name in mypy debian-11 debian-12 debian-13 fedora-41 fedora-42 fedora-missing-deps ubuntu-22.04; do
 	if ! runTest "${test_name}"; then
 	    echo "Tests failed"
 	    exit 1

--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -102,7 +102,7 @@ function runServiceTest() {
 
 
 if [ -z "${test_names}" ]; then
-    for test_name in mypy debian-11 debian-12 debian-13 fedora-41 fedora-42 fedora-missing-deps ubuntu-22.04; do
+    for test_name in mypy debian-11 debian-12 debian-13 fedora-42 fedora-missing-deps ubuntu-22.04; do
 	if ! runTest "${test_name}"; then
 	    echo "Tests failed"
 	    exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
           - debian-11
           - debian-12
           - debian-13
-          - fedora-41
           - fedora-42
           - fedora-missing-deps
           - ubuntu-22.04


### PR DESCRIPTION
Fedora 41 and 42 use the same version of Python.