### PR TITLE
chore: update error message for missing `generate_script`

### DIFF
--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -424,7 +424,7 @@ class Element(Plugin):
         If the script fails, it is expected to return with an exit
         code != 0.
         """
-        raise ImplError("element plugin '{kind}' does not implement write_script()".format(kind=self.get_kind()))
+        raise ImplError("element plugin '{kind}' does not implement generate_script()".format(kind=self.get_kind()))
 
     #############################################################
     #                       Public Methods                      #


### PR DESCRIPTION
Updated error message for non-implemented `generate_script`: it was referencing `write_script`, which is misleading.