### PR TITLE
Support multi source source provenance info

### DIFF
--- a/tests/frontend/show.py
+++ b/tests/frontend/show.py
@@ -814,3 +814,33 @@ def test_source_info_workspace(cli, datafiles, tmpdir):
 
     # There is no version guessing for a workspace
     assert source_info.get_str("version-guess", None) is None
+
+
+@pytest.mark.datafiles(os.path.join(DATA_DIR, "source-info"))
+def test_multi_source_info(cli, datafiles):
+    project = str(datafiles)
+    result = cli.run(
+        project=project, silent=True, args=["show", "--format", "%{name}:\n%{source-info}", "multisource.bst"]
+    )
+    result.assert_success()
+
+    loaded = _yaml.load_data(result.output)
+    sources = loaded.get_sequence("multisource.bst")
+
+    source_info = sources.mapping_at(0)
+    assert source_info.get_str("kind") == "multisource"
+    assert source_info.get_str("url") == "http://ponyfarm.com/ponies"
+    assert source_info.get_str("medium") == "pony-ride"
+    assert source_info.get_str("version-type") == "pony-age"
+    assert source_info.get_str("version") == "1234567"
+    assert source_info.get_str("version-guess", None) == "12"
+    assert "homepage" not in source_info
+
+    source_info = sources.mapping_at(1)
+    assert source_info.get_str("kind") == "multisource"
+    assert source_info.get_str("url") == "http://ponyfarm.com/happy"
+    assert source_info.get_str("medium") == "pony-ride"
+    assert source_info.get_str("version-type") == "pony-age"
+    assert source_info.get_str("version") == "1234567"
+    assert source_info.get_str("version-guess", None) == "12"
+    assert source_info.get_str("homepage") == "http://happy.ponyfarm.com"

--- a/tests/frontend/source-info/elements/multisource.bst
+++ b/tests/frontend/source-info/elements/multisource.bst
@@ -1,0 +1,4 @@
+kind: import
+
+sources:
+- kind: multisource

--- a/tests/frontend/source-info/plugins/multisource.py
+++ b/tests/frontend/source-info/plugins/multisource.py
@@ -1,0 +1,48 @@
+from buildstream import Node, Source
+
+
+class MultiSource(Source):
+    BST_MIN_VERSION = "2.0"
+
+    BST_CUSTOM_SOURCE_PROVENANCE = True
+
+    def configure(self, node):
+        pass
+
+    def preflight(self):
+        pass
+
+    def get_unique_key(self):
+        return {}
+
+    def load_ref(self, node):
+        pass
+
+    def get_ref(self):
+        return {}
+
+    def set_ref(self, ref, node):
+        pass
+
+    def is_cached(self):
+        return False
+
+    def collect_source_info(self):
+        return [
+            self.create_source_info(
+                "http://ponyfarm.com/ponies", "pony-ride", "pony-age", "1234567", version_guess="12"
+            ),
+            self.create_source_info(
+                "http://ponyfarm.com/happy",
+                "pony-ride",
+                "pony-age",
+                "1234567",
+                version_guess="12",
+                provenance_node=Node.from_dict({"homepage": "http://happy.ponyfarm.com"}),
+            ),
+        ]
+
+
+# Plugin entry point
+def setup():
+    return MultiSource

--- a/tests/frontend/source-info/project.conf
+++ b/tests/frontend/source-info/project.conf
@@ -12,5 +12,6 @@ plugins:
   path: plugins
   sources:
   - extradata
+  - multisource
   - testsource
   - unimplemented

--- a/tests/sources/source_provenance_attributes.py
+++ b/tests/sources/source_provenance_attributes.py
@@ -1,0 +1,51 @@
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# Pylint doesn't play well with fixtures and dependency injection from pytest
+# pylint: disable=redefined-outer-name
+
+import os
+import pytest
+
+from buildstream._testing import generate_project, load_yaml
+from buildstream._testing import cli  # pylint: disable=unused-import
+from buildstream.exceptions import ErrorDomain
+
+
+DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "source_provenance_attributes")
+
+
+##################################################################
+#                              Tests                             #
+##################################################################
+# Test that no defined source provenance attributes blocks all source provenance data
+@pytest.mark.datafiles(DATA_DIR)
+def test_source_provenance_disallow_top_level(cli, datafiles):
+    project = str(datafiles)
+
+    # Set the project_dir alias in project.conf to the path to the tested project
+    project_config_path = os.path.join(project, "project.conf")
+    project_config = load_yaml(project_config_path)
+    aliases = project_config.get_mapping("aliases")
+    aliases["project_dir"] = "file://{}".format(project)
+
+    generate_project(project, project_config)
+
+    # Make sure disallowed usage of top-level source proveance fails
+    result = cli.run(
+        project=project,
+        args=["show", "target.bst"],
+    )
+
+    result.assert_main_error(ErrorDomain.SOURCE, "top-level-provenance-on-custom-implementation")

--- a/tests/sources/source_provenance_attributes/elements/target.bst
+++ b/tests/sources/source_provenance_attributes/elements/target.bst
@@ -1,0 +1,7 @@
+kind: import
+
+sources:
+- kind: multisource-plugin
+  url: project_dir:/files/file
+  provenance:
+    homepage: bar

--- a/tests/sources/source_provenance_attributes/files/file
+++ b/tests/sources/source_provenance_attributes/files/file
@@ -1,0 +1,1 @@
+Hello World!

--- a/tests/sources/source_provenance_attributes/plugins/multisource-plugin.py
+++ b/tests/sources/source_provenance_attributes/plugins/multisource-plugin.py
@@ -1,0 +1,36 @@
+from buildstream import Node, Source
+
+
+class MultiSource(Source):
+    BST_MIN_VERSION = "2.0"
+
+    BST_CUSTOM_SOURCE_PROVENANCE = True
+
+    def configure(self, node):
+        pass
+
+    def preflight(self):
+        pass
+
+    def get_unique_key(self):
+        return {}
+
+    def load_ref(self, node):
+        pass
+
+    def get_ref(self):
+        return {}
+
+    def set_ref(self, ref, node):
+        pass
+
+    def is_cached(self):
+        return False
+
+    def collect_source_info(self):
+        return []
+
+
+# Plugin entry point
+def setup():
+    return MultiSource

--- a/tests/sources/source_provenance_attributes/project.conf
+++ b/tests/sources/source_provenance_attributes/project.conf
@@ -1,0 +1,14 @@
+# Project with source provenance attributes
+name: foo
+min-version: 2.0
+
+element-path: elements
+
+aliases:
+  project_dir: file://{project_dir}
+
+plugins:
+- origin: local
+  path: plugins
+  sources:
+  - multisource-plugin


### PR DESCRIPTION
Fixes https://github.com/apache/buildstream/issues/2073

This PR provides a way for multi-source plugins to provide source provenance info in their own way instead of only the top level source source info being used.

This is done by exposing the optional `source_provenance_attrs` argument to `create_source_info()` which when used overrides the usage of the default provenance for a source. Any plugin that needs to parse provenance in it's own way can then supply it's results using this. This has been trialled with the `cargo2` source plugin in https://gitlab.com/BuildStream/buildstream-plugins-community/-/merge_requests/408.