### PR TITLE
_sourcetests: fetch missing after tracking

### DIFF
--- a/src/buildstream/_testing/_sourcetests/track.py
+++ b/src/buildstream/_testing/_sourcetests/track.py
@@ -233,6 +233,15 @@ def test_cross_junction(cli, tmpdir, datafiles, ref_storage, kind):
     else:
         result.assert_success()
 
+        # And now fetch it: The Source has probably already cached the
+        # latest ref locally, but it is not required to have cached
+        # the associated content of the latest ref at track time, that
+        # is the job of fetch.
+        result = cli.run(
+            project=project, args=["source", "fetch", "--deps", "none", "junction.bst:import-etc-repo.bst"]
+        )
+        result.assert_success()
+
         assert cli.get_element_state(project, "junction.bst:import-etc-repo.bst") == "buildable"
 
         assert os.path.exists(os.path.join(project, "project.refs"))


### PR DESCRIPTION
Over in: https://gitlab.com/BuildStream/buildstream-plugins-community/-/merge_requests/484 We hit: FAILED
`buildstream/_testing/_sourcetests/track.py::test_cross_junction[git_repo-project.refs] - AssertionError: assert 'fetch needed' == 'buildable'`

Looking at the other tests in this file,
all except this one have the '# And now fetch it:` comment and call a call to bst fetch.

It looks like it's missing in this test.

As `git_repo` does not cache it's sources as part of track.