### PR TITLE
ci: update GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         # BuildStream requires tags to be able to find its version.
         with:
           fetch-depth: 0
@@ -82,7 +82,7 @@ jobs:
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         # BuildStream requires tags to be able to find its version.
         with:
           fetch-depth: 0
@@ -98,7 +98,7 @@ jobs:
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         # BuildStream requires tags to be able to find its version.
         with:
           fetch-depth: 0
@@ -115,7 +115,7 @@ jobs:
             docs
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs
           path: doc/build/html
@@ -128,7 +128,7 @@ jobs:
         os: [ubuntu-24.04]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -138,7 +138,7 @@ jobs:
       - name: Build wheels
         run: pipx run cibuildwheel==v3.1.4
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels
           path: ./wheelhouse/*.whl
@@ -160,11 +160,11 @@ jobs:
           - wheels-manylinux_2_28-cp314
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: wheels
           path: ./wheelhouse

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -14,7 +14,7 @@ jobs:
       run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v7
       # BuildStream requires tags to be able to find its version.
       with:
         fetch-depth: 0
@@ -38,7 +38,7 @@ jobs:
         tar -C doc/build/html -zcf docs.tgz .
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: docs
         path: |
@@ -51,13 +51,13 @@ jobs:
     steps:
 
     - name: Download artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: docs
         path: docs
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v7
       with:
         ref: gh-pages
         path: pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         # BuildStream requires tags to be able to find its version.
         with:
           fetch-depth: 0
@@ -35,7 +35,7 @@ jobs:
 
           tar -C doc/build/html -zcf docs.tgz .
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: docs
           path: docs.tgz
@@ -44,14 +44,14 @@ jobs:
     name: "Build Python source distribution tarball"
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
 
     - name: Build sdist
       run: pipx run build --sdist
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: sdist
         path: dist/*.tar.gz
@@ -64,7 +64,7 @@ jobs:
         os: [ubuntu-24.04]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -74,7 +74,7 @@ jobs:
       - name: Build wheels
         run: pipx run cibuildwheel==v3.1.4
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels
           path: ./wheelhouse/*.whl
@@ -96,11 +96,11 @@ jobs:
           - wheels-manylinux_2_28-cp314
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: wheels
           path: ./wheelhouse
@@ -114,11 +114,11 @@ jobs:
     needs: [build_docs, build_sdist, build_wheels, test_wheels]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: docs
 
@@ -134,12 +134,12 @@ jobs:
     needs: [build_docs, build_sdist, build_wheels, test_wheels]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: sdist
           path: dist
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: wheels
           path: dist


### PR DESCRIPTION
- actions/checkout: v2/v3 -> v7 (Node 24 runtime, fixes deprecation)
- actions/upload-artifact: v4 -> v7
- actions/download-artifact: v4 -> v8

This eliminates the Node 20 deprecation warnings and the associated punycode warnings.