### PR TITLE
_cas: avoid blocking calls to long grpc methods

### DIFF
--- a/src/buildstream/_cas/cascache.py
+++ b/src/buildstream/_cas/cascache.py
@@ -127,7 +127,13 @@ class CASCache:
         request.fetch_file_blobs = not self._remote_cache
 
         try:
-            local_cas.FetchTree(request)
+            response_future = local_cas.FetchTree.future(request)
+            try:
+                response_future.result()
+            except:
+                response_future.cancel()
+                raise
+
             if not self._remote_cache:
                 return True
         except grpc.RpcError as e:
@@ -141,7 +147,13 @@ class CASCache:
         request = local_cas_pb2.UploadTreeRequest()
         request.root_digest.CopyFrom(digest)
         try:
-            local_cas.UploadTree(request)
+            response_future = local_cas.UploadTree.future(request)
+            try:
+                response_future.result()
+            except:
+                response_future.cancel()
+                raise
+
             return True
         except grpc.RpcError as e:
             if e.code() == grpc.StatusCode.NOT_FOUND:
@@ -231,7 +243,12 @@ class CASCache:
             request.root_digest.CopyFrom(tree)
             request.fetch_file_blobs = True
 
-            local_cas.FetchTree(request)
+            response_future = local_cas.FetchTree.future(request)
+            try:
+                response_future.result()
+            except:
+                response_future.cancel()
+                raise
 
     # fetch_directory():
     #
@@ -252,7 +269,13 @@ class CASCache:
         request.fetch_file_blobs = False
 
         try:
-            local_cas.FetchTree(request)
+            response_future = local_cas.FetchTree.future(request)
+            try:
+                response_future.result()
+            except:
+                response_future.cancel()
+                raise
+
         except grpc.RpcError as e:
             if e.code() == grpc.StatusCode.NOT_FOUND:
                 raise BlobNotFound(
@@ -536,7 +559,13 @@ class CASCache:
                 d.CopyFrom(required_digest)
 
             try:
-                response = cas.FindMissingBlobs(request)
+                response_future = cas.FindMissingBlobs.future(request)
+                try:
+                    response = response_future.result()
+                except:
+                    response_future.cancel()
+                    raise
+
             except grpc.RpcError as e:
                 if e.code() == grpc.StatusCode.INVALID_ARGUMENT and e.details().startswith("Invalid instance name"):
                     raise CASCacheError("Unsupported buildbox-casd version: FindMissingBlobs failed") from e
@@ -566,7 +595,12 @@ class CASCache:
             request.root_digest.CopyFrom(directory_digest)
             request.fetch_file_blobs = False
 
-            local_cas.FetchTree(request)
+            response_future = local_cas.FetchTree.future(request)
+            try:
+                response_future.result()
+            except:
+                response_future.cancel()
+                raise
 
         # parse directory, and recursively add blobs
 

--- a/src/buildstream/_cas/casremote.py
+++ b/src/buildstream/_cas/casremote.py
@@ -92,7 +92,13 @@ class _CASBatchRead:
         local_cas = self._remote.casd.get_local_cas()
 
         for request in self._requests:
-            batch_response = local_cas.FetchMissingBlobs(request)
+            batch_response_future = local_cas.FetchMissingBlobs.future(request)
+
+            try:
+                batch_response = batch_response_future.result()
+            except:
+                batch_response_future.cancel()
+                raise
 
             for response in batch_response.responses:
                 if response.status.code == code_pb2.NOT_FOUND:
@@ -146,7 +152,13 @@ class _CASBatchUpdate:
         local_cas = self._remote.casd.get_local_cas()
 
         for request in self._requests:
-            batch_response = local_cas.UploadMissingBlobs(request)
+            batch_response_future = local_cas.UploadMissingBlobs.future(request)
+
+            try:
+                batch_response = batch_response_future.result()
+            except:
+                batch_response_future.cancel()
+                raise
 
             for response in batch_response.responses:
                 if response.status.code != code_pb2.OK:


### PR DESCRIPTION
Long-running synchronous grpc calls block the thread where they are
called, which can cause the scheduler to be unable to terminate the
job.

This commit replaces them with usage of the "asynchronous" future
API. The result() method of a grpc future will not block the thread
while it's waiting, and thus allows terminating the job without
waiting for the blocking call to return. This covers the LocalCAS
methods {Fetch,Upload}{Tree,MissingBlobs}.

As an added benefit, we try to cancel the grpc calls when
terminated. This depends on the server side (buildbox-casd) promptly
cancelling the remote calls, which it doesn't consistently do at the
moment. But that can be fixed independently.

Fixes https://github.com/apache/buildstream/issues/2157