### PR TITLE
nix: Add Nix tooling support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758029226,
+        "narHash": "sha256-TjqVmbpoCqWywY9xIZLTf6ANFvDCXdctCjoYuYPYdMI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "08b8f92ac6354983f5382124fef6006cade4a1c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
+    flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
+  };
+
+  outputs = inputs: let
+    inherit (inputs) self nixpkgs;
+    forAllSystems = function:
+      nixpkgs.lib.genAttrs [
+        "x86_64-linux"
+        "aarch64-linux"
+      ] (system:
+        function (import nixpkgs {
+          inherit system;
+          overlays = [
+            (_: prev: {
+              buildstream = prev.buildstream.overrideAttrs (_: {
+                version = "git";
+                src = self;
+              });
+            })
+          ];
+        }));
+  in {
+    devShells = forAllSystems (pkgs: {
+      default = pkgs.mkShell {
+        inputsFrom = [pkgs.buildstream];
+      };
+    });
+
+    packages = forAllSystems (pkgs: {
+      inherit (pkgs) buildstream;
+      default = self.packages.${pkgs.system}.buildstream;
+    });
+
+    overlays.default = _final: prev: {
+      inherit (self.packages.${prev.system}) buildstream;
+    };
+  };
+}


### PR DESCRIPTION
The key difference here is that the Nix package manager will use the Git rev of this repo to build itself, making it useful for developer iterations. It overrides the attribute set of the upstream Nixpkg derivation to use this Git repo.

- `default.nix`/`shell.nix` allow 'legacy Nix' to use the Flake without needing the Flake feature 'enabled'.
- `flake.lock` may need updating occasionally, but only if there's an update to the Buildstream package other than a version bump upstream on Nixpkgs.
- `flake.nix` is where the development shell and 'Flake-enabled Nix' tooling works from.