### PR TITLE
FastEnum: implement __str__ and __repr__ to match StrEnum for docs reproducibility

### DIFF
--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -553,7 +553,7 @@ def build(
 @click.option(
     "--deps",
     "-d",
-    default=_PipelineSelection.ALL,
+    default=str(_PipelineSelection.ALL),
     show_default=True,
     type=FastEnumType(
         _PipelineSelection,
@@ -814,7 +814,7 @@ def source():
 @click.option(
     "--deps",
     "-d",
-    default=_PipelineSelection.NONE,
+    default=str(_PipelineSelection.NONE),
     show_default=True,
     type=FastEnumType(
         _PipelineSelection,
@@ -887,7 +887,7 @@ def source_fetch(app, elements, deps, except_, source_remotes, ignore_project_so
 @click.option(
     "--deps",
     "-d",
-    default=_PipelineSelection.NONE,
+    default=str(_PipelineSelection.NONE),
     show_default=True,
     type=FastEnumType(
         _PipelineSelection,
@@ -960,7 +960,7 @@ def source_push(app, elements, deps, except_, source_remotes, ignore_project_sou
 @click.option(
     "--deps",
     "-d",
-    default=_PipelineSelection.NONE,
+    default=str(_PipelineSelection.NONE),
     show_default=True,
     type=FastEnumType(
         _PipelineSelection,
@@ -1015,7 +1015,7 @@ def source_track(app, elements, deps, except_, cross_junctions):
 @click.option(
     "--deps",
     "-d",
-    default=_PipelineSelection.NONE,
+    default=str(_PipelineSelection.NONE),
     show_default=True,
     type=FastEnumType(
         _PipelineSelection,
@@ -1296,7 +1296,7 @@ def artifact():
 @click.option(
     "--deps",
     "-d",
-    default=_PipelineSelection.NONE,
+    default=str(_PipelineSelection.NONE),
     show_default=True,
     type=FastEnumType(
         _PipelineSelection,
@@ -1339,7 +1339,7 @@ def artifact_show(app, deps, artifact_remotes, ignore_project_artifact_remotes, 
 @click.option(
     "--deps",
     "-d",
-    default=_PipelineSelection.RUN,
+    default=str(_PipelineSelection.RUN),
     show_default=True,
     type=FastEnumType(
         _PipelineSelection,
@@ -1464,7 +1464,7 @@ def artifact_checkout(
 @click.option(
     "--deps",
     "-d",
-    default=_PipelineSelection.NONE,
+    default=str(_PipelineSelection.NONE),
     show_default=True,
     type=FastEnumType(
         _PipelineSelection,
@@ -1533,7 +1533,7 @@ def artifact_pull(app, deps, artifact_remotes, ignore_project_artifact_remotes, 
 @click.option(
     "--deps",
     "-d",
-    default=_PipelineSelection.NONE,
+    default=str(_PipelineSelection.NONE),
     show_default=True,
     type=FastEnumType(
         _PipelineSelection,
@@ -1673,7 +1673,7 @@ def artifact_list_contents(app, artifacts, long_):
 @click.option(
     "--deps",
     "-d",
-    default=_PipelineSelection.NONE,
+    default=str(_PipelineSelection.NONE),
     show_default=True,
     type=FastEnumType(
         _PipelineSelection,

--- a/src/buildstream/types.py
+++ b/src/buildstream/types.py
@@ -81,10 +81,13 @@ class FastEnum(metaclass=MetaFastEnum):
         return hash(id(self))
 
     def __str__(self):
-        return "{}.{}".format(self.__class__.__name__, self.name)
+        return str(self.value)
 
     def __reduce__(self):
         return self.__class__, (self.value,)
+
+    def __repr__(self):
+        return "<{}.{}: {}>".format(self.__class__.__name__, self.name, self.value)
 
 
 class CoreWarnings:
@@ -306,9 +309,6 @@ class _PipelineSelection(FastEnum):
     # All direct runtime dependencies and their recursive runtime dependencies,
     # including the targets
     RUN = "run"
-
-    def __str__(self):
-        return str(self.value)
 
 
 # _ProjectInformation()


### PR DESCRIPTION
I have been looking to package BuildStream's documentation alongside the application and library in Debian. Debian policy now requires that binary packages, including documentation, are reproducible, so this MR is motivated by fixing the (only) reproducibility failure Debian CI discovered in BuildStream's documentation, in the `Using / Commands` page.

This is my first upstream patch to BuildStream, so I am of course happy to adjust as needed. Thank you for your consideration!

---

sphinx-click uses `__repr__` when rendering the `default` option of a `click.choice` in the HTML documentation [[ref](https://github.com/click-contrib/sphinx-click/blob/e8eb75e292ff6df69230420d992a34e68a7385d0/sphinx_click/ext.py#L124)].

Implementing `__repr__` on `_PipelineSelection` gives more helpful (and reproducible) documentation than the default representation, `<buildstream.types._PipelineSelection object at 0x7f775b6b4ec0>`. As an example in the documentation of `bst show`:

_Mainline:_

<img height="150" alt="image" src="https://github.com/user-attachments/assets/fcdd3496-a3c6-47e9-a332-7af885bcdd31" />

_This branch:_

<img height="150" alt="image" src="https://github.com/user-attachments/assets/e18442cc-6bad-4588-b1e7-c77052dca922" />
