### PR TITLE
ci: Fix buildstream-plugins-community version for `plugins-master`

### DIFF
--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -51,7 +51,7 @@ services:
   plugins-master:
     <<: *tests-template
     environment:
-      BST_PLUGINS_EXPERIMENTAL_VERSION: master
+      BST_PLUGINS_COMMUNITY_VERSION: master
 
   buildgrid:
     <<: *tests-template


### PR DESCRIPTION
Fixes #2096.

Reported-by: Dor Askayo <dor.askayo@gmail.com>