### PR TITLE
Artifact cache fixes

### DIFF
--- a/src/buildstream/_artifactcache.py
+++ b/src/buildstream/_artifactcache.py
@@ -288,28 +288,28 @@ class ArtifactCache(AssetCache):
         artifact_proto = artifact._get_proto()
 
         try:
-            if str(artifact_proto.files):
+            if artifact_proto.HasField("files"):
                 self.cas._send_directory(remote, artifact_proto.files)
 
-            if str(artifact_proto.buildtree):
+            if artifact_proto.HasField("buildtree"):
                 try:
                     self.cas._send_directory(remote, artifact_proto.buildtree)
                 except FileNotFoundError:
                     pass
 
-            if str(artifact_proto.buildroot):
+            if artifact_proto.HasField("buildroot"):
                 try:
                     self.cas._send_directory(remote, artifact_proto.buildroot)
                 except FileNotFoundError:
                     pass
 
-            if artifact_proto.buildsandbox:
+            if artifact_proto.HasField("buildsandbox"):
                 for subsandbox_digest in artifact_proto.buildsandbox.subsandbox_digests:
                     self.cas._send_directory(remote, subsandbox_digest)
 
             digests = [artifact_digest, artifact_proto.low_diversity_meta, artifact_proto.high_diversity_meta]
 
-            if str(artifact_proto.public_data):
+            if artifact_proto.HasField("public_data"):
                 digests.append(artifact_proto.public_data)
 
             for log_file in artifact_proto.logs:
@@ -357,15 +357,15 @@ class ArtifactCache(AssetCache):
             raise ArtifactError("{}".format(e), temporary=True) from e
 
         referenced_directories = []
-        if artifact_proto.files:
+        if artifact_proto.HasField("files"):
             referenced_directories.append(artifact_proto.files)
-        if artifact_proto.buildtree:
+        if artifact_proto.HasField("buildtree"):
             referenced_directories.append(artifact_proto.buildtree)
-        if artifact_proto.sources:
+        if artifact_proto.HasField("sources"):
             referenced_directories.append(artifact_proto.sources)
-        if artifact_proto.buildroot:
+        if artifact_proto.HasField("buildroot"):
             referenced_directories.append(artifact_proto.buildroot)
-        if artifact_proto.buildsandbox:
+        if artifact_proto.HasField("buildsandbox"):
             for subsandbox_digest in artifact_proto.buildsandbox.subsandbox_digests:
                 referenced_directories.append(subsandbox_digest)
 
@@ -418,20 +418,20 @@ class ArtifactCache(AssetCache):
             with utils.save_file_atomic(artifact_path, mode="wb") as f:
                 f.write(artifact.SerializeToString())
 
-            if str(artifact.files):
+            if artifact.HasField("files"):
                 self.cas.fetch_directory(remote, artifact.files)
 
             if pull_buildtrees:
-                if str(artifact.buildtree):
+                if artifact.HasField("buildtree"):
                     self.cas.fetch_directory(remote, artifact.buildtree)
-                if str(artifact.buildroot):
+                if artifact.HasField("buildroot"):
                     self.cas.fetch_directory(remote, artifact.buildroot)
-                if artifact.buildsandbox:
+                if artifact.HasField("buildsandbox"):
                     for subsandbox_digest in artifact.buildsandbox.subsandbox_digests:
                         self.cas.fetch_directory(remote, subsandbox_digest)
 
             digests = [artifact.low_diversity_meta, artifact.high_diversity_meta]
-            if str(artifact.public_data):
+            if artifact.HasField("public_data"):
                 digests.append(artifact.public_data)
 
             for log_digest in artifact.logs:

--- a/src/buildstream/_artifactcache.py
+++ b/src/buildstream/_artifactcache.py
@@ -297,6 +297,12 @@ class ArtifactCache(AssetCache):
                 except FileNotFoundError:
                     pass
 
+            if artifact_proto.HasField("sources"):
+                try:
+                    self.cas._send_directory(remote, artifact_proto.sources)
+                except FileNotFoundError:
+                    pass
+
             if artifact_proto.HasField("buildroot"):
                 try:
                     self.cas._send_directory(remote, artifact_proto.buildroot)
@@ -427,6 +433,8 @@ class ArtifactCache(AssetCache):
             if pull_buildtrees:
                 if artifact.HasField("buildtree"):
                     self.cas.fetch_directory(remote, artifact.buildtree)
+                if artifact.HasField("sources"):
+                    self.cas.fetch_directory(remote, artifact.sources)
                 if artifact.HasField("buildroot"):
                     self.cas.fetch_directory(remote, artifact.buildroot)
                 if artifact.HasField("buildsandbox"):

--- a/src/buildstream/_artifactcache.py
+++ b/src/buildstream/_artifactcache.py
@@ -373,6 +373,9 @@ class ArtifactCache(AssetCache):
             log_file.digest for log_file in artifact_proto.logs
         ]
 
+        if artifact_proto.HasField("public_data"):
+            referenced_blobs.append(artifact_proto.public_data)
+
         try:
             remote.push_blob(
                 uris,


### PR DESCRIPTION
*   _artifactcache.py: Fix presence checks of protobuf digest fields
    
    Python truth values can't be used for presence checks of embedded protobuf message fields. Use `HasField()` instead. This prevents passing invalid digests to the Remote Asset server.
    
    Fixes #2090.

*   _artifactcache.py: Add `public_data` to list of referenced blobs

*    _artifactcache.py: Push and fetch sources
    The source digest is already stored in the artifact proto and added to the list of referenced directories if the buildtree is cached, however, the actual push and fetch was missing.