### PR TITLE
tox.ini: Test against current version of plugins

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,8 +22,8 @@ isolated_build = true
 
 # Configuration variables to share across environments
 [config]
-BST_PLUGINS_COMMUNITY_VERSION = e7575e2de264476632b90c74a5b412f9d97d015b # 1.100.1
-BST_PLUGINS_VERSION = db71610b7ae9884f6d8cbe0d3cc5a1c657c19edb # 2.2.0
+BST_PLUGINS_COMMUNITY_VERSION = 637e2d95e656b9d46575da5737b65fd0cc25dce2 # 2.1.0
+BST_PLUGINS_VERSION = 79649529cffb695d0d22195ed9a4910c80ca6907 # 2.5.0
 
 #
 # Defaults for all environments


### PR DESCRIPTION
This is:
- buildstream-plugins 2.5.0
- buildstream-plugins-community 2.1.0