### PR TITLE
_yaml: Split error reporting for parser initialisation

### DIFF
--- a/src/buildstream/_yaml.pyx
+++ b/src/buildstream/_yaml.pyx
@@ -293,10 +293,10 @@ cpdef MappingNode load(str filename, str shortname, bint copy_tree=False, object
 cpdef MappingNode load_data(str data, int file_index=node._SYNTHETIC_FILE_INDEX, str file_name=None, bint copy_tree=False):
     cdef Representer rep
 
-    try:
-        rep = Representer(file_index)
-        parser = yaml.CParser(data)
+    rep = Representer(file_index)
+    parser = yaml.CParser(data)
 
+    try:
         try:
             while parser.check_event():
                 rep.handle_event(parser.get_event())

--- a/src/buildstream/_yaml.pyx
+++ b/src/buildstream/_yaml.pyx
@@ -296,7 +296,11 @@ cpdef MappingNode load_data(str data, int file_index=node._SYNTHETIC_FILE_INDEX,
     try:
         rep = Representer(file_index)
         parser = yaml.CParser(data)
+    except Exception as e:
+        raise LoadError("YAML parser initialization failed: {}".format(e),
+                        LoadErrorReason.INVALID_YAML) from e
 
+    try:
         try:
             while parser.check_event():
                 rep.handle_event(parser.get_event())


### PR DESCRIPTION
Some versions of ruamel-yaml-clib have a defective aarch64 wheel, but
buildstream was reporting "Severely malformed YAML" instead.


Fixes https://github.com/apache/buildstream/issues/1833