### PR TITLE
tests/integration/pullbuildtrees.py: Clear local asset cache

### DIFF
--- a/tests/integration/pullbuildtrees.py
+++ b/tests/integration/pullbuildtrees.py
@@ -38,6 +38,7 @@ DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project")
 # cleared as just forcefully removing the refpath leaves dangling objects.
 def default_state(cli, tmpdir, share):
     shutil.rmtree(os.path.join(str(tmpdir), "cas"))
+    shutil.rmtree(os.path.join(str(tmpdir), "assets"))
     cli.configure(
         {
             "artifacts": {"servers": [{"url": share.repo, "push": False}]},


### PR DESCRIPTION
The remote asset proxy support in buildbox-casd 1.3.37 uses a local asset cache. Clear that cache in `default_state()` where we already clear the local CAS cache.