### PR TITLE
Update links to installation documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ BuildStream operates on a set of YAML files (.bst files), as follows:
 How can I get started?
 ======================
 To get started, first `install BuildStream by following the installation guide
-<https://buildstream.build/install.html>`_
+<https://docs.buildstream.build/master/main_install.html>`_
 and then follow our tutorial in the
 `user guide <https://docs.buildstream.build/master/main_using.html>`_.
 

--- a/doc/source/additional_docker.rst
+++ b/doc/source/additional_docker.rst
@@ -23,7 +23,7 @@ which these integrations work.
 
 Run BuildStream inside Docker
 -----------------------------
-Refer to the `BuildStream inside Docker <https://buildstream.build/install.html#container-images>`_
+Refer to the `BuildStream inside Docker <main_install.html#container-images>`_
 documentation for instructions on how to run BuildStream as a Docker container.
 
 

--- a/doc/source/format_project.rst
+++ b/doc/source/format_project.rst
@@ -493,7 +493,7 @@ Here are a couple of examples:
    python package versions are available when using your project.
 
    Follow `these instructions
-   <https://buildstream.build/source_install.html#installing-in-virtual-environments>`_
+   <main_install.html#installing-in-virtual-environments>`_
    to install BuildStream in a virtual environment.
 
    **Possible junction conflicts**

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -33,5 +33,4 @@ Later sections provide detailed information on BuildStream internals.
    main_architecture
    main_glossary
 
-For any other information, including `how to install BuildStream <https://buildstream.build/install.html>`_,
-refer to `the BuildStream website <https://buildstream.build>`_.
+For any other information refer to `the BuildStream website <https://buildstream.build>`_.

--- a/doc/source/main_install.rst
+++ b/doc/source/main_install.rst
@@ -47,9 +47,8 @@ Note that:
 Installing from Source
 ======================
 
-This page explains how to build and install this version of BuildStream from
-source. For general purpose installation instructions consult the
-`website <https://buildstream.build/install.html>`_.
+If you can not make use of currently supported packages or simply want to install from source, read the
+following sections.
 
 For full install instructions, read on:
 


### PR DESCRIPTION
When https://github.com/apache/buildstream/pull/2124 was merged, the links were not updated to match the new install docs location, this PR fixes that by updating the links and fixing wording where necessary.

Once the links point to the new location the https://buildstream.build/install.html docs can be removed to avoid continued duplication.