### PR TITLE
 _frontend/cli.py: Update default min-version for `bst init`

### DIFF
--- a/src/buildstream/_frontend/cli.py
+++ b/src/buildstream/_frontend/cli.py
@@ -420,7 +420,7 @@ def help_command(ctx, command):
 @click.option(
     "--min-version",
     type=click.STRING,
-    default="2.7",
+    default="2.8",
     show_default=True,
     help="The required format version",
 )


### PR DESCRIPTION
This is implicitly required by tests after creating the 2.8.0.dev0 tag.