### PR TITLE
conftest: rename the destination of the --plugins option

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ from tests.testutils.repo.tar import Tar
 #################################################
 def pytest_addoption(parser):
     parser.addoption("--integration", action="store_true", default=False, help="Run integration tests")
-    parser.addoption("--plugins", action="store_true", default=False, help="Run only plugins tests")
+    parser.addoption("--plugins", action="store_true", dest="bst_plugins", default=False, help="Run only plugins tests")
     parser.addoption("--remote-execution", action="store_true", default=False, help="Run remote-execution tests only")
     parser.addoption("--remote-cache", action="store_true", default=False, help="Run remote-cache tests only")
 
@@ -74,7 +74,7 @@ def pytest_collection_modifyitems(session, config, items):
                 item.add_marker(pytest.mark.skip("skipping remote-cache test"))
 
         # With --plugins only run plugins tests
-        if config.getvalue("plugins"):
+        if config.getvalue("bst_plugins"):
             if not item.get_closest_marker("generic_source_test"):
                 item.add_marker(pytest.mark.skip("Skipping not generic source test"))
 


### PR DESCRIPTION
This conflicts with the `-p` option of pytest