### PR TITLE
source.py: Fix mirror usage in subprojects

### DIFF
--- a/src/buildstream/source.py
+++ b/src/buildstream/source.py
@@ -2036,11 +2036,7 @@ class Source(Plugin):
         #
         else:
             alias = self._get_alias()
-            if self.__first_pass:
-                mirrors = project.first_pass_config.mirrors
-            else:
-                mirrors = project.config.mirrors
-            if not mirrors or not alias:
+            if not alias:
                 self.fetch(**kwargs)
                 return
 
@@ -2066,12 +2062,8 @@ class Source(Plugin):
     def __do_track(self, **kwargs):
         project = self._get_project()
         alias = self._get_alias()
-        if self.__first_pass:
-            mirrors = project.first_pass_config.mirrors
-        else:
-            mirrors = project.config.mirrors
-        # If there are no mirrors, or no aliases to replace, there's nothing to do here.
-        if not mirrors or not alias:
+        # If there are no aliases to replace, there's nothing to do here.
+        if not alias:
             return self.track(**kwargs)
 
         # NOTE: We are assuming here that tracking only requires substituting the

--- a/tests/frontend/mirror.py
+++ b/tests/frontend/mirror.py
@@ -15,6 +15,7 @@
 # Pylint doesn't play well with fixtures and dependency injection from pytest
 # pylint: disable=redefined-outer-name
 
+import copy
 import os
 import shutil
 
@@ -942,6 +943,7 @@ def test_source_mirror_plugin(cli, tmpdir, origin):
 @pytest.mark.parametrize("alias_override", [["foo"], ["foo", "bar"], "global"])
 @pytest.mark.parametrize("alias_mapping", ["identity", "project-prefix", "invalid"])
 @pytest.mark.parametrize("source_mirror", [True, False])
+@pytest.mark.parametrize("source_plugin_uses_sourcefetcher", [True, False])
 def test_mirror_subproject_aliases(
     cli,
     tmpdir,
@@ -952,6 +954,7 @@ def test_mirror_subproject_aliases(
     alias_override,
     alias_mapping,
     source_mirror,
+    source_plugin_uses_sourcefetcher,
 ):
     if alias_override == "global":
         if alias_mapping == "invalid":
@@ -984,7 +987,7 @@ def test_mirror_subproject_aliases(
             "bar": "RAB/" if subproject_bar_alias_succeed else "BAR/",
         },
         "plugins": [
-            {"origin": "local", "path": "sources", "sources": ["fetch_source"]},
+            {"origin": "local", "path": "sources", "sources": ["fetch_source", "fetch_source_nofetcher"]},
         ],
     }
 
@@ -998,6 +1001,17 @@ def test_mirror_subproject_aliases(
 
     if unaliased_sources:
         element["sources"][0]["urls"] = ["foo:repo1", "RAB/repo2"]
+
+    if not source_plugin_uses_sourcefetcher:
+        # Exercise code paths for source plugins that don't use SourceFetcher
+        # Instantiate two sources with one URL each
+        urls = element["sources"][0]["urls"]
+        element["sources"][0]["kind"] = "fetch_source_nofetcher"
+        del element["sources"][0]["urls"]
+        element["sources"].append(copy.deepcopy(element["sources"][0]))
+        element["sources"][0]["url"] = urls[0]
+        element["sources"][1]["url"] = urls[1]
+
     _yaml.roundtrip_dump(element, str(subproject_element_dir / element_name))
 
     # copy the source plugin to the subproject

--- a/tests/frontend/project/sources/fetch_source_nofetcher.py
+++ b/tests/frontend/project/sources/fetch_source_nofetcher.py
@@ -1,0 +1,72 @@
+import os
+
+from buildstream import Source, SourceError
+
+# Expected config
+# sources:
+# - output-text: $FILE
+#   url: foo:bar
+#   fetch-succeeds:
+#     Foo/bar: true
+#     ooF/bar: false
+
+
+class FetchSource(Source):
+
+    BST_MIN_VERSION = "2.0"
+
+    # Read config to know which URL to fetch
+    def configure(self, node):
+        self.original_url = node.get_str("url")
+        self.output_file = node.get_str("output-text")
+        self.fetch_succeeds = {key: value.as_bool() for key, value in node.get_mapping("fetch-succeeds", {}).items()}
+
+        self.mark_download_url(self.original_url)
+
+    def preflight(self):
+        output_dir = os.path.dirname(self.output_file)
+        if not os.path.exists(output_dir):
+            raise SourceError("Directory '{}' does not exist".format(output_dir))
+
+    def stage(self, directory):
+        pass
+
+    def fetch(self):
+        url = self.translate_url(self.original_url)
+        with open(self.output_file, "a") as f:
+            success = url in self.fetch_succeeds and self.fetch_succeeds[url]
+            message = "Fetch {} {} from {}\n".format(self.original_url, "succeeded" if success else "failed", url)
+            f.write(message)
+            if not success:
+                raise SourceError("Failed to fetch {}".format(url))
+
+    def get_unique_key(self):
+        return {"url": self.original_url, "output_file": self.output_file}
+
+    def is_resolved(self):
+        return True
+
+    def is_cached(self) -> bool:
+        if not os.path.exists(self.output_file):
+            return False
+
+        with open(self.output_file, "r") as f:
+            contents = f.read()
+            if self.original_url not in contents:
+                return False
+
+        return True
+
+    # We dont have a ref, we're a local file...
+    def load_ref(self, node):
+        pass
+
+    def get_ref(self):
+        return None  # pragma: nocover
+
+    def set_ref(self, ref, node):
+        pass  # pragma: nocover
+
+
+def setup():
+    return FetchSource


### PR DESCRIPTION
Don't skip source cloning if there are no mirrors configured in the element's project. With alias mapping, the mirror configuration of the parent project matters.

For `fetch()`, this bug only affected source plugins that don't use `SourceFetcher` objects. For `track()`, all source plugins were affected.

Fixes #2110.