### PR TITLE
Use CASDProcessManager directly to access REAPI stubs 

### DIFF
--- a/src/buildstream/_assetcache.py
+++ b/src/buildstream/_assetcache.py
@@ -264,7 +264,7 @@ class AssetRemote(BaseRemote):
 # to establish a connection to this remote at initialization time.
 #
 class RemotePair:
-    def __init__(self, casd: CASDProcessManager, cas: CASCache, spec: RemoteSpec):
+    def __init__(self, casd: CASDProcessManager, spec: RemoteSpec):
         self.index: Optional[AssetRemote] = None
         self.storage: Optional[CASRemote] = None
         self.error: Optional[str] = None
@@ -275,7 +275,7 @@ class RemotePair:
                 index.check()
                 self.index = index
             if spec.remote_type in [RemoteType.STORAGE, RemoteType.ALL]:
-                storage = CASRemote(spec, cas)
+                storage = CASRemote(spec, casd)
                 storage.check()
                 self.storage = storage
         except RemoteError as e:
@@ -322,7 +322,7 @@ class AssetCache:
             if spec in self._remotes:
                 continue
 
-            remote = RemotePair(casd, self.cas, spec)
+            remote = RemotePair(casd, spec)
             if remote.error:
                 self.context.messenger.warn("Failed to initialize remote {}: {}".format(spec.url, remote.error))
 

--- a/src/buildstream/_cas/casremote.py
+++ b/src/buildstream/_cas/casremote.py
@@ -37,10 +37,10 @@ class BlobNotFound(CASRemoteError):
 # Represents a single remote CAS cache.
 #
 class CASRemote(BaseRemote):
-    def __init__(self, spec, cascache, **kwargs):
+    def __init__(self, spec, casd, **kwargs):
         super().__init__(spec, **kwargs)
 
-        self.cascache = cascache
+        self.casd = casd
         self.local_cas_instance_name = None
 
     # check_remote
@@ -55,7 +55,7 @@ class CASRemote(BaseRemote):
             self.local_cas_instance_name = ""
             return
 
-        local_cas = self.cascache.get_local_cas()
+        local_cas = self.casd.get_local_cas()
         request = local_cas_pb2.GetInstanceNameForRemotesRequest()
         self.spec.to_localcas_remote(request.content_addressable_storage)
         response = local_cas.GetInstanceNameForRemotes(request)
@@ -89,7 +89,7 @@ class _CASBatchRead:
         if not self._requests:
             return
 
-        local_cas = self._remote.cascache.get_local_cas()
+        local_cas = self._remote.casd.get_local_cas()
 
         for request in self._requests:
             batch_response = local_cas.FetchMissingBlobs(request)
@@ -143,7 +143,7 @@ class _CASBatchUpdate:
         if not self._requests:
             return
 
-        local_cas = self._remote.cascache.get_local_cas()
+        local_cas = self._remote.casd.get_local_cas()
 
         for request in self._requests:
             batch_response = local_cas.UploadMissingBlobs(request)

--- a/src/buildstream/_cas/casremote.py
+++ b/src/buildstream/_cas/casremote.py
@@ -61,24 +61,6 @@ class CASRemote(BaseRemote):
         response = local_cas.GetInstanceNameForRemotes(request)
         self.local_cas_instance_name = response.instance_name
 
-    # push_message():
-    #
-    # Push the given protobuf message to a remote.
-    #
-    # Args:
-    #     message (Message): A protobuf message to push.
-    #
-    # Raises:
-    #     (CASRemoteError): if there was an error
-    #
-    def push_message(self, message):
-
-        message_buffer = message.SerializeToString()
-
-        self.init()
-
-        return self.cascache.add_object(buffer=message_buffer, instance_name=self.local_cas_instance_name)
-
 
 # Represents a batch of blobs queued for fetching.
 #

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -1810,7 +1810,7 @@ class Stream:
             self._session_start_callback()
 
         self._running = True
-        status = self._scheduler.run(self.queues, self._context.get_cascache().get_casd())
+        status = self._scheduler.run(self.queues, self._context.get_casd())
         self._running = False
 
         if status == SchedStatus.ERROR:

--- a/src/buildstream/sandbox/_reremote.py
+++ b/src/buildstream/sandbox/_reremote.py
@@ -22,8 +22,8 @@ from .._exceptions import RemoteError
 
 
 class RERemote(CASRemote):
-    def __init__(self, cas_spec, remote_execution_specs, cascache):
-        super().__init__(cas_spec, cascache)
+    def __init__(self, cas_spec, remote_execution_specs, casd):
+        super().__init__(cas_spec, casd)
 
         self.remote_execution_specs = remote_execution_specs
         self.exec_service = None
@@ -31,7 +31,7 @@ class RERemote(CASRemote):
         self.ac_service = None
 
     def _configure_protocols(self):
-        local_cas = self.cascache.get_local_cas()
+        local_cas = self.casd.get_local_cas()
         request = local_cas_pb2.GetInstanceNameForRemotesRequest()
         if self.remote_execution_specs.storage_spec:
             self.remote_execution_specs.storage_spec.to_localcas_remote(request.content_addressable_storage)
@@ -50,10 +50,9 @@ class RERemote(CASRemote):
         response = local_cas.GetInstanceNameForRemotes(request)
         self.local_cas_instance_name = response.instance_name
 
-        casd = self.cascache.get_casd()
-        self.exec_service = casd.get_exec_service()
-        self.operations_service = casd.get_operations_service()
-        self.ac_service = casd.get_ac_service()
+        self.exec_service = self.casd.get_exec_service()
+        self.operations_service = self.casd.get_operations_service()
+        self.ac_service = self.casd.get_ac_service()
 
     def _check(self):
         super()._check()

--- a/src/buildstream/sandbox/_sandboxbuildboxrun.py
+++ b/src/buildstream/sandbox/_sandboxbuildboxrun.py
@@ -38,11 +38,11 @@ class SandboxBuildBoxRun(SandboxREAPI):
         super().__init__(*args, **kwargs)
 
         context = self._get_context()
-        cascache = context.get_cascache()
+        casd = context.get_casd()
 
         re_specs = context.remote_execution_specs
         if re_specs and re_specs.action_spec:
-            self.re_remote = RERemote(context.remote_cache_spec, re_specs, cascache)
+            self.re_remote = RERemote(context.remote_cache_spec, re_specs, casd)
             try:
                 self.re_remote.init()
                 self.re_remote.check()
@@ -110,8 +110,7 @@ class SandboxBuildBoxRun(SandboxREAPI):
         stdout, stderr = self._get_output()
 
         context = self._get_context()
-        cascache = context.get_cascache()
-        casd = cascache.get_casd()
+        casd = context.get_casd()
         config = self._get_config()
 
         if config.remote_apis_socket_path and context.remote_cache_spec and not self.re_remote:

--- a/src/buildstream/sandbox/_sandboxremote.py
+++ b/src/buildstream/sandbox/_sandboxremote.py
@@ -37,7 +37,7 @@ class SandboxRemote(SandboxREAPI):
         super().__init__(*args, **kwargs)
 
         context = self._get_context()
-        cascache = context.get_cascache()
+        casd = context.get_casd()
 
         specs = context.remote_execution_specs
         if specs is None or specs.exec_spec is None:
@@ -48,7 +48,7 @@ class SandboxRemote(SandboxREAPI):
         self.action_spec = specs.action_spec
         self.operation_name = None
 
-        self.re_remote = RERemote(context.remote_cache_spec, specs, cascache)
+        self.re_remote = RERemote(context.remote_cache_spec, specs, casd)
         try:
             self.re_remote.init()
         except grpc.RpcError as e:

--- a/tests/artifactcache/pull.py
+++ b/tests/artifactcache/pull.py
@@ -195,7 +195,12 @@ def test_pull_tree(cli, tmpdir, datafiles):
             # Push the Tree as a regular message
             _, remotes = artifactcache.get_remotes(project.name, True)
             assert len(remotes) == 1
-            tree_digest = remotes[0].push_message(tree)
+
+            remotes[0].init()
+            tree_digest = cas.add_object(
+                buffer=tree.SerializeToString(), instance_name=remotes[0].local_cas_instance_name
+            )
+
             tree_hash, tree_size = tree_digest.hash, tree_digest.size_bytes
             assert tree_hash and tree_size
 


### PR DESCRIPTION
This removes some indirections through CASCache, now that CASDProcessManager is directly available from the Context.