### PR TITLE
ci: Add Fedora 44, remove other Fedora images

### DIFF
--- a/.github/common.env
+++ b/.github/common.env
@@ -1,6 +1,6 @@
 # Shared common variables
 
-CI_IMAGE_VERSION=master-2310077904
+CI_IMAGE_VERSION=master-2779642792
 CI_TOXENV_MAIN=py310,py311,py312,py313,py314
 CI_TOXENV_PLUGINS=py310-plugins,py311-plugins,py312-plugins,py313-plugins,py314-plugins
 CI_TOXENV_ALL="${CI_TOXENV_MAIN},${CI_TOXENV_PLUGINS}"

--- a/.github/compose/ci.docker-compose.yml
+++ b/.github/compose/ci.docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 
 x-tests-template: &tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:42-${CI_IMAGE_VERSION:-latest}
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:44-${CI_IMAGE_VERSION:-latest}
     command: tox -vvvvv -- --color=yes --integration
     environment:
       TOXENV: ${CI_TOXENV_ALL}
@@ -30,13 +30,9 @@ services:
     <<: *tests-template
     image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-debian:13-${CI_IMAGE_VERSION:-latest}
 
-  fedora-42:
+  fedora-44:
     <<: *tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:42-${CI_IMAGE_VERSION:-latest}
-
-  fedora-43:
-    <<: *tests-template
-    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:43-${CI_IMAGE_VERSION:-latest}
+    image: registry.gitlab.com/buildstream/buildstream-docker-images/testsuite-fedora:44-${CI_IMAGE_VERSION:-latest}
 
   ubuntu-22.04:
     <<: *tests-template

--- a/.github/run-ci.sh
+++ b/.github/run-ci.sh
@@ -102,7 +102,7 @@ function runServiceTest() {
 
 
 if [ -z "${test_names}" ]; then
-    for test_name in mypy debian-12 debian-13 fedora-42 fedora-43 fedora-missing-deps ubuntu-22.04; do
+    for test_name in mypy debian-12 debian-13 fedora-44 fedora-missing-deps ubuntu-22.04; do
 	if ! runTest "${test_name}"; then
 	    echo "Tests failed"
 	    exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,7 @@ jobs:
         test-name:
           - debian-12
           - debian-13
-          - fedora-42
-          - fedora-43
+          - fedora-44
           - fedora-missing-deps
           - ubuntu-22.04
           - lint

--- a/tests/integration/interactive_build.py
+++ b/tests/integration/interactive_build.py
@@ -36,6 +36,13 @@ DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "project")
 def build_session(integration_cache, datafiles, element_name):
     project = str(datafiles)
 
+    # Interactive tests need a usable TERM so tools like click's pager (less)
+    # run interactively.  Containers used for CI often leave TERM unset even
+    # when pexpect allocates a PTY.
+    env = os.environ.copy()
+    if not env.get("TERM") or env["TERM"] == "dumb":
+        env["TERM"] = "xterm"
+
     # Spawn interactive session using `configured()` context manager in order
     # to get the same config file as the `cli` fixture.
     with runcli.configured(project, config={"sourcedir": integration_cache.sources}) as config_file:
@@ -50,6 +57,7 @@ def build_session(integration_cache, datafiles, element_name):
                 "build",
                 element_name,
             ],
+            env=env,
             timeout=PEXPECT_TIMEOUT_SHORT,
         )
         yield session


### PR DESCRIPTION
Fedora 42 is EOL for a while, python 3.14 is already tested with F44

Depends on https://gitlab.com/BuildStream/buildstream-docker-images/-/merge_requests/239

Tested succesfully at https://github.com/jjardon/buildstream-1/pull/1

Fixes https://github.com/apache/buildstream/issues/2180