### PR TITLE
Correctly track session elements in dynamic build plan

### DIFF
--- a/src/buildstream/_scheduler/queues/queue.py
+++ b/src/buildstream/_scheduler/queues/queue.py
@@ -62,6 +62,7 @@ class Queue:
     # Resources this queues' jobs want
     resources = []  # type: List[int]
     log_to_file = True
+    session_elements = None
 
     def __init__(self, scheduler, *, imperative=False):
 
@@ -171,6 +172,15 @@ class Queue:
     #####################################################
     #          Scheduler / Pipeline facing APIs         #
     #####################################################
+
+    # set_session_elements()
+    #
+    # Track elements enqueued
+    #
+    # Args:
+    #    session_elements (list): a list to put session elements
+    def set_session_elements(self, session_elements):
+        self.session_elements = session_elements
 
     # enqueue()
     #
@@ -381,6 +391,9 @@ class Queue:
     #    element (Element): The Element to enqueue
     #
     def _enqueue_element(self, element):
+        if self.session_elements is not None:
+            self.session_elements.append(element)
+
         status = self.status(element)
 
         if status == QueueStatus.SKIP:

--- a/src/buildstream/_scheduler/queues/queue.py
+++ b/src/buildstream/_scheduler/queues/queue.py
@@ -62,6 +62,7 @@ class Queue:
     # Resources this queues' jobs want
     resources = []  # type: List[int]
     log_to_file = True
+    session_elements = None
 
     def __init__(self, scheduler, *, imperative=False):
 
@@ -256,6 +257,17 @@ class Queue:
     def set_required_element_check(self):
         self._required_element_check = True
 
+    # set_session_elements()
+    #
+    # This passes a reference to a set used to keep track of the
+    # elements enqued. This is used in the first queue to determine
+    # which elements are actually considered in the current session.
+    #
+    # Args:
+    #    session_elements (set): a set to put session elements
+    def set_session_elements(self, session_elements):
+        self.session_elements = session_elements
+
     # any_failed_elements()
     #
     # Returns whether any elements in this queue have failed their jobs
@@ -381,6 +393,9 @@ class Queue:
     #    element (Element): The Element to enqueue
     #
     def _enqueue_element(self, element):
+        if self.session_elements is not None:
+            self.session_elements.add(element)
+
         status = self.status(element)
 
         if status == QueueStatus.SKIP:

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -1814,7 +1814,7 @@ class Stream:
         if not track and not self.queues:
             # First non-track queue
             queue.set_required_element_check()
-
+            queue.set_session_elements(self.session_elements)
         self.queues.append(queue)
 
     # _enqueue_plan()
@@ -1828,7 +1828,6 @@ class Stream:
     def _enqueue_plan(self, plan, *, queue=None):
         queue = queue or self.queues[0]
         queue.enqueue(plan)
-        self.session_elements += plan
 
     # _run()
     #

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -72,7 +72,7 @@ class Stream:
         # Public members
         #
         self.targets = []  # Resolved target elements
-        self.session_elements = []  # List of elements being processed this session
+        self.session_elements = set()  # Set of elements being processed this session
         self.total_elements = []  # Total list of elements based on targets
         self.queues = []  # Queue objects
 
@@ -1802,7 +1802,7 @@ class Stream:
     #
     def _reset(self):
         self._scheduler.clear_queues()
-        self.session_elements = []
+        self.session_elements = set()
         self.total_elements = []
 
     # _add_queue()
@@ -1817,6 +1817,9 @@ class Stream:
             # First non-track queue
             queue.set_required_element_check()
 
+        if not self.queues:
+            queue.set_session_elements(self.session_elements)
+
         self.queues.append(queue)
 
     # _enqueue_plan()
@@ -1830,7 +1833,6 @@ class Stream:
     def _enqueue_plan(self, plan, *, queue=None):
         queue = queue or self.queues[0]
         queue.enqueue(plan)
-        self.session_elements += plan
 
     # _run()
     #


### PR DESCRIPTION
When using a dynamic build plan, all elements are passed to the queue to be enqueued, but are only actually enqueued when they become required.

This moves the tracking of session elements to the first queue rather than just take everything that we pass to the queue (which would be all elements).

This is only used in the UI AFAICT, and doesn't actually affect the build.