### PR TITLE
fix(docs): update `workspace reset --soft` to avoid smart-quotes

### DIFF
--- a/doc/source/developing/workspaces.rst
+++ b/doc/source/developing/workspaces.rst
@@ -105,7 +105,8 @@ where build scripts automatically detect sources in it's configuration phase,
 so newly added sources you add might be ignored.
 
 In order to force the configuration step to be called again on the next build,
-you can use :ref:`bst workspace reset --soft <invoking_workspace_reset>`, like so:
+you can use :ref:`bst workspace reset <invoking_workspace_reset>` with the
+``--soft`` option, like so:
 
 In these cases, you can perform a hard reset on the workspace using
 :ref:`bst workspace reset <invoking_workspace_reset>`, like so:
@@ -147,4 +148,3 @@ To discard the workspace completely we can do:
 
 This will close the workspace and completely remove the workspace_hello
 directory.
-

--- a/src/buildstream/buildelement.py
+++ b/src/buildstream/buildelement.py
@@ -76,8 +76,8 @@ artifact collection purposes.
 
    In the case that the element is currently workspaced, the ``configure-commands``
    will only be run in subsequent builds until they succeed at least once, unless
-   :ref:`bst workspace reset --soft <invoking_workspace_reset>` is called on the
-   workspace to explicitly avoid an incremental build.
+   :ref:`bst workspace reset <invoking_workspace_reset>` is called with the
+   ``--soft`` option on the workspace to explicitly avoid an incremental build.
 
 """
 


### PR DESCRIPTION
In docs for incremental builds and buildelement `--soft` turned into `–soft`, which is ignored by CLI parser.
This lead to running `bst workspace reset –-soft --all` (with en-dash) by copypasting it, which turned out to hard-reset of workspaces.

See:
* https://docs.buildstream.build/2.5/developing/workspaces.html#incremental-builds:~:text=bst%20workspace%20reset-,%E2%80%93soft%2C,-like%20so%3A
* https://docs.buildstream.build/2.5/buildstream.buildelement.html#:~:text=bst%20workspace%20reset-,%E2%80%93soft,-is%20called%20on

This patch fixes docs so sphinx would not render it as `en-dash`: moved `--soft` outside of `:ref:`, as I could not get it to work otherwise.