### PR TITLE
Defer source provenance check until the project is fully loaded

### DIFF
--- a/src/buildstream/_context.py
+++ b/src/buildstream/_context.py
@@ -565,6 +565,13 @@ class Context:
         #
         return self._projects[0]
 
+    # ensure_fully_loaded():
+    #
+    # Ensure all projects are fully loaded.
+    def ensure_fully_loaded(self) -> None:
+        for project in self._projects:
+            project.ensure_fully_loaded()
+
     # initialize_remotes()
     #
     # This will resolve what remotes each loaded project will interact
@@ -592,9 +599,7 @@ class Context:
         ignore_project_source_remotes: bool = False,
     ) -> None:
 
-        # Ensure all projects are fully loaded.
-        for project in self._projects:
-            project.ensure_fully_loaded()
+        self.ensure_fully_loaded()
 
         #
         # If the global remote execution specs have been overridden by the

--- a/src/buildstream/_project.py
+++ b/src/buildstream/_project.py
@@ -15,7 +15,7 @@
 #        Tristan Van Berkom <tristan.vanberkom@codethink.co.uk>
 #        Tiago Gomes <tiago.gomes@codethink.co.uk>
 
-from typing import TYPE_CHECKING, Optional, Dict, Union, List, Sequence
+from typing import TYPE_CHECKING, Optional, Dict, Union, List, Sequence, Callable
 
 import os
 import urllib.parse
@@ -157,6 +157,8 @@ class Project:
         self._partially_loaded: bool = False
         self._fully_loaded: bool = False
         self._project_includes: Optional[Includes] = None
+
+        self._fully_loaded_callbacks: List[Callable[[], None]] = []
 
         #
         # Initialization body
@@ -692,6 +694,17 @@ class Project:
     def loaded_projects(self):
         yield from self.load_context.loaded_projects()
 
+    # register_fully_loaded_callback()
+    #
+    # Call the specified function once the project is fully loaded.
+    #
+    # Args:
+    #    callback (Callable[[], None]): A function to call once fully loaded
+    #
+    def register_fully_loaded_callback(self, callback: Callable[[], None]):
+        assert not self._fully_loaded
+        self._fully_loaded_callbacks.append(callback)
+
     ########################################################
     #                    Private Methods                   #
     ########################################################
@@ -1016,6 +1029,10 @@ class Project:
         self.source_provenance_attributes = project_conf_second_pass.get_mapping(
             "source-provenance-attributes", None
         ) or config.get_mapping("source-provenance-attributes")
+
+        for callback in self._fully_loaded_callbacks:
+            callback()
+        self._fully_loaded_callbacks = None
 
     # _load_pass():
     #

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -1684,6 +1684,7 @@ class Stream:
         elements, except_elements, artifacts = self._load_elements_from_targets(
             targets, except_targets, rewritable=False, valid_artifact_names=load_artifacts
         )
+        self._context.ensure_fully_loaded()
 
         if artifacts:
             if selection in (_PipelineSelection.ALL, _PipelineSelection.RUN):

--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -2638,13 +2638,21 @@ class Element(Plugin):
                 provenance_node: MappingNode = source.get_mapping(Symbol.PROVENANCE, default=None)
                 if provenance_node:
                     del source[Symbol.PROVENANCE]
-                    try:
-                        provenance_node.validate_keys(project.source_provenance_attributes.keys())
-                    except LoadError as E:
-                        raise LoadError(
-                            f"Specified source provenance attribute not defined in project config\n {E}",
-                            LoadErrorReason.UNDEFINED_SOURCE_PROVENANCE_ATTRIBUTE,
-                        )
+
+                    def source_provenance_attribute_check(provenance_node=provenance_node):
+                        try:
+                            provenance_node.validate_keys(project.source_provenance_attributes.keys())
+                        except LoadError as E:
+                            raise LoadError(
+                                f"Specified source provenance attribute not defined in project config\n {E}",
+                                LoadErrorReason.UNDEFINED_SOURCE_PROVENANCE_ATTRIBUTE,
+                            )
+
+                    # Source provenance attributes are available only after the project is fully loaded
+                    if project.source_provenance_attributes is None:
+                        project.register_fully_loaded_callback(source_provenance_attribute_check)
+                    else:
+                        source_provenance_attribute_check()
 
                     # make sure everything is a string
                     for key, value in provenance_node.items():

--- a/tests/sources/source_provenance_attributes.py
+++ b/tests/sources/source_provenance_attributes.py
@@ -54,7 +54,8 @@ def test_source_provenance_disallow_top_level(cli, datafiles):
 
 
 @pytest.mark.datafiles(DATA_DIR)
-def test_source_provenance_no_defined_attributes(cli, datafiles):
+@pytest.mark.parametrize("element", ["target", "junction"])
+def test_source_provenance_no_defined_attributes(cli, datafiles, element):
     project = str(datafiles)
 
     # Set the project_dir alias in project.conf to the path to the tested project
@@ -68,21 +69,22 @@ def test_source_provenance_no_defined_attributes(cli, datafiles):
     # Make sure a non-default attribute fails
     result = cli.run(
         project=project,
-        args=["show", "--format", "%{source-info}", "target_a.bst"],
+        args=["show", "--format", "%{source-info}", f"{element}_a.bst"],
     )
     result.assert_main_error(ErrorDomain.LOAD, LoadErrorReason.UNDEFINED_SOURCE_PROVENANCE_ATTRIBUTE)
 
     # Make sure a default attribute fails
     result = cli.run(
         project=project,
-        args=["show", "--format", "%{source-info}", "target_b.bst"],
+        args=["show", "--format", "%{source-info}", f"{element}_b.bst"],
     )
     result.assert_main_error(ErrorDomain.LOAD, LoadErrorReason.UNDEFINED_SOURCE_PROVENANCE_ATTRIBUTE)
 
 
 # Test that no defined source provenance attributes blocks all source provenance data
 @pytest.mark.datafiles(DATA_DIR)
-def test_source_provenance_default_attributes(cli, datafiles):
+@pytest.mark.parametrize("element", ["target", "junction"])
+def test_source_provenance_default_attributes(cli, datafiles, element):
     project = str(datafiles)
 
     # Set the project_dir alias in project.conf to the path to the tested project
@@ -99,7 +101,7 @@ def test_source_provenance_default_attributes(cli, datafiles):
     # Make sure defined attributes are available
     result = cli.run(
         project=project,
-        args=["show", "--format", "%{source-info}", "target_b.bst"],
+        args=["show", "--format", "%{source-info}", f"{element}_b.bst"],
     )
     result.assert_success()
 
@@ -113,14 +115,15 @@ def test_source_provenance_default_attributes(cli, datafiles):
     # Make sure undefined attributes fail
     result = cli.run(
         project=project,
-        args=["show", "--format", "%{source-info}", "target_a.bst"],
+        args=["show", "--format", "%{source-info}", f"{element}_a.bst"],
     )
     result.assert_main_error(ErrorDomain.LOAD, LoadErrorReason.UNDEFINED_SOURCE_PROVENANCE_ATTRIBUTE)
 
 
 # Test that no defined source provenance attributes blocks all source provenance data
 @pytest.mark.datafiles(DATA_DIR)
-def test_source_provenance_project_defined_attributes(cli, datafiles):
+@pytest.mark.parametrize("element", ["target", "junction"])
+def test_source_provenance_project_defined_attributes(cli, datafiles, element):
     project = str(datafiles)
 
     # Set the project_dir alias in project.conf to the path to the tested project
@@ -139,7 +142,7 @@ def test_source_provenance_project_defined_attributes(cli, datafiles):
     # Make sure defined attributes are available
     result = cli.run(
         project=project,
-        args=["show", "--format", "%{source-info}", "target_a.bst"],
+        args=["show", "--format", "%{source-info}", f"{element}_a.bst"],
     )
     result.assert_success()
 
@@ -153,6 +156,6 @@ def test_source_provenance_project_defined_attributes(cli, datafiles):
     # Make sure undefined attributes fail
     result = cli.run(
         project=project,
-        args=["show", "--format", "%{source-info}", "target_b.bst"],
+        args=["show", "--format", "%{source-info}", f"{element}_b.bst"],
     )
     result.assert_main_error(ErrorDomain.LOAD, LoadErrorReason.UNDEFINED_SOURCE_PROVENANCE_ATTRIBUTE)

--- a/tests/sources/source_provenance_attributes/elements/junction_a.bst
+++ b/tests/sources/source_provenance_attributes/elements/junction_a.bst
@@ -1,0 +1,7 @@
+kind: junction
+
+sources:
+- kind: local
+  path: .
+  provenance:
+    originator: bar

--- a/tests/sources/source_provenance_attributes/elements/junction_b.bst
+++ b/tests/sources/source_provenance_attributes/elements/junction_b.bst
@@ -1,0 +1,7 @@
+kind: junction
+
+sources:
+- kind: local
+  path: .
+  provenance:
+    homepage: foo


### PR DESCRIPTION
Junctions may be loaded before a project is fully loaded, which means
that the source provenance attribute project configuration may not be
available yet.

This adds a callback mechanism to defer the source provenance attribute
check if the project is not fully loaded when a junction element with a
provenance node is loaded.

      File "src/buildstream/element.py", line 1075, in _new_from_load_element
        element.__load_sources(load_element)
        ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
      File "src/buildstream/element.py", line 2642, in __load_sources
        provenance_node.validate_keys(project.source_provenance_attributes.keys())
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    AttributeError: 'NoneType' object has no attribute 'keys'

Fixes #2116.