### PR TITLE
_sourcetests: Do not assume Source.ref is a string

### DIFF
--- a/src/buildstream/_testing/_sourcetests/mirror.py
+++ b/src/buildstream/_testing/_sourcetests/mirror.py
@@ -238,7 +238,7 @@ def test_mirror_track_upstream_present(cli, tmpdir, datafiles, kind):
     new_element = _yaml.load(element_path, shortname=element_name)
     source = new_element.get_sequence("sources").mapping_at(0)
     if "ref" in source:
-        assert source.get_str("ref") == upstream_ref
+        assert source.get_node("ref").strip_node_info() == upstream_ref
 
 
 @pytest.mark.datafiles(DATA_DIR)
@@ -293,4 +293,4 @@ def test_mirror_track_upstream_absent(cli, tmpdir, datafiles, kind):
     new_element = _yaml.load(element_path, shortname=element_name)
     source = new_element.get_sequence("sources").mapping_at(0)
     if "ref" in source:
-        assert source.get_str("ref") == mirror_ref
+        assert source.get_node("ref").strip_node_info() == mirror_ref

--- a/src/buildstream/_testing/_sourcetests/track.py
+++ b/src/buildstream/_testing/_sourcetests/track.py
@@ -295,7 +295,7 @@ def test_track_include(cli, tmpdir, datafiles, ref_storage, kind):
         # Get the first source from the sources list
         new_source = sources_list.mapping_at(0)
         assert "ref" in new_source
-        assert ref == new_source.get_str("ref")
+        assert ref == new_source.get_node("ref").strip_node_info()
 
 
 @pytest.mark.datafiles(DATA_DIR)


### PR DESCRIPTION
types.py specifies as:
`SourceRef = Union[None, int, str, List[Any], Dict[str, Any]]`