### PR TITLE
README.rst: Update communication channels

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,4 +120,6 @@ We also recommend exploring some existing BuildStream projects:
 * https://gitlab.com/freedesktop-sdk/freedesktop-sdk
 * https://gitlab.com/baserock/definitions
 
-If you have any questions please ask on our `#buildstream <irc://irc.gnome.org/buildstream>`_ channel in `irc.gnome.org <irc://irc.gnome.org>`_
+If you have any questions please ask on one of our communication channels:
+- Matrix: `#buildstream <https://matrix.to/#/#buildstream:matrix.org>`_ room on `matrix.org <https://matrix.org/>`_
+- Mailing List: `dev@buildstream.apache.org <https://lists.apache.org/list.html?dev@buildstream.apache.org>`_ on `lists.apache.org <https://lists.apache.org/>`_


### PR DESCRIPTION
- Remove link to the old irc server, that has been discontinued
- Add link to the unoffical channel on matrix.org
- Add link to the official mailing list on apache.org
- Add link to the official Slack channel on the-asf.slack.com