### PR TITLE
Migrate from ujson to orjson

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -24,7 +24,7 @@ extension-pkg-whitelist=
     buildstream._utils,
     buildstream._variables,
     buildstream._yaml,
-    ujson
+    orjson
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -8,4 +8,4 @@ psutil
 ruamel.yaml >= 0.16.7
 ruamel.yaml.clib >= 0.1.2
 pyroaring
-ujson
+orjson >= 3.10,<4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,7 +8,7 @@ psutil==7.2.2
 ruamel.yaml==0.19.1
 ruamel.yaml.clib==0.2.15
 pyroaring==1.1.0
-ujson==5.12.0
+orjson==3.12.0
 ## The following requirements were added by pip freeze:
 MarkupSafe==3.0.3
 typing_extensions==4.15.0

--- a/src/buildstream/_cachekey.py
+++ b/src/buildstream/_cachekey.py
@@ -17,7 +17,7 @@
 
 import hashlib
 
-import ujson
+import orjson
 
 # Internal record of the size of a cache key
 _CACHEKEY_SIZE = len(hashlib.sha256().hexdigest())
@@ -58,5 +58,5 @@ def is_key(key):
 #    (str): An sha256 hex digest of the given value
 #
 def generate_key(value):
-    ustring = ujson.dumps(value, sort_keys=True, escape_forward_slashes=False).encode("utf-8")
+    ustring = orjson.dumps(value, option=orjson.OPT_SORT_KEYS)
     return hashlib.sha256(ustring).hexdigest()

--- a/src/buildstream/node.pyx
+++ b/src/buildstream/node.pyx
@@ -81,7 +81,7 @@ cdef class Node:
         self.column = column
 
     # This is in order to ensure we never add a `Node` to a cache key
-    # as ujson will try to convert objects if they have a `__json__`
+    # as orjson will try to convert objects if they have a `__json__`
     # attribute.
     def __json__(self):
         raise ValueError("Nodes should not be allowed when jsonify-ing data", self)

--- a/tox.ini
+++ b/tox.ini
@@ -180,7 +180,6 @@ commands =
 deps =
     mypy==1.13.0
     types-protobuf==5.28.3.20241030
-    types-ujson==5.10.0.20240515
     -rrequirements/requirements.txt
     -rrequirements/dev-requirements.txt
 


### PR DESCRIPTION
ujson is in maintenance-only mode and its own maintainers recommend migrating to orjson. This change replaces the dependency and updates the single call site in _cachekey.py.

Key differences handled:
- orjson.dumps() returns bytes (so the extra .encode("utf-8") is removed)
- sort_keys=True becomes option=orjson.OPT_SORT_KEYS
- escape_forward_slashes=False is the default behaviour of orjson

Tested successfully at https://github.com/jjardon/buildstream-1/actions/runs/32796227859?pr=4

Fixes #2184