### PR TITLE
requirements: Add version exclusion qualifier for `Click` on 8.2.2

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,4 +1,4 @@
-Click >= 7.0
+Click >= 7.0, != 8.2.2
 grpcio
 Jinja2 >= 2.10
 importlib_metadata >= 3.6; python_version < "3.10"


### PR DESCRIPTION
Click ==8.2.2 causes a regression that affects Buildstream's argument parsing. Currently, one known case is where `--no-strict` is set when not explicitly configured to by the command-line.

This change to requirements.in adds a exclusion for Click 8.2.2, but allows any other version higher than Click 7.0.