### PR TITLE
ci: Update BuildGrid setup to use PostgreSQL

### DIFF
--- a/.github/compose/ci.buildgrid.yml
+++ b/.github/compose/ci.buildgrid.yml
@@ -3,13 +3,9 @@
 #
 # Spins-up a unnamed and unauthenticated grid:
 #  - Controller + CAS + AC at http://localhost:50051
-#  - Ref. + CAS at: http://localhost:50052
 #
 # BuildStream configuration snippet:
 #
-#    artifacts:
-#      url: http://localhost:50052
-#      push: true
 #    remote-execution:
 #      execution-service:
 #        url: http://localhost:50051
@@ -46,16 +42,6 @@ services:
         target: /var/lib/buildgrid/cache
     depends_on:
       - controller
-    networks:
-      - grid
-
-  storage:
-    image: registry.gitlab.com/buildgrid/buildgrid.hub.docker.com/buildgrid:nightly
-    command: [
-      "bgd", "server", "start", "-v",
-      "/etc/buildgrid/artifacts.yml"]
-    ports:
-      - 50052:50052
     networks:
       - grid
 

--- a/.github/compose/ci.buildgrid.yml
+++ b/.github/compose/ci.buildgrid.yml
@@ -21,6 +21,26 @@
 version: "3.2"
 
 services:
+  database:
+    image: registry.gitlab.com/buildgrid/buildgrid.hub.docker.com/buildgrid-postgres:nightly
+    environment:
+      POSTGRES_USER: bgd
+      POSTGRES_PASSWORD: insecure
+      POSTGRES_DB: bgd
+    volumes:
+      - type: volume
+        source: db
+        target: /var/lib/postgresql
+    networks:
+      - grid
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "bgd"]
+      interval: 1s
+      timeout: 5s
+      retries: 10
+
   controller:
     image: registry.gitlab.com/buildgrid/buildgrid.hub.docker.com/buildgrid:nightly
     command: [
@@ -30,6 +50,9 @@ services:
       - 50051:50051
     networks:
       - grid
+    depends_on:
+      database:
+        condition: service_healthy
 
   bot:
     image: registry.gitlab.com/buildgrid/buildgrid.hub.docker.com/buildbox:nightly
@@ -51,3 +74,4 @@ networks:
 
 volumes:
   cache:
+  db:

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -58,9 +58,7 @@ services:
     command: tox -vvvvv -- --color=yes --remote-execution
     environment:
       TOXENV: ${CI_TOXENV_MAIN}
-      ARTIFACT_CACHE_SERVICE: http://localhost:50052
       REMOTE_EXECUTION_SERVICE: http://localhost:50051
-      SOURCE_CACHE_SERVICE: http://localhost:50052
 
     # We need to use host networking mode in order to be able to
     # properly resolve services exposed by adjacent containers.


### PR DESCRIPTION
SQLite support is deprecated in BuildGrid and the default configuration now requires PostgreSQL instead.

https://gitlab.com/BuildGrid/buildgrid/-/merge_requests/1318
https://gitlab.com/BuildGrid/buildgrid/-/merge_requests/1332