### PR TITLE
_stream: Don't require runtime deps when building with --deps none

### DIFF
--- a/doc/source/using_config.rst
+++ b/doc/source/using_config.rst
@@ -381,6 +381,7 @@ Attributes
   values for this attribute are:
 
   * ``none``: Only build elements required to generate the expected target artifacts
+  * ``run``: Build required elements and their their runtime dependencies
   * ``all``: Build elements even if they are build dependencies of artifacts which are already cached
 
 

--- a/src/buildstream/_context.py
+++ b/src/buildstream/_context.py
@@ -465,10 +465,10 @@ class Context:
         self.build_retry_failed = build.get_bool("retry-failed")
 
         dependencies = build.get_str("dependencies")
-        if dependencies not in ["none", "all"]:
+        if dependencies not in ["none", "run", "all"]:
             provenance = build.get_scalar("dependencies").get_provenance()
             raise LoadError(
-                "{}: Invalid value for 'dependencies'. Choose 'none' or 'all'.".format(provenance),
+                "{}: Invalid value for 'dependencies'. Choose 'none', 'run', or 'all'.".format(provenance),
                 LoadErrorReason.INVALID_DATA,
             )
         self.build_dependencies = _PipelineSelection(dependencies)

--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -455,7 +455,7 @@ def init(app, project_name, min_version, element_path, force, target_directory):
     default=None,
     type=FastEnumType(
         _PipelineSelection,
-        [_PipelineSelection.NONE, _PipelineSelection.BUILD, _PipelineSelection.ALL],
+        [_PipelineSelection.NONE, _PipelineSelection.BUILD, _PipelineSelection.RUN, _PipelineSelection.ALL],
     ),
     help="The dependencies to build",
 )
@@ -513,6 +513,7 @@ def build(
     \b
         none:  No dependencies, just the element itself
         build: Build time dependencies, excluding the element itself
+        run:   The element and its runtime dependencies
         all:   All dependencies
 
     Dependencies that are consequently required to build the requested

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -1775,8 +1775,13 @@ class Stream:
         if not required_elements:
             required_elements = selected
 
+        if selection == _PipelineSelection.NONE:
+            scope = _Scope.NONE
+        else:
+            scope = _Scope.RUN
+
         for element in required_elements:
-            element._set_required()
+            element._set_required(scope)
 
         return selected
 

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -1766,7 +1766,7 @@ class Stream:
             # rely on state changes during processing to determine which elements
             # must be processed.
             #
-            if selection == _PipelineSelection.NONE:
+            if selection in (_PipelineSelection.NONE, _PipelineSelection.RUN):
                 required_elements = elements
             elif selection == _PipelineSelection.BUILD:
                 required_elements = list(_pipeline.dependencies(elements, _Scope.BUILD, recurse=False))

--- a/src/buildstream/data/userconfig.yaml
+++ b/src/buildstream/data/userconfig.yaml
@@ -93,7 +93,7 @@ build:
   #
   # Control which dependencies to build
   #
-  dependencies: none
+  dependencies: run
 
 
 #


### PR DESCRIPTION
Before this change, running a build with `--deps none` would also build / pull runtime dependencies. This commit changes the elements on the command line to not require their runtime dependencies if we're using `--deps none`.

In addition to the config file option dependencies `none` and `all`, this PR adds `run` and makes it the
default instead of `none`. The previous commit changed the meaning of
`--deps none` to be different from `--deps run`, so we change the default to be
`run`.
