### PR TITLE
ci: Add Fedora 43 and update images

### DIFF
--- a/.github/common.env
+++ b/.github/common.env
@@ -1,6 +1,6 @@
 # Shared common variables
 
-CI_IMAGE_VERSION=master-2053497538
+CI_IMAGE_VERSION=master-2057058575
 CI_TOXENV_MAIN=py39,py310,py311,py312,py313,py314
 CI_TOXENV_PLUGINS=py39-plugins,py310-plugins,py311-plugins,py312-plugins,py313-plugins,py314-plugins
 CI_TOXENV_ALL="${CI_TOXENV_MAIN},${CI_TOXENV_PLUGINS}"

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -38,6 +38,10 @@ services:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:42-${CI_IMAGE_VERSION:-latest}
 
+  fedora-43:
+    <<: *tests-template
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:43-${CI_IMAGE_VERSION:-latest}
+
   ubuntu-22.04:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-ubuntu:22.04-${CI_IMAGE_VERSION:-latest}

--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -102,7 +102,7 @@ function runServiceTest() {
 
 
 if [ -z "${test_names}" ]; then
-    for test_name in mypy debian-11 debian-12 debian-13 fedora-42 fedora-missing-deps ubuntu-22.04; do
+    for test_name in mypy debian-11 debian-12 debian-13 fedora-42 fedora-43 fedora-missing-deps ubuntu-22.04; do
 	if ! runTest "${test_name}"; then
 	    echo "Tests failed"
 	    exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           - debian-12
           - debian-13
           - fedora-42
+          - fedora-43
           - fedora-missing-deps
           - ubuntu-22.04
           - lint


### PR DESCRIPTION
Fedora 43 extends test coverage to Python 3.14.