### PR TITLE
_pluginfactory/pluginoriginpip.py: Fix the description string

### DIFF
--- a/src/buildstream/_pluginfactory/pluginoriginpip.py
+++ b/src/buildstream/_pluginfactory/pluginoriginpip.py
@@ -101,7 +101,7 @@ class PluginOriginPip(PluginOrigin):
         return (
             os.path.dirname(location),
             str(defaults),
-            "python package '{}' at: {}".format(dist, dist.locate_file("")),
+            "python package '{}' version {} at: {}".format(dist.name, dist.version, dist.locate_file("")),
         )
 
     def load_config(self, origin_node):


### PR DESCRIPTION
The `Distribution` object returned by importlib.metadata.distribution() does not have a sensible `__str__()` dunder method to rely on. Instead we should be using `Distribution.name` and `Distribution.version` members to describe the pip package which was loaded in the plugin description string.

This changes the following annoying output from `bst build` and other session commands:

```
    Source Plugins
        tar:      core plugin
        git_repo: junction: plugins/buildstream-plugins-community.bst (project directory: src/buildstream_plugins_community/sources)
        patch:    python package '<importlib.metadata.PathDistribution object at 0x7fc2d858cda0>' at: /usr/lib/python3.12/site-packages
```

To the following, more satisfying output:

```
    Source Plugins
        tar:      core plugin
        git_repo: junction: plugins/buildstream-plugins-community.bst (project directory: src/buildstream_plugins_community/sources)
        patch:    python package 'buildstream-plugins' version 2.5.0 at: /usr/lib/python3.12/site-packages
```