### PR TITLE
tests/testutils: Use `threading` instead of `multiprocessing`

### DIFF
--- a/tests/testutils/bearer_http_server.py
+++ b/tests/testutils/bearer_http_server.py
@@ -11,7 +11,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-import multiprocessing
+import threading
 import os
 import posixpath
 import html
@@ -87,7 +87,7 @@ class BearerHTTPServer(HTTPServer):
         super().__init__(*args, **kwargs)
 
 
-class BearerHttpServer(multiprocessing.Process):
+class BearerHttpServer(threading.Thread):
     def __init__(self):
         super().__init__()
         self.server = BearerHTTPServer(("127.0.0.1", 0), BearerRequestHandler)
@@ -103,7 +103,7 @@ class BearerHttpServer(multiprocessing.Process):
     def stop(self):
         if not self.started:
             return
-        self.terminate()
+        self.server.shutdown()
         self.join()
 
     def set_directory(self, directory):

--- a/tests/testutils/ftp_server.py
+++ b/tests/testutils/ftp_server.py
@@ -11,28 +11,26 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-import multiprocessing
+import threading
 
 from pyftpdlib.authorizers import DummyAuthorizer
 from pyftpdlib.handlers import FTPHandler
-from pyftpdlib.servers import FTPServer
+from pyftpdlib.servers import ThreadedFTPServer
 
 
-class SimpleFtpServer(multiprocessing.Process):
+class SimpleFtpServer(threading.Thread):
     def __init__(self):
         super().__init__()
         self.authorizer = DummyAuthorizer()
         handler = FTPHandler
         handler.authorizer = self.authorizer
-        self.server = FTPServer(("127.0.0.1", 0), handler)
+        self.server = ThreadedFTPServer(("127.0.0.1", 0), handler)
 
     def run(self):
         self.server.serve_forever()
 
     def stop(self):
         self.server.close_all()
-        self.server.close()
-        self.terminate()
         self.join()
 
     def allow_anonymous(self, cwd):

--- a/tests/testutils/http_server.py
+++ b/tests/testutils/http_server.py
@@ -11,7 +11,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-import multiprocessing
+import threading
 import os
 import posixpath
 import html
@@ -93,7 +93,7 @@ class AuthHTTPServer(HTTPServer):
         super().__init__(*args, **kwargs)
 
 
-class SimpleHttpServer(multiprocessing.Process):
+class SimpleHttpServer(threading.Thread):
     def __init__(self):
         super().__init__()
         self.server = AuthHTTPServer(("127.0.0.1", 0), RequestHandler)
@@ -109,7 +109,7 @@ class SimpleHttpServer(multiprocessing.Process):
     def stop(self):
         if not self.started:
             return
-        self.terminate()
+        self.server.shutdown()
         self.join()
 
     def allow_anonymous(self, cwd):


### PR DESCRIPTION
Python 3.14 defaults to `forkserver`, which breaks the test servers as they can't be pickled.