### PR TITLE
docs/README: Add note to make OS requirement clear

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,10 @@ To get started, first `install BuildStream by following the installation guide
 and then follow our tutorial in the
 `user guide <https://docs.buildstream.build/master/main_using.html>`_.
 
+  Running BuildStream on macOS or Windows may work under Docker Desktop, WSL,
+  or Podman Desktop, but it is not officially supported, and CI runs tests only on
+  Linux.
+
 We also recommend exploring some existing BuildStream projects:
 
 * https://gitlab.gnome.org/GNOME/gnome-build-meta/


### PR DESCRIPTION
This PR adds a note to the README to make the OS requirement clearer.

It might be that people think WSL2 can run Buildstream/Buildbox, and this has not yet been officially tested.