### PR TITLE
Support artifact remote options in `bst artifact show`

### DIFF
--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -1302,12 +1302,29 @@ def artifact():
     ),
     help="The dependencies we also want to show",
 )
+@click.option(
+    "--artifact-remote",
+    "artifact_remotes",
+    type=RemoteSpecType(RemoteSpecPurpose.PULL),
+    multiple=True,
+    help="A remote for downloading artifacts (Since: 2.7)",
+)
+@click.option(
+    "--ignore-project-artifact-remotes",
+    is_flag=True,
+    help="Ignore remote artifact cache servers recommended by projects (Since: 2.7)",
+)
 @click.argument("artifacts", type=click.Path(), nargs=-1)
 @click.pass_obj
-def artifact_show(app, deps, artifacts):
-    """show the cached state of artifacts"""
+def artifact_show(app, deps, artifact_remotes, ignore_project_artifact_remotes, artifacts):
+    """Show the cached state of artifacts"""
     with app.initialized():
-        targets = app.stream.artifact_show(artifacts, selection=deps)
+        targets = app.stream.artifact_show(
+            artifacts,
+            selection=deps,
+            artifact_remotes=artifact_remotes,
+            ignore_project_artifact_remotes=ignore_project_artifact_remotes,
+        )
         click.echo(app.logger.show_state_of_artifacts(targets))
         sys.exit(0)
 

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -792,12 +792,12 @@ class Stream:
     #    ignore_project_artifact_remotes: Whether to ignore artifact remotes specified by projects
     #
     def artifact_show(
-            self,
-            targets,
-            *,
-            selection=_PipelineSelection.NONE,
-            artifact_remotes: Iterable[RemoteSpec] = (),
-            ignore_project_artifact_remotes: bool = False,
+        self,
+        targets,
+        *,
+        selection=_PipelineSelection.NONE,
+        artifact_remotes: Iterable[RemoteSpec] = (),
+        ignore_project_artifact_remotes: bool = False,
     ):
         # Obtain list of Element and/or ArtifactElement objects
         target_objects = self.load_selection(

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -788,11 +788,25 @@ class Stream:
     #
     # Args:
     #    targets (str): Targets to show the cached state of
+    #    artifact_remotes: Artifact cache remotes specified on the commmand line
+    #    ignore_project_artifact_remotes: Whether to ignore artifact remotes specified by projects
     #
-    def artifact_show(self, targets, *, selection=_PipelineSelection.NONE):
+    def artifact_show(
+            self,
+            targets,
+            *,
+            selection=_PipelineSelection.NONE,
+            artifact_remotes: Iterable[RemoteSpec] = (),
+            ignore_project_artifact_remotes: bool = False,
+    ):
         # Obtain list of Element and/or ArtifactElement objects
         target_objects = self.load_selection(
-            targets, selection=selection, connect_artifact_cache=True, load_artifacts=True
+            targets,
+            selection=selection,
+            connect_artifact_cache=True,
+            load_artifacts=True,
+            artifact_remotes=artifact_remotes,
+            ignore_project_artifact_remotes=ignore_project_artifact_remotes,
         )
 
         self.query_cache(target_objects)

--- a/tests/frontend/artifact-show/elements/compose-all.bst
+++ b/tests/frontend/artifact-show/elements/compose-all.bst
@@ -1,0 +1,12 @@
+kind: compose
+
+depends:
+- filename: import-bin.bst
+  type: build
+- filename: import-dev.bst
+  type: build
+
+config:
+  # Dont try running the sandbox, we dont have a
+  # runtime to run anything in this context.
+  integrate: False

--- a/tests/frontend/artifact-show/elements/import-bin.bst
+++ b/tests/frontend/artifact-show/elements/import-bin.bst
@@ -1,0 +1,4 @@
+kind: import
+sources:
+- kind: local
+  path: files/bin-files

--- a/tests/frontend/artifact-show/elements/import-dev.bst
+++ b/tests/frontend/artifact-show/elements/import-dev.bst
@@ -1,0 +1,4 @@
+kind: import
+sources:
+- kind: local
+  path: files/dev-files

--- a/tests/frontend/artifact-show/elements/manual.bst
+++ b/tests/frontend/artifact-show/elements/manual.bst
@@ -1,0 +1,9 @@
+kind: manual
+
+config:
+  build-commands:
+    - echo "hello"
+
+sources:
+  - kind: local
+    path: elements/manual.bst

--- a/tests/frontend/artifact-show/elements/target.bst
+++ b/tests/frontend/artifact-show/elements/target.bst
@@ -1,0 +1,8 @@
+kind: stack
+description: |
+
+  Main stack target for the bst build test
+
+depends:
+- import-bin.bst
+- compose-all.bst

--- a/tests/frontend/artifact-show/files/bin-files/usr/bin/hello
+++ b/tests/frontend/artifact-show/files/bin-files/usr/bin/hello
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "Hello !"

--- a/tests/frontend/artifact-show/files/dev-files/usr/include/pony.h
+++ b/tests/frontend/artifact-show/files/dev-files/usr/include/pony.h
@@ -1,0 +1,12 @@
+#ifndef __PONY_H__
+#define __PONY_H__
+
+#define PONY_BEGIN "Once upon a time, there was a pony."
+#define PONY_END "And they lived happily ever after, the end."
+
+#define MAKE_PONY(story)  \
+  PONY_BEGIN \
+  story \
+  PONY_END
+
+#endif /* __PONY_H__ */

--- a/tests/frontend/artifact-show/project.conf
+++ b/tests/frontend/artifact-show/project.conf
@@ -1,0 +1,10 @@
+# Project config for frontend build test
+name: test
+min-version: 2.0
+element-path: elements
+
+plugins:
+- origin: pip
+  package-name: sample-plugins
+  sources:
+  - git

--- a/tests/frontend/artifact_show.py
+++ b/tests/frontend/artifact_show.py
@@ -26,7 +26,7 @@ from tests.testutils import create_artifact_share
 # Project directory
 DATA_DIR = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
-    "project",
+    "artifact-show",
 )
 SIMPLE_DIR = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),


### PR DESCRIPTION
This command was missed when applying the `--artifact-remote` and `--ignore-project-artifact-remotes` options uniformly to all relevant commands.
