### PR TITLE
examples: use ftp.gnu.org instead of ftpmirror.gnu.org

### DIFF
--- a/doc/examples/autotools/project.conf
+++ b/doc/examples/autotools/project.conf
@@ -10,10 +10,17 @@ element-path: elements
 # Define some aliases for the tarballs we download
 aliases:
   alpine: https://bst-integration-test-images.ams3.cdn.digitaloceanspaces.com/
-  gnu: http://ftpmirror.gnu.org/gnu/automake/
+  gnu: https://ftp.gnu.org/gnu/automake/
 
 plugins:
 - origin: pip
   package-name: buildstream-plugins
   elements:
   - autotools
+
+# Define mirrors
+mirrors:
+- name: gnu_mirror
+  aliases:
+    gnu:
+    - https://ftpmirror.gnu.org/gnu/automake/

--- a/doc/examples/junction-includes/project.conf
+++ b/doc/examples/junction-includes/project.conf
@@ -3,7 +3,7 @@ min-version: 2.0
 element-path: elements
 
 aliases:
-  gnu: http://ftpmirror.gnu.org/gnu/automake/
+  gnu: https://ftp.gnu.org/gnu/automake/
 
 plugins:
 - origin: pip
@@ -18,3 +18,10 @@ options:
     type: bool
     description: Whether this project is funky
     default: False
+
+# Define mirrors
+mirrors:
+- name: gnu_mirror
+  aliases:
+    gnu:
+    - https://ftpmirror.gnu.org/gnu/automake/

--- a/doc/examples/junctions/autotools/project.conf
+++ b/doc/examples/junctions/autotools/project.conf
@@ -10,7 +10,7 @@ element-path: elements
 # Define some aliases for the tarballs we download
 aliases:
   alpine: https://bst-integration-test-images.ams3.cdn.digitaloceanspaces.com/
-  gnu: https://ftpmirror.gnu.org/gnu/automake/
+  gnu: https://ftp.gnu.org/gnu/automake/
 
 # Declare the plugins we're going to use
 plugins:
@@ -18,3 +18,10 @@ plugins:
   package-name: buildstream-plugins
   elements:
   - autotools
+
+# Define mirrors
+mirrors:
+- name: gnu_mirror
+  aliases:
+    gnu:
+    - https://ftpmirror.gnu.org/gnu/automake/


### PR DESCRIPTION
The latter has been unreliable recently