### PR TITLE
Move static metadata from setup.py/setup.cfg into pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,40 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "BuildStream"
+dynamic = ["version", "dependencies"]
+description = "A framework for modelling build pipelines in YAML"
+readme = { file = "README.rst", content-type = "text/x-rst" }
+license = "Apache-2.0"
+requires-python = ">=3.10"
+authors = [
+    { name = "The Apache Software Foundation", email = "dev@buildstream.apache.org" },
+]
+classifiers = [
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development :: Build Tools",
+]
+
+[project.urls]
+Homepage = "https://buildstream.build"
+Documentation = "https://docs.buildstream.build"
+Source = "https://github.com/apache/buildstream"
+Tracker = "https://github.com/apache/buildstream/issues"
+"Mailing List" = "https://lists.apache.org/list.html?dev@buildstream.apache.org"
+
+[project.scripts]
+bst = "buildstream._frontend:cli"
+
 [tool.black]
 line-length = 119
 exclude = '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@
 #
 [build-system]
 requires = [
-    # We need at least version 41.2.0 to support python 3.9
-    "setuptools>=41.2.0",
+    # We need at least version 77 to support PEP 639
+    "setuptools>=77",
     # In order to build wheels, and as required by PEP 517
     "wheel",
     # Require a new enough cython for the python versions we support
@@ -22,6 +22,39 @@ requires = [
     "packaging",
 ]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "BuildStream"
+dynamic = ["version", "dependencies"]
+description = "A framework for modelling build pipelines in YAML"
+readme = "README.rst"
+license = "Apache-2.0"
+requires-python = ">=3.10"
+authors = [
+    { name = "The Apache Software Foundation", email = "dev@buildstream.apache.org" },
+]
+classifiers = [
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development :: Build Tools",
+]
+
+[project.urls]
+Homepage = "https://buildstream.build"
+Documentation = "https://docs.buildstream.build"
+Source = "https://github.com/apache/buildstream"
+Tracker = "https://github.com/apache/buildstream/issues"
+"Mailing List" = "https://lists.apache.org/list.html?dev@buildstream.apache.org"
+
+[project.scripts]
+bst = "buildstream._frontend:cli"
 
 [tool.black]
 target-version = ["py310", "py311", "py312", "py313", "py314"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,9 +11,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-[options]
-python_requires = >=3.10
-
 [versioneer]
 VCS = git
 style = pep440

--- a/setup.py
+++ b/setup.py
@@ -216,12 +216,6 @@ def get_cmdclass():
 with open("requirements/requirements.in", encoding="utf-8") as install_reqs:
     install_requires = install_reqs.read().splitlines()
 
-#####################################################
-#     Prepare package description from README       #
-#####################################################
-with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), "README.rst"), encoding="utf-8") as readme:
-    long_description = readme.read()
-
 
 #####################################################
 #            Setup Cython and extensions            #
@@ -310,36 +304,10 @@ register_cython_module("buildstream._variables", dependencies=["buildstream.node
 #             Main setup() Invocation               #
 #####################################################
 setup(
-    name="BuildStream",
+    # Static metadata now lives in pyproject.toml [project] table.
+    # Only dynamic values and build-time logic remain here.
     version=version,
     cmdclass=get_cmdclass(),
-    author="The Apache Software Foundation",
-    author_email="dev@buildstream.apache.org",
-    classifiers=[
-        "Environment :: Console",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: POSIX",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: 3.14",
-        "Topic :: Software Development :: Build Tools",
-    ],
-    description="A framework for modelling build pipelines in YAML",
-    license="Apache License Version 2.0",
-    long_description=long_description,
-    long_description_content_type="text/x-rst; charset=UTF-8",
-    url="https://buildstream.build",
-    project_urls={
-        "Source": "https://github.com/apache/buildstream",
-        "Documentation": "https://docs.buildstream.build",
-        "Tracker": "https://github.com/apache/buildstream/issues",
-        "Mailing List": "https://lists.apache.org/list.html?dev@buildstream.apache.org",
-    },
-    python_requires="~={}.{}".format(REQUIRED_PYTHON_MAJOR, REQUIRED_PYTHON_MINOR),
     package_dir={"": "src"},
     packages=find_packages(where="src", exclude=("subprojects", "tests", "tests.*")),
     package_data={
@@ -369,7 +337,6 @@ setup(
         ("share/bash-completion/completions", [os.path.join("src", "buildstream", "data", "bst")]),
     ],
     install_requires=install_requires,
-    entry_points={"console_scripts": ["bst = buildstream._frontend:cli"]},
     ext_modules=cythonize(
         BUILD_EXTENSIONS,
         compiler_directives={

--- a/tox.ini
+++ b/tox.ini
@@ -140,7 +140,7 @@ setenv =
 [testenv:format]
 skip_install = True
 deps =
-    black~=26.3.0
+    black==26.3.0
 commands =
     black {posargs: src tests doc/source/conf.py setup.py}
 
@@ -150,7 +150,7 @@ commands =
 [testenv:format-check]
 skip_install = True
 deps =
-    black~=26.3.0
+    black==26.3.0
 commands =
     black --check --diff {posargs: src tests doc/source/conf.py setup.py}
 


### PR DESCRIPTION
Move the static project metadata that can be expressed with PEP 621 into the [project] table of pyproject.toml and remove the corresponding duplicated arguments from setup() and the python_requires line from setup.cfg.