### PR TITLE
fix: make `workspace reset` accept either `--all` or elements list

### DIFF
--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -1211,14 +1211,21 @@ def workspace_close(app, remove_dir, all_, elements):
     is_flag=True,
     help="Mark workspace to re-execute configuration steps (if any) on next build. Does not alter workspace contents.",
 )
-@click.option("--all", "-a", "all_", is_flag=True, help="Reset all open workspaces")
+@click.option("--all", "-a", "all_", is_flag=True, help="Reset all open workspaces. Cannot be combined with ELEMENTS.")
 @click.argument("elements", nargs=-1, type=click.Path(readable=False))
 @click.pass_obj
 def workspace_reset(app, soft, all_, elements):
-    """Reset a workspace to its original state"""
+    """Reset a workspace to its original state.
+
+    Specify either one or more ELEMENTS, or use ``--all`` to target all
+    workspaces at once. These options are mutually exclusive.
+    """
 
     # Check that the workspaces in question exist
     with app.initialized():
+
+        if all_ and elements:
+            raise AppError("Specify either --all or elements, not both")
 
         if not (all_ or elements):
             element = app.stream.get_default_target()

--- a/tests/frontend/workspace.py
+++ b/tests/frontend/workspace.py
@@ -635,6 +635,41 @@ def test_reset_all(cli, tmpdir, datafiles):
 
 
 @pytest.mark.datafiles(DATA_DIR)
+@pytest.mark.parametrize(
+    "element_arg",
+    [
+        "element_name",  # actual element
+        "\u2013-soft",  # en-dash soft (copy-pasted from docs)
+    ],
+    ids=["real-element", "en-dash-soft"],
+)
+def test_reset_all_with_elements_error(cli, tmpdir, datafiles, element_arg):
+    # Open a workspace
+    tmpdir_alpha = os.path.join(str(tmpdir), "alpha")
+    element_name, project, workspace = open_workspace(cli, tmpdir_alpha, datafiles, "tar", suffix="-alpha")
+
+    # Modify workspace
+    shutil.rmtree(os.path.join(workspace, "usr", "bin"))
+    os.makedirs(os.path.join(workspace, "etc"))
+    with open(os.path.join(workspace, "etc", "pony.conf"), "w", encoding="utf-8") as f:
+        f.write("PONY='pink'")
+
+    # Resolve the argument: if it's the literal "element_name", use the real one
+    if element_arg == "element_name":
+        args = ["workspace", "reset", "--all", element_name]
+    else:
+        args = ["workspace", "reset", element_arg, "--all"]
+
+    # Reset with --all and elements should fail
+    result = cli.run(project=project, args=args)
+    result.assert_main_error(ErrorDomain.APP, None)
+
+    # Verify workspace content was NOT modified
+    assert not os.path.exists(os.path.join(workspace, "usr", "bin", "hello"))
+    assert os.path.exists(os.path.join(workspace, "etc", "pony.conf"))
+
+
+@pytest.mark.datafiles(DATA_DIR)
 def test_list(cli, tmpdir, datafiles):
     element_name, project, workspace = open_workspace(cli, tmpdir, datafiles, "tar")
 


### PR DESCRIPTION
When using `bst workspace reset --all a.bst b.bst c.bst`, list of elements is ignored and it resets all workspaces, which could be confusing.

This patch adds a check that either `--all` is specified or list of elementsis provided.

This also fixes the following strange problem:

Running `bst workspace reset --all --soft` (with en-dash in `--soft`) causes buildstream to parse it as: reset with `all` flag and with list of elements `--soft`, as it could not parse it as a flag due to en-dash. This leads to bst hard-resetting workspace when for user it seems like he requested the `--soft`-one.

Now bst would throw error that either `--all` or element list needs to be provided, and would not reset user changes to workspace.

Ref. https://github.com/apache/buildstream/pull/2136