### PR TITLE
_frontend/cli.py: Update default min-version for `bst init`

### DIFF
--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -419,7 +419,7 @@ def help_command(ctx, command):
 @click.option(
     "--min-version",
     type=click.STRING,
-    default="2.6",
+    default="2.7",
     show_default=True,
     help="The required format version",
 )


### PR DESCRIPTION
This is implicitly required by tests after creating the 2.7.0.dev0 tag.