### PR TITLE
source.py: Add `SHA512` variant to SourceVersionType enum

### DIFF
--- a/src/buildstream/source.py
+++ b/src/buildstream/source.py
@@ -497,6 +497,11 @@ class SourceVersionType(FastEnum):
     An sha256 checksum of the content of a file
     """
 
+    SHA512 = "sha512"
+    """
+    An sha512 checksum of the content of a file
+    """
+
     CAS_DIGEST = "cas-digest"
     """
     A CAS digest expressed as ``{hash}/{size}``.


### PR DESCRIPTION
This commit adds `SHA512` as a variant to the SourceVersionType Enum, which allows for more checksum options in the Source Provenance API.