### PR TITLE
fix: use full element names in workspace reset

### DIFF
--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -1152,8 +1152,9 @@ class Stream:
 
         nonexisting = []
         for element in elements:
-            if not self.workspace_exists(element.name):
-                nonexisting.append(element.name)
+            name = element._get_full_name()
+            if not self.workspace_exists(name):
+                nonexisting.append(name)
         if nonexisting:
             raise StreamError("Workspace does not exist", detail="\n".join(nonexisting))
 

--- a/tests/frontend/workspace.py
+++ b/tests/frontend/workspace.py
@@ -557,6 +557,32 @@ def test_reset_soft(cli, tmpdir, datafiles):
 
 
 @pytest.mark.datafiles(DATA_DIR)
+def test_reset_junction_workspace(cli, tmpdir, datafiles):
+    project = str(datafiles)
+    workspace = os.path.join(str(tmpdir), "junction-workspace")
+    target = "nested.bst:import-etc.bst"
+
+    _yaml.roundtrip_dump(
+        {"kind": "junction", "sources": [{"kind": "local", "path": "files/sub-project"}]},
+        os.path.join(project, "elements", "nested.bst"),
+    )
+
+    result = cli.run(project=project, args=["workspace", "open", "--directory", workspace, target])
+    result.assert_success()
+
+    result = cli.run(project=project, args=["workspace", "reset", target])
+    result.assert_success()
+
+    result = cli.run(project=project, args=["workspace", "list"])
+    result.assert_success()
+    loaded = _yaml.load_data(result.output)
+    workspaces = loaded.get_sequence("workspaces")
+    assert len(workspaces) == 1
+    space = workspaces.mapping_at(0)
+    assert space.get_str("element") == target
+
+
+@pytest.mark.datafiles(DATA_DIR)
 def test_reset_multiple(cli, tmpdir, datafiles):
     # Open the workspaces
     tmpdir_alpha = os.path.join(str(tmpdir), "alpha")


### PR DESCRIPTION
Fixes a bug where `workspace reset` did not work for junctions.

For example, we have a project with struct like this:
```
nested.bst:hello.bst
```

So the root project has one element `nested.bst`, which is a junction to another project, and the junction has one element `hello.bst`.

If we try to open this element as workspace, it works:
```
bst workspace open nested.bst:hello.bst
```

If we try to close this workspace, it works:
```
bst workspace close nested.bst:hello.bst
```

However, if we try `bst workspace reset` command on it, it fails with error `Workspace does not exist`.
The error is that `workspace_reset` method called `workspace_exists` with `element.name`, which was resolved to just `hello.bst`. In comparsion, a few lines down, it uses `get_workspace` with `element._get_full_name()`, which is `nested.bst:hello.bst`.

This patch updates `workspace_reset` function to check existence using element full name to support junctions.