### PR TITLE
reduce redundant artifact, CAS, and cache-key work

### DIFF
--- a/src/buildstream/_artifact.py
+++ b/src/buildstream/_artifact.py
@@ -220,7 +220,6 @@ class Artifact:
 
         context = self._context
         element = self._element
-        size = 0
 
         filesvdir = None
         buildtreevdir = None
@@ -247,7 +246,6 @@ class Artifact:
             filesvdir = CasBasedDirectory(cas_cache=self._cas)
             filesvdir._import_files_internal(collectvdir, properties=properties, collect_result=False)
             artifact.files.CopyFrom(filesvdir._get_digest())
-            size += filesvdir._get_size()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             files_to_capture = []

--- a/src/buildstream/_cas/cascache.py
+++ b/src/buildstream/_cas/cascache.py
@@ -286,7 +286,7 @@ class CASCache:
                 "Failed to fetch directory tree {}: {}: {}".format(dir_digest.hash, e.code().name, e.details())
             ) from e
 
-        required_blobs = self.required_blobs_for_directory(dir_digest)
+        required_blobs = self.required_blobs_for_directory(dir_digest, _fetch_tree=False)
         self.fetch_blobs(remote, required_blobs)
 
     # pull_tree():

--- a/src/buildstream/element.py
+++ b/src/buildstream/element.py
@@ -3337,6 +3337,8 @@ class Element(Plugin):
         # This code can be run multiple times until the strict key can be calculated,
         # so let's ensure we only ever calculate the weak key once, even though we need
         # to resolve it before we can resolve the strict key.
+        build_dependencies = list(self._dependencies(_Scope.BUILD))
+
         if self.__weak_cache_key is None:
             # Weak cache key includes names of direct build dependencies
             # so as to only trigger rebuilds when the shape of the
@@ -3353,14 +3355,14 @@ class Element(Plugin):
                     if self.BST_STRICT_REBUILD or e in self.__strict_dependencies
                     else [e.project_name, e.name]
                 )
-                for e in self._dependencies(_Scope.BUILD)
+                for e in build_dependencies
             ]
             self.__weak_cache_key = self._calculate_cache_key(dependencies)
 
         context = self._get_context()
 
         # Calculate the strict cache key
-        dependencies = [[e.project_name, e.name, e.__strict_cache_key] for e in self._dependencies(_Scope.BUILD)]
+        dependencies = [[e.project_name, e.name, e.__strict_cache_key] for e in build_dependencies]
         self.__strict_cache_key = self._calculate_cache_key(dependencies, self.__weak_cache_key)
 
         if self.__strict_cache_key is None:


### PR DESCRIPTION
This change removes redundant work from artifact creation, remote CAS directory fetching, and cache-key calculation:

- Remove the unused recursive artifact size calculation.
- Avoid issuing a second `FetchTree` request in `CASCache.fetch_directory()`.
- Reuse the build dependency list when calculating weak and strict cache keys.