### PR TITLE
doc: Escape `--` for CLI options in `:ref:`

### DIFF
--- a/doc/source/developing/workspaces.rst
+++ b/doc/source/developing/workspaces.rst
@@ -105,7 +105,7 @@ where build scripts automatically detect sources in it's configuration phase,
 so newly added sources you add might be ignored.
 
 In order to force the configuration step to be called again on the next build,
-you can use :ref:`bst workspace reset --soft <invoking_workspace_reset>`, like so:
+you can use :ref:`bst workspace reset \\\\-\\\\-soft <invoking_workspace_reset>`, like so:
 
 In these cases, you can perform a hard reset on the workspace using
 :ref:`bst workspace reset <invoking_workspace_reset>`, like so:

--- a/doc/source/format_project.rst
+++ b/doc/source/format_project.rst
@@ -159,7 +159,7 @@ following to your ``project.conf``:
 
    When using the ``project.refs`` file, it is possible to override the
    references in subprojects by editing the ``project.refs`` file directly
-   or by using :ref:`bst source track --cross-junctions <invoking_source_track>`,
+   or by using :ref:`bst source track \\\\-\\\\-cross-junctions <invoking_source_track>`,
    this can be practical to try out fresher versions of components which
    are maintained in a subproject.
 
@@ -320,7 +320,7 @@ they are defined when fetching, and in reverse-order when tracking.
 The mirrors can be overridden on a per project basis using
 :ref:`user configuration <config_mirrors>`. One can also specify which mirror should
 be used first in the :ref:`user configuration <config_default_mirror>`, or using
-the  :ref:`--default-mirror <invoking_bst>` command-line argument.
+the  :ref:`\\\\-\\\\-default-mirror <invoking_bst>` command-line argument.
 
 If you want this project's mirrors to also be used for subprojects,
 see :ref:`Mapping source aliases of subprojects <project_junctions_source_aliases>`.
@@ -635,7 +635,7 @@ dictionary.
        default: False
 
 Project options can be specified on the command line using
-:ref:`bst --option ... <invoking_bst>`
+:ref:`bst \\\\-\\\\-option ... <invoking_bst>`
 
 .. note::
 

--- a/src/buildstream/buildelement.py
+++ b/src/buildstream/buildelement.py
@@ -76,7 +76,7 @@ artifact collection purposes.
 
    In the case that the element is currently workspaced, the ``configure-commands``
    will only be run in subsequent builds until they succeed at least once, unless
-   :ref:`bst workspace reset --soft <invoking_workspace_reset>` is called on the
+   :ref:`bst workspace reset \\\\\\\\-\\\\\\\\-soft <invoking_workspace_reset>` is called on the
    workspace to explicitly avoid an incremental build.
 
 """

--- a/src/buildstream/plugins/sources/workspace.py
+++ b/src/buildstream/plugins/sources/workspace.py
@@ -39,7 +39,7 @@ The *guess_version* of a workspace source is meaningless and omitted.
 .. attention::
 
    Observing a SourceInfo with the ``SourceInfoMedium.WORKSPACE`` in the output of
-   :ref:`bst show --format %{source-info} <invoking_show>` is most likely undesirable, given
+   :ref:`bst show \\\\\\\\-\\\\\\\\-format %{source-info} <invoking_show>` is most likely undesirable, given
    that you are likely interested in observing the source provenance information of the
    project in a clean state rather than in a state with open workspaces.
 """


### PR DESCRIPTION
Escaping with a ludicrous number of backslashes prevents the Smart Quotes transform to en-dashes. See https://github.com/sphinx-doc/sphinx/issues/11492.

Alternative to #2136, also covering all cases that I could find.