### PR TITLE
doc/source/core_plugins.rst: Fix link to buildstream-plugins

### DIFF
--- a/doc/source/core_plugins.rst
+++ b/doc/source/core_plugins.rst
@@ -68,6 +68,6 @@ running BuildStream and loaded using the :ref:`pip method <project_plugins_pip>`
 
 Here is a list of BuildStream plugin projects known to us at this time:
 
-* `buildstream-plugins <https://github.com/apache/buildstream-plugins/>`_
+* `buildstream-plugins <https://apache.github.io/buildstream-plugins/index.html>`_
 * `buildstream-plugins-community (formerly known as bst-plugins-experimental) <http://buildstream.gitlab.io/buildstream-plugins-community/>`_
 * `bst-plugins-container <https://pypi.org/project/bst-plugins-container/>`_


### PR DESCRIPTION
Fix link to buildstream plugins in the documentation.