### PR TITLE
_stream: Persist soft workspace resets

### DIFF
--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -1174,6 +1174,9 @@ class Stream:
             workspaces.save_config()
             self.workspace_open([element._get_full_name()], no_checkout=False, force=True, custom_dir=workspace_path)
 
+        if soft:
+            workspaces.save_config()
+
     # workspace_exists
     #
     # Check if a workspace exists

--- a/src/buildstream/_stream.py
+++ b/src/buildstream/_stream.py
@@ -1168,6 +1168,7 @@ class Stream:
                 self._context.messenger.info(
                     "Reset workspace state for {} at: {}".format(element.name, workspace_path)
                 )
+                workspaces.save_config()
                 continue
 
             self.workspace_close(element._get_full_name(), remove_dir=True)

--- a/tests/frontend/workspace.py
+++ b/tests/frontend/workspace.py
@@ -510,6 +510,7 @@ def test_reset(cli, tmpdir, datafiles):
 def test_reset_soft(cli, tmpdir, datafiles):
     # Open the workspace
     element_name, project, workspace = open_workspace(cli, tmpdir, datafiles, "tar")
+    workspace_config_path = os.path.join(project, ".bst2", "workspaces.yml")
 
     assert cli.get_element_state(project, element_name) == "buildable"
 
@@ -527,6 +528,10 @@ def test_reset_soft(cli, tmpdir, datafiles):
     assert cli.get_element_state(project, element_name) == "cached"
     key_2 = cli.get_element_key(project, element_name)
     assert key_2 != "{:?<64}".format("")
+
+    workspace_config = _yaml.load(workspace_config_path, shortname="workspaces.yml")
+    workspace_node = workspace_config.get_mapping("workspaces").get_mapping(element_name)
+    assert workspace_node.get_str("last_build", default=None) is not None
 
     # workspace keys are not recalculated
     assert key_1 == key_2
@@ -549,6 +554,17 @@ def test_reset_soft(cli, tmpdir, datafiles):
     assert not os.path.exists(os.path.join(workspace, "usr", "bin"))
     # and added this one
     assert os.path.exists(os.path.join(workspace, "etc", "pony.conf"))
+
+    workspace_config = _yaml.load(workspace_config_path, shortname="workspaces.yml")
+    workspace_node = workspace_config.get_mapping("workspaces").get_mapping(element_name)
+    assert workspace_node.get_str("last_build", default=None) is None
+
+    # A new BuildStream invocation must keep the soft-reset state.
+    result = cli.run(project=project, args=["workspace", "list"])
+    result.assert_success()
+    workspace_config = _yaml.load(workspace_config_path, shortname="workspaces.yml")
+    workspace_node = workspace_config.get_mapping("workspaces").get_mapping(element_name)
+    assert workspace_node.get_str("last_build", default=None) is None
 
     assert cli.get_element_state(project, element_name) == "buildable"
     key_3 = cli.get_element_key(project, element_name)


### PR DESCRIPTION
The soft reset path cleared `workspace.last_build` only in memory. Since `workspace_reset()` returned without `Workspaces.save_config()`, the old hash remained in `.bst2/workspaces.yml` and was loaded by the next BuildStream invocation. That retained the previous buildtree and could skip configure-commands.

This regressed in 1eedab4fd, when the final save after the reset loop was removed as hard reset moved to `workspace_close()`/`workspace_open()`; those methods save the config themselves, but the soft path does not. The later `last_successful` -> `last_build` rename preserved the omission.

Save the config once after all soft-reset targets are processed and cover the on-disk state before and after a new CLI invocation.